### PR TITLE
Remove Emby VAAPI render device

### DIFF
--- a/compose/.apps/emby/emby.yml
+++ b/compose/.apps/emby/emby.yml
@@ -14,5 +14,3 @@ services:
       - ${MEDIADIR_MOVIES}:/data/movies
       - ${MEDIADIR_MUSIC}:/data/music
       - ${MEDIADIR_TV}:/data/tv
-    devices:
-      - "/dev/dri/renderD128"

--- a/tests/run_generate.sh
+++ b/tests/run_generate.sh
@@ -5,9 +5,6 @@ IFS=$'\n\t'
 run_generate() {
     cp "${SCRIPTPATH}/compose/.env.example" "${SCRIPTPATH}/compose/.env"
     sed -i 's/_ENABLED=false/_ENABLED=true/' "${SCRIPTPATH}/compose/.env"
-    #sed -i 's/EMBY_ENABLED=true/EMBY_ENABLED=false/' "${SCRIPTPATH}/compose/.env"
-    sed -i 's/^\s*devices\:$//' "${SCRIPTPATH}/compose/.apps/emby/emby.yml"
-    sed -i 's/^.*renderD128.*$//' "${SCRIPTPATH}/compose/.apps/emby/emby.yml"
     sed -i 's/HEADPHONES_PORT_8181=8181/HEADPHONES_PORT_8181=18181/' "${SCRIPTPATH}/compose/.env"
     sed -i 's/PLEX_PORT_1900=1900/PLEX_PORT_1900=11900/' "${SCRIPTPATH}/compose/.env"
     sed -i 's/RUTORRENT_PORT_51413=51413/RUTORRENT_PORT_51413=41413/' "${SCRIPTPATH}/compose/.env"


### PR DESCRIPTION
This is just causing issues for people who don't have the device available. It can be included using overrides if needed.