### PR TITLE
Fix root check

### DIFF
--- a/scripts/root_check.sh
+++ b/scripts/root_check.sh
@@ -5,6 +5,6 @@ IFS=$'\n\t'
 root_check() {
     if [[ ${EUID} -ne 0 ]]; then
         echo
-        fatal "Please run as root using the command: sudo bash ${SCRIPTNAME} ${ARGS}"
+        fatal "Please run as root using the command: sudo bash ${SCRIPTNAME}"
     fi
 }


### PR DESCRIPTION
This caused an issue running without root. Downside is it won't show which options you ran with. Prior behavior wasn't right with this anyway.

I ran `main.sh -g` and it asked me to run `sudo main.sh -g` (good)

I ran `main.sh --fake -g` and it asked me to run `sudo main.sh --fake` (bad, missing `-g`)

I adjusted `${ARGS}` to `${ARGS[@]}` and also tried `${ARGS[*]}` and both resulted in the following:
I ran `main.sh --fake -g` and it asked me to run
```
sudo main.sh --fake
-g
```
(bad, newline for each arg)

***

So my conclusion was to just remove ARGS entirely at least for now.

Result is I ran `main.sh -g` and it asked me to run `sudo main.sh` (good enough for now)