### PR TITLE
Remove version from all app yml files

### DIFF
--- a/compose/.apps/bazarr/bazarr.yml
+++ b/compose/.apps/bazarr/bazarr.yml
@@ -1,4 +1,3 @@
-version:             "3.6"
 services:
   bazarr:
     image:           morpheus65535/bazarr

--- a/compose/.apps/couchpotato/couchpotato.yml
+++ b/compose/.apps/couchpotato/couchpotato.yml
@@ -1,4 +1,3 @@
-version:             "3.6"
 services:
   couchpotato:
     image:           linuxserver/couchpotato

--- a/compose/.apps/deluge/deluge.yml
+++ b/compose/.apps/deluge/deluge.yml
@@ -1,4 +1,3 @@
-version:             "3.6"
 services:
   deluge:
     image:           linuxserver/deluge

--- a/compose/.apps/duckdns/duckdns.yml
+++ b/compose/.apps/duckdns/duckdns.yml
@@ -1,4 +1,3 @@
-version:             "3.6"
 services:
   duckdns:
     image:           linuxserver/duckdns

--- a/compose/.apps/duplicati/duplicati.yml
+++ b/compose/.apps/duplicati/duplicati.yml
@@ -1,4 +1,3 @@
-version:             "3.6"
 services:
   duplicati:
     image:           linuxserver/duplicati

--- a/compose/.apps/emby/emby.yml
+++ b/compose/.apps/emby/emby.yml
@@ -1,4 +1,3 @@
-version:             "3.6"
 services:
   emby:
     image:           emby/embyserver:latest

--- a/compose/.apps/headphones/headphones.yml
+++ b/compose/.apps/headphones/headphones.yml
@@ -1,4 +1,3 @@
-version:             "3.6"
 services:
   headphones:
     image:           linuxserver/headphones

--- a/compose/.apps/homeassistant/homeassistant.yml
+++ b/compose/.apps/homeassistant/homeassistant.yml
@@ -1,4 +1,3 @@
-version:             "3.6"
 services:
   homeassistant:
     image:           homeassistant/home-assistant

--- a/compose/.apps/hydra2/hydra2.yml
+++ b/compose/.apps/hydra2/hydra2.yml
@@ -1,4 +1,3 @@
-version:             "3.6"
 services:
   hydra2:
     image:           linuxserver/hydra2

--- a/compose/.apps/jackett/jackett.yml
+++ b/compose/.apps/jackett/jackett.yml
@@ -1,4 +1,3 @@
-version:             "3.6"
 services:
   jackett:
     image:           linuxserver/jackett

--- a/compose/.apps/lazylibrarian/lazylibrarian.yml
+++ b/compose/.apps/lazylibrarian/lazylibrarian.yml
@@ -1,4 +1,3 @@
-version:             "3.6"
 services:
   lazylibrarian:
     image:           linuxserver/lazylibrarian

--- a/compose/.apps/letsencrypt/letsencrypt.yml
+++ b/compose/.apps/letsencrypt/letsencrypt.yml
@@ -1,4 +1,3 @@
-version:             "3.6"
 services:
   letsencrypt:
     image:           linuxserver/letsencrypt

--- a/compose/.apps/lidarr/lidarr.yml
+++ b/compose/.apps/lidarr/lidarr.yml
@@ -1,4 +1,3 @@
-version:             "3.6"
 services:
   lidarr:
     image:           linuxserver/lidarr

--- a/compose/.apps/logarr/logarr.yml
+++ b/compose/.apps/logarr/logarr.yml
@@ -1,4 +1,3 @@
-version:             "3.6"
 services:
   logarr:
     image:           monitorr/logarr

--- a/compose/.apps/monitorr/monitorr.yml
+++ b/compose/.apps/monitorr/monitorr.yml
@@ -1,4 +1,3 @@
-version:             "3.6"
 services:
   monitorr:
     image:           monitorr/monitorr

--- a/compose/.apps/muximux/muximux.yml
+++ b/compose/.apps/muximux/muximux.yml
@@ -1,4 +1,3 @@
-version:             "3.6"
 services:
   muximux:
     image:           linuxserver/muximux

--- a/compose/.apps/nzbget/nzbget.yml
+++ b/compose/.apps/nzbget/nzbget.yml
@@ -1,4 +1,3 @@
-version:             "3.6"
 services:
   nzbget:
     image:           linuxserver/nzbget

--- a/compose/.apps/ombi/ombi.yml
+++ b/compose/.apps/ombi/ombi.yml
@@ -1,4 +1,3 @@
-version:             "3.6"
 services:
   ombi:
     image:           linuxserver/ombi

--- a/compose/.apps/organizr/organizr.yml
+++ b/compose/.apps/organizr/organizr.yml
@@ -1,4 +1,3 @@
-version:             "3.6"
 services:
   organizr:
     image:           lsiocommunity/organizr

--- a/compose/.apps/plex/plex.yml
+++ b/compose/.apps/plex/plex.yml
@@ -1,4 +1,3 @@
-version:             "3.6"
 services:
   plex:
     image:           plexinc/pms-docker:${PLEX_TAG}

--- a/compose/.apps/plexrequests/plexrequests.yml
+++ b/compose/.apps/plexrequests/plexrequests.yml
@@ -1,4 +1,3 @@
-version:             "3.6"
 services:
   plexrequests:
     image:           linuxserver/plexrequests

--- a/compose/.apps/portainer/portainer.yml
+++ b/compose/.apps/portainer/portainer.yml
@@ -1,4 +1,3 @@
-version:             "3.6"
 services:
   portainer:
     image:           portainer/portainer

--- a/compose/.apps/radarr/radarr.yml
+++ b/compose/.apps/radarr/radarr.yml
@@ -1,4 +1,3 @@
-version:             "3.6"
 services:
   radarr:
     image:           linuxserver/radarr

--- a/compose/.apps/rutorrent/rutorrent.yml
+++ b/compose/.apps/rutorrent/rutorrent.yml
@@ -1,4 +1,3 @@
-version:             "3.6"
 services:
   rutorrent:
     image:           linuxserver/rutorrent

--- a/compose/.apps/sabnzbd/sabnzbd.yml
+++ b/compose/.apps/sabnzbd/sabnzbd.yml
@@ -1,4 +1,3 @@
-version:             "3.6"
 services:
   sabnzbd:
     image:           linuxserver/sabnzbd

--- a/compose/.apps/sickrage/sickrage.yml
+++ b/compose/.apps/sickrage/sickrage.yml
@@ -1,4 +1,3 @@
-version:             "3.6"
 services:
   sickrage:
     image:           linuxserver/sickrage

--- a/compose/.apps/sonarr/sonarr.yml
+++ b/compose/.apps/sonarr/sonarr.yml
@@ -1,4 +1,3 @@
-version:             "3.6"
 services:
   sonarr:
     image:           linuxserver/sonarr

--- a/compose/.apps/syncthing/syncthing.yml
+++ b/compose/.apps/syncthing/syncthing.yml
@@ -1,4 +1,3 @@
-version:             "3.6"
 services:
   syncthing:
     image:           linuxserver/syncthing

--- a/compose/.apps/tautulli/tautulli.yml
+++ b/compose/.apps/tautulli/tautulli.yml
@@ -1,4 +1,3 @@
-version:             "3.6"
 services:
   tautulli:
     image:           linuxserver/tautulli

--- a/compose/.apps/transmission/transmission.yml
+++ b/compose/.apps/transmission/transmission.yml
@@ -1,4 +1,3 @@
-version:             "3.6"
 services:
   transmission:
     image:           linuxserver/transmission

--- a/compose/.apps/unifi/unifi.yml
+++ b/compose/.apps/unifi/unifi.yml
@@ -1,4 +1,3 @@
-version:             "3.6"
 services:
   unifi:
     image:           linuxserver/unifi

--- a/compose/.apps/watchtower/watchtower.yml
+++ b/compose/.apps/watchtower/watchtower.yml
@@ -1,4 +1,3 @@
-version:             "3.6"
 services:
   watchtower:
     image:           v2tec/watchtower


### PR DESCRIPTION
Kind of a follow up to https://github.com/GhostWriters/DockSTARTer/commit/83c82b42b4d99c97684ec0b196f7637f7ad782fa where we found Travis was unhappy with version 3.6. The versions are not required to exist anywhere except the req files or in whatever placeholder files we have for apps without ports and things like that (although I'd like to find a better solution for those).