### PR TITLE
Add set_permissions function

### DIFF
--- a/scripts/cmd_install.sh
+++ b/scripts/cmd_install.sh
@@ -11,5 +11,6 @@ cmd_install() {
     run_script 'install_compose_completion'
     run_script 'setup_docker_group'
     run_script 'enable_docker_systemd'
+    run_script 'set_permissions'
     run_script 'request_reboot'
 }

--- a/scripts/run_compose.sh
+++ b/scripts/run_compose.sh
@@ -25,6 +25,11 @@ run_compose() {
             [Yy]* )
                 run_script 'install_docker'
                 run_script 'install_compose'
+                local PUID
+                PUID=$(run_script 'env_get' PUID)
+                local PGID
+                PGID=$(run_script 'env_get' PGID)
+                run_script 'set_permissions' "${SCRIPTPATH}" "${PUID}" "${PGID}"
                 cd "${SCRIPTPATH}/compose/" || return 1
                 docker-compose up -d
                 cd "${SCRIPTPATH}" || return 1

--- a/scripts/set_permissions.sh
+++ b/scripts/set_permissions.sh
@@ -9,6 +9,11 @@ set_permissions() {
     CH_PUID=${2:-$DETECTED_PUID}
     local CH_PGID
     CH_PGID=${3:-$DETECTED_PGID}
+    if [[ ${CI:-} == true ]] && [[ ${TRAVIS:-} == true ]]; then
+        info "Overriding PUID and PGID for Travis."
+        CH_PUID=${DETECTED_UNAME}
+        CH_PGID=${DETECTED_UGROUP}
+    fi
     info "Taking ownership of ${CH_PATH} for user ${CH_PUID} and group ${CH_PGID}"
     chown -R "${CH_PUID}":"${CH_PGID}" "${CH_PATH}"
     info "Setting folder permissions in ${CH_PATH} to 755"

--- a/scripts/set_permissions.sh
+++ b/scripts/set_permissions.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+set_permissions() {
+    local CH_PATH
+    CH_PATH=${1:-$SCRIPTPATH}
+    local CH_PUID
+    CH_PUID=${2:-$DETECTED_PUID}
+    local CH_PGID
+    CH_PGID=${3:-$DETECTED_PGID}
+    info "Taking ownership of ${CH_PATH} for user ${CH_PUID} and group ${CH_PGID}"
+    chown -R "${CH_PUID}":"${CH_PGID}" "${CH_PATH}"
+    info "Setting folder permissions in ${CH_PATH} to 755"
+    find "${CH_PATH}" -type d -print0 | xargs -0 chmod 755
+    info "Setting file permissions in ${CH_PATH} to 644"
+    find "${CH_PATH}" -type f -print0 | xargs -0 chmod 644
+}


### PR DESCRIPTION
This should be usable with every folder prompt in the GUI (like downloads and media folders). There is an example below of using this without any parameters (install just defaults to chmod on script path) and also one in the compose function that passes in the environment variables.