### PR TITLE
Another ARM fix for Docker Compose

### DIFF
--- a/scripts/install_compose.sh
+++ b/scripts/install_compose.sh
@@ -17,7 +17,7 @@ install_compose() {
             info "ARM architecture detected. Please let us know on Gitter chat if this works for you!"
             apt-get remove docker-compose > /dev/null 2>&1
             apt-get -y install python-pip > /dev/null 2>&1
-            pip uninstall docker-py > /dev/null 2>&1
+            pip uninstall docker-py > /dev/null 2>&1 || true
             pip install -U docker-compose > /dev/null 2>&1
         fi
         if [[ ${ARCH} == "amd64" ]]; then


### PR DESCRIPTION
According to this log https://github.com/GhostWriters/DockSTARTer/issues/105#issuecomment-406692035 arm installations are failing on the `pip uninstall docker-py` command, which makes sense if they never had it installed to begin with (that command was added to cleanup former messy installs). This commit ignores the failure of the above command and proceeds to install docker compose.