### PR TITLE
Fix env_set to handle escaping

### DIFF
--- a/scripts/env_set.sh
+++ b/scripts/env_set.sh
@@ -9,5 +9,9 @@ env_set() {
     NEW_VAL=${2:-}
     local VAR_VAL
     VAR_VAL=$(grep "${SET_VAR}" "${SCRIPTPATH}/compose/.env" | xargs || fatal "Could not find ${SET_VAR} in ${SCRIPTPATH}/compose/.env")
-    sed -i "s/${VAR_VAL}/${SET_VAR}=${NEW_VAL}/" "${SCRIPTPATH}/compose/.env"
+    local SED_FIND
+    SED_FIND=$(echo "${VAR_VAL}" | sed -e 's/[\/&]/\\&/g')
+    local SED_REPLACE
+    SED_REPLACE=$(echo "${SET_VAR}=${NEW_VAL}" | sed -e 's/[\/&]/\\&/g')
+    sed -i "s/${SED_FIND}/${SED_REPLACE}/" "${SCRIPTPATH}/compose/.env"
 }


### PR DESCRIPTION
More GUI prep, to make sure the GUI branch can rebase/squash easily.

Previous behaviour was unhappy handling timezones because of the `/` character. This resolves by escaping.