### PR TITLE
Include TZ and localtime in all containers

### DIFF
--- a/compose/.apps/bazarr/bazarr.yml
+++ b/compose/.apps/bazarr/bazarr.yml
@@ -9,5 +9,6 @@ services:
       - PUID=${PUID}
       - TZ=${TZ}
     volumes:
+      - /etc/localtime:/etc/localtime:ro
       - ${DOCKERCONFDIR}/bazarr:/bazarr/data
       - ${MEDIADIR_TV}:/tv

--- a/compose/.apps/couchpotato/couchpotato.yml
+++ b/compose/.apps/couchpotato/couchpotato.yml
@@ -9,6 +9,7 @@ services:
       - PUID=${PUID}
       - TZ=${TZ}
     volumes:
+      - /etc/localtime:/etc/localtime:ro
       - ${DOCKERCONFDIR}/couchpotato:/config
       - ${DOWNLOADSDIR}:/downloads
       - ${MEDIADIR_MOVIES}:/movies

--- a/compose/.apps/deluge/deluge.yml
+++ b/compose/.apps/deluge/deluge.yml
@@ -9,5 +9,6 @@ services:
       - PUID=${PUID}
       - TZ=${TZ}
     volumes:
+      - /etc/localtime:/etc/localtime:ro
       - ${DOCKERCONFDIR}/deluge:/config
       - ${DOWNLOADSDIR}:/downloads

--- a/compose/.apps/duckdns/duckdns.yml
+++ b/compose/.apps/duckdns/duckdns.yml
@@ -12,4 +12,5 @@ services:
       - PUID=${PUID}
       - TZ=${TZ}
     volumes:
+      - /etc/localtime:/etc/localtime:ro
       - ${DOCKERCONFDIR}/duckdns:/config

--- a/compose/.apps/duplicati/duplicati.yml
+++ b/compose/.apps/duplicati/duplicati.yml
@@ -9,6 +9,7 @@ services:
       - PUID=${PUID}
       - TZ=${TZ}
     volumes:
+      - /etc/localtime:/etc/localtime:ro
       - ${DOCKERCONFDIR}/duplicati:/config
       - ${DUPLICATI_BACKUPSDIR}:/backups
       - ${DUPLICATI_SOURCEDIR}:/source

--- a/compose/.apps/emby/emby.yml
+++ b/compose/.apps/emby/emby.yml
@@ -10,6 +10,7 @@ services:
       - TZ=${TZ}
       - UID=${PUID}
     volumes:
+      - /etc/localtime:/etc/localtime:ro
       - ${DOCKERCONFDIR}/emby:/config
       - ${MEDIADIR_MOVIES}:/data/movies
       - ${MEDIADIR_MUSIC}:/data/music

--- a/compose/.apps/headphones/headphones.yml
+++ b/compose/.apps/headphones/headphones.yml
@@ -9,6 +9,7 @@ services:
       - PUID=${PUID}
       - TZ=${TZ}
     volumes:
+      - /etc/localtime:/etc/localtime:ro
       - ${DOCKERCONFDIR}/headphones:/config
       - ${DOWNLOADSDIR}:/downloads
       - ${MEDIADIR_MUSIC}:/music

--- a/compose/.apps/homeassistant/homeassistant.yml
+++ b/compose/.apps/homeassistant/homeassistant.yml
@@ -7,4 +7,5 @@ services:
     environment:
       - TZ=${TZ}
     volumes:
+      - /etc/localtime:/etc/localtime:ro
       - ${DOCKERCONFDIR}/homeassistant:/config

--- a/compose/.apps/hydra2/hydra2.yml
+++ b/compose/.apps/hydra2/hydra2.yml
@@ -9,5 +9,6 @@ services:
       - PUID=${PUID}
       - TZ=${TZ}
     volumes:
+      - /etc/localtime:/etc/localtime:ro
       - ${DOCKERCONFDIR}/hydra2:/config
       - ${DOWNLOADSDIR}:/downloads

--- a/compose/.apps/jackett/jackett.yml
+++ b/compose/.apps/jackett/jackett.yml
@@ -9,5 +9,6 @@ services:
       - PUID=${PUID}
       - TZ=${TZ}
     volumes:
+      - /etc/localtime:/etc/localtime:ro
       - ${DOCKERCONFDIR}/jackett:/config
       - ${DOWNLOADSDIR}:/downloads

--- a/compose/.apps/lazylibrarian/lazylibrarian.yml
+++ b/compose/.apps/lazylibrarian/lazylibrarian.yml
@@ -9,6 +9,7 @@ services:
       - PUID=${PUID}
       - TZ=${TZ}
     volumes:
+      - /etc/localtime:/etc/localtime:ro
       - ${DOCKERCONFDIR}/lazylibrarian:/config
       - ${DOWNLOADSDIR}:/downloads
       - ${MEDIADIR_BOOKS}:/books

--- a/compose/.apps/letsencrypt/letsencrypt.yml
+++ b/compose/.apps/letsencrypt/letsencrypt.yml
@@ -15,6 +15,7 @@ services:
       - URL=${LETSENCRYPT_URL}
       - VALIDATION=${LETSENCRYPT_VALIDATION}
     volumes:
+      - /etc/localtime:/etc/localtime:ro
       - ${DOCKERCONFDIR}/letsencrypt:/config
     cap_add:
       - NET_ADMIN

--- a/compose/.apps/lidarr/lidarr.yml
+++ b/compose/.apps/lidarr/lidarr.yml
@@ -9,6 +9,7 @@ services:
       - PUID=${PUID}
       - TZ=${TZ}
     volumes:
+      - /etc/localtime:/etc/localtime:ro
       - ${DOCKERCONFDIR}/lidarr:/config
       - ${DOWNLOADSDIR}:/downloads
       - ${MEDIADIR_MUSIC}:/music

--- a/compose/.apps/logarr/logarr.yml
+++ b/compose/.apps/logarr/logarr.yml
@@ -9,5 +9,6 @@ services:
       - PUID=${PUID}
       - TZ=${TZ}
     volumes:
+      - /etc/localtime:/etc/localtime:ro
       - ${DOCKERCONFDIR}/logarr:/app
       - ${DOCKERCONFDIR}:/var/log/logarrlogs:ro

--- a/compose/.apps/monitorr/monitorr.yml
+++ b/compose/.apps/monitorr/monitorr.yml
@@ -9,4 +9,5 @@ services:
       - PUID=${PUID}
       - TZ=${TZ}
     volumes:
+      - /etc/localtime:/etc/localtime:ro
       - ${DOCKERCONFDIR}/monitorr:/app

--- a/compose/.apps/muximux/muximux.yml
+++ b/compose/.apps/muximux/muximux.yml
@@ -9,4 +9,5 @@ services:
       - PUID=${PUID}
       - TZ=${TZ}
     volumes:
+      - /etc/localtime:/etc/localtime:ro
       - ${DOCKERCONFDIR}/muximux:/config

--- a/compose/.apps/nzbget/nzbget.yml
+++ b/compose/.apps/nzbget/nzbget.yml
@@ -9,5 +9,6 @@ services:
       - PUID=${PUID}
       - TZ=${TZ}
     volumes:
+      - /etc/localtime:/etc/localtime:ro
       - ${DOCKERCONFDIR}/nzbget:/config
       - ${DOWNLOADSDIR}:/downloads

--- a/compose/.apps/ombi/ombi.yml
+++ b/compose/.apps/ombi/ombi.yml
@@ -9,4 +9,5 @@ services:
       - PUID=${PUID}
       - TZ=${TZ}
     volumes:
+      - /etc/localtime:/etc/localtime:ro
       - ${DOCKERCONFDIR}/ombi:/config

--- a/compose/.apps/organizr/organizr.yml
+++ b/compose/.apps/organizr/organizr.yml
@@ -9,4 +9,5 @@ services:
       - PUID=${PUID}
       - TZ=${TZ}
     volumes:
+      - /etc/localtime:/etc/localtime:ro
       - ${DOCKERCONFDIR}/organizr:/config

--- a/compose/.apps/plex/plex.yml
+++ b/compose/.apps/plex/plex.yml
@@ -11,6 +11,7 @@ services:
       - PLEX_UID=${PUID}
       - TZ=${TZ}
     volumes:
+      - /etc/localtime:/etc/localtime:ro
       - ${DOCKERCONFDIR}/plex:/config
       - ${MEDIADIR_MOVIES}:/data/movies
       - ${MEDIADIR_MUSIC}:/data/music

--- a/compose/.apps/plexrequests/plexrequests.yml
+++ b/compose/.apps/plexrequests/plexrequests.yml
@@ -10,4 +10,5 @@ services:
       - PUID=${PUID}
       - TZ=${TZ}
     volumes:
+      - /etc/localtime:/etc/localtime:ro
       - ${DOCKERCONFDIR}/plexrequests:/config

--- a/compose/.apps/portainer/portainer.yml
+++ b/compose/.apps/portainer/portainer.yml
@@ -4,6 +4,8 @@ services:
     image:           portainer/portainer
     container_name:  portainer
     restart:         always
+    environment:
+      - TZ=${TZ}
     volumes:
       - /etc/localtime:/etc/localtime:ro
       - /var/run/docker.sock:/var/run/docker.sock

--- a/compose/.apps/radarr/radarr.yml
+++ b/compose/.apps/radarr/radarr.yml
@@ -9,6 +9,7 @@ services:
       - PUID=${PUID}
       - TZ=${TZ}
     volumes:
+      - /etc/localtime:/etc/localtime:ro
       - ${DOCKERCONFDIR}/radarr:/config
       - ${DOWNLOADSDIR}:/downloads
       - ${MEDIADIR_MOVIES}:/movies

--- a/compose/.apps/rutorrent/rutorrent.yml
+++ b/compose/.apps/rutorrent/rutorrent.yml
@@ -9,5 +9,6 @@ services:
       - PUID=${PUID}
       - TZ=${TZ}
     volumes:
+      - /etc/localtime:/etc/localtime:ro
       - ${DOCKERCONFDIR}/rutorrent:/config
       - ${DOWNLOADSDIR}:/downloads

--- a/compose/.apps/sabnzbd/sabnzbd.yml
+++ b/compose/.apps/sabnzbd/sabnzbd.yml
@@ -9,6 +9,7 @@ services:
       - PUID=${PUID}
       - TZ=${TZ}
     volumes:
+      - /etc/localtime:/etc/localtime:ro
       - ${DOCKERCONFDIR}/sabnzbd:/config
       - ${DOWNLOADSDIR}:/downloads
       - ${DOWNLOADSDIR}/incomplete-downloads:/incomplete-downloads

--- a/compose/.apps/sickrage/sickrage.yml
+++ b/compose/.apps/sickrage/sickrage.yml
@@ -9,6 +9,7 @@ services:
       - PUID=${PUID}
       - TZ=${TZ}
     volumes:
+      - /etc/localtime:/etc/localtime:ro
       - ${DOCKERCONFDIR}/sickrage:/config
       - ${DOWNLOADSDIR}:/downloads
       - ${MEDIADIR_TV}:/tv

--- a/compose/.apps/sonarr/sonarr.yml
+++ b/compose/.apps/sonarr/sonarr.yml
@@ -9,6 +9,7 @@ services:
       - PUID=${PUID}
       - TZ=${TZ}
     volumes:
+      - /etc/localtime:/etc/localtime:ro
       - ${DOCKERCONFDIR}/sonarr:/config
       - ${DOWNLOADSDIR}:/downloads
       - ${MEDIADIR_TV}:/tv

--- a/compose/.apps/syncthing/syncthing.yml
+++ b/compose/.apps/syncthing/syncthing.yml
@@ -9,5 +9,6 @@ services:
       - PUID=${PUID}
       - TZ=${TZ}
     volumes:
+      - /etc/localtime:/etc/localtime:ro
       - ${DOCKERCONFDIR}/syncthing:/config
       - ${SYNCTHING_SOURCEDIR}:/source

--- a/compose/.apps/tautulli/tautulli.yml
+++ b/compose/.apps/tautulli/tautulli.yml
@@ -9,5 +9,6 @@ services:
       - PUID=${PUID}
       - TZ=${TZ}
     volumes:
+      - /etc/localtime:/etc/localtime:ro
       - ${DOCKERCONFDIR}/tautulli:/config
       - ${DOCKERCONFDIR}/plex/Library/Application\ Support/Plex\ Media\ Server/Logs:/logs:ro

--- a/compose/.apps/transmission/transmission.yml
+++ b/compose/.apps/transmission/transmission.yml
@@ -9,6 +9,7 @@ services:
       - PUID=${PUID}
       - TZ=${TZ}
     volumes:
+      - /etc/localtime:/etc/localtime:ro
       - ${DOCKERCONFDIR}/transmission:/config
       - ${DOWNLOADSDIR}:/downloads
       - ${DOWNLOADSDIR}/watch:/watch

--- a/compose/.apps/unifi/unifi.yml
+++ b/compose/.apps/unifi/unifi.yml
@@ -9,4 +9,5 @@ services:
       - PUID=${PUID}
       - TZ=${TZ}
     volumes:
+      - /etc/localtime:/etc/localtime:ro
       - ${DOCKERCONFDIR}/unifi:/config

--- a/compose/.apps/watchtower/watchtower.yml
+++ b/compose/.apps/watchtower/watchtower.yml
@@ -7,5 +7,6 @@ services:
     environment:
       - TZ=${TZ}
     volumes:
+      - /etc/localtime:/etc/localtime:ro
       - /var/run/docker.sock:/var/run/docker.sock
     command:         --schedule "0 0 4 * * *" --cleanup


### PR DESCRIPTION
Todo on #82

This is really a belt and suspenders kind of change, but since in some cases one is recommended over the other and it varies from image to image I'd rather just have both. If we ever switch a container image without realizing which one of these it needs and the new image needs the opposite this would prevent an issue.