### PR TITLE
Disable Travis Buddy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,5 +25,5 @@ script:
 matrix:
     fast_finish:   true
 
-notifications:
-    webhooks:      https://www.travisbuddy.com/
+#notifications:
+#    webhooks:      https://www.travisbuddy.com/


### PR DESCRIPTION
This thing is just needlessly chatty and you still need to actually go to Travis and read the logs even when it comments about failure because it doesn't comment any part of the log. It looks promising on paper but doesn't seem complete.