### PR TITLE
Reset screen after whiptails

### DIFF
--- a/scripts/menus/application_selector.sh
+++ b/scripts/menus/application_selector.sh
@@ -23,6 +23,7 @@ application_selector() {
 
     if [[ ${CI:-} != true ]] && [[ ${TRAVIS:-} != true ]]; then
         whiptail --title "Application Selector" --fb --checklist --separate-output "Choose which apps you would like to install:" --fb ${LINES} ${COLUMNS} ${NETLINES} "${SupportedAppDescr[@]}" 2>"${tempfile}"
+        reset || true
     fi
     #TODO - Ask if the user wants the disable the other apps in .env
 

--- a/scripts/menus/config_folder_set.sh
+++ b/scripts/menus/config_folder_set.sh
@@ -5,7 +5,7 @@ IFS=$'\n\t'
 config_folder_set() {
     if [[ ${CI:-} != true ]] && [[ ${TRAVIS:-} != true ]] && (whiptail --title "Configs Location" --fb --yesno \
             "The default place for config files is: ${DETECTED_HOMEDIR}/.docker/config\\nThis will be passed into the applications.\\n\\nWould you like to accept this?" 12 78); then
-
+        reset || true
         #TODO - Check if the folder exists?
         #TODO - Set permissions on the folder?
         run_script 'env_set' 'DOCKERCONFDIR' "${DETECTED_HOMEDIR}/.docker/config"

--- a/scripts/menus/download_folder_set.sh
+++ b/scripts/menus/download_folder_set.sh
@@ -5,7 +5,7 @@ IFS=$'\n\t'
 download_folder_set() {
     if [[ ${CI:-} != true ]] && [[ ${TRAVIS:-} != true ]] && (whiptail --title "Dowloads Location" --fb --yesno \
             "The default place for download files is: ${DETECTED_HOMEDIR}/Downloads\\nThis will be passed into the applications.\\n\\nWould you like to accept this?" 12 78); then
-
+        reset || true
         #TODO - Should we check if the folder exists?
         #TODO - Should we set permissions on the folder?
         run_script 'env_set' 'DOWNLOADSDIR' "${DETECTED_HOMEDIR}/Downloads"

--- a/scripts/menus/input_prompt.sh
+++ b/scripts/menus/input_prompt.sh
@@ -10,6 +10,7 @@ input_prompt() {
     local INPUT
     if [[ ${CI:-} != true ]] && [[ ${TRAVIS:-} != true ]]; then
         INPUT=$(whiptail --inputbox "What would you like to set ${SET_VAR} to?" 12 78 "${NEW_VAL}" --fb --title "Set folder" 3>&1 1>&2 2>&3)
+        reset || true
     else
         INPUT="${2}"
     fi
@@ -18,6 +19,7 @@ input_prompt() {
         run_script 'env_set' "${SET_VAR}" "${INPUT}"
     else
         whiptail --title "Error" --msgbox "${INPUT} is not a valid path. Please try again." --fb 9 78
+        reset || true
         input_prompt "${SET_VAR}" "${NEW_VAL}"
     fi
 }

--- a/scripts/menus/media_folders_set.sh
+++ b/scripts/menus/media_folders_set.sh
@@ -5,7 +5,7 @@ IFS=$'\n\t'
 media_folders_set() {
     if [[ ${CI:-} != true ]] && [[ ${TRAVIS:-} != true ]] && (whiptail --title "Media Locations" --fb --yesno \
             "The default place for Media files is:\\n${DETECTED_HOMEDIR}/Books\\n${DETECTED_HOMEDIR}/Movies\\n${DETECTED_HOMEDIR}/Music\\n${DETECTED_HOMEDIR}/TV\\n\\nThis will be passed into the applications.\\n\\nWould you like to accept this?" 17 78); then
-
+        reset || true
         #TODO - Should we check if the folder exists?
         #TODO - Should we set permissions on the folder?
         run_script 'env_set' 'MEDIADIR_BOOKS' "${DETECTED_HOMEDIR}/Books"

--- a/scripts/menus/menu_main.sh
+++ b/scripts/menus/menu_main.sh
@@ -22,6 +22,7 @@ menu_main() {
                 "Configure Apps" "Setup and start applications" \
                 "Install Dependencies" "Latest version of Docker and Docker-Compose" \
                 "Update DockStarter" "Get the latest version of DockSTARTer" 3>&1 1>&2 2>&3)
+    reset || true
 
     case "${MAINCHOICE}" in
         "Configure Apps")

--- a/scripts/menus/timezone_set.sh
+++ b/scripts/menus/timezone_set.sh
@@ -12,7 +12,7 @@ timezone_set() {
     else
         whiptail --title "Time Zone" --fb --yesno --yes-button "OK" --no-button "Cancel" \
             "Your Current Time Zone is: ${CURRENTTIMEZONE} \\nThis will be passed into the applications.\\n\\nIf this is incorrect cancel now and change your system time zone!" 12 78
-
+        reset || true
         run_script 'env_set' 'TZ' "${CURRENTTIMEZONE}"
     fi
 }

--- a/scripts/menus/user_group_set.sh
+++ b/scripts/menus/user_group_set.sh
@@ -9,7 +9,7 @@ user_group_set() {
     else
         whiptail --title "User and Group"  --fb --yesno --yes-button "OK" --no-button "Cancel" \
             "The detected User is: ${DETECTED_UNAME}\\nThe detected Group is: ${DETECTED_UGROUP}\\n\\nThis will be passed into the applications.\\n\\nPlease cancel if this is incorrect or adjust .env file manually after." 14 78
-
+        reset || true
         run_script 'env_set' 'PUID' "${DETECTED_PUID}"
         run_script 'env_set' 'PGID' "${DETECTED_PGID}"
     fi

--- a/scripts/request_reboot.sh
+++ b/scripts/request_reboot.sh
@@ -17,6 +17,7 @@ request_reboot() {
             set +e
             ANSWER=$(whiptail --fb --yesno "${QUESTION}" 0 0 3>&1 1>&2 2>&3; echo $?)
             set -e
+            reset || true
             [[ ${ANSWER} == 0 ]] && YN=Y || YN=N
         else
             read -rp "[Yn]" YN

--- a/scripts/run_compose.sh
+++ b/scripts/run_compose.sh
@@ -17,6 +17,7 @@ run_compose() {
             set +e
             ANSWER=$(whiptail --fb --yesno "${QUESTION}" 0 0 3>&1 1>&2 2>&3; echo $?)
             set -e
+            reset || true
             [[ ${ANSWER} == 0 ]] && YN=Y || YN=N
         else
             read -rp "[Yn]" YN

--- a/scripts/update_self.sh
+++ b/scripts/update_self.sh
@@ -17,6 +17,7 @@ update_self() {
             set +e
             ANSWER=$(whiptail --fb --yesno "${QUESTION}" 0 0 3>&1 1>&2 2>&3; echo $?)
             set -e
+            reset || true
             [[ ${ANSWER} == 0 ]] && YN=Y || YN=N
         else
             read -rp "[Yn]" YN


### PR DESCRIPTION
So this is kind of a quality of life change. We have discussed previously that it's a bit jarring to be bounced between the whiptail menus and the terminal, but I feel like this helps that a little bit by resetting the console immediately after any whiptail menu is shown thus you get a nice clean console and don't watch what's left of the whiptail menu float upward as the console slowly adds more lines. There's still the back and forth between menus and console, but at least it's cleaner.