### PR TITLE
Remove trap commands and prevent leftovers on the spot

### DIFF
--- a/scripts/generate_yml.sh
+++ b/scripts/generate_yml.sh
@@ -76,5 +76,5 @@ generate_yml() {
     run_script 'install_yq'
     bash "${RUNFILE}"
     info "Merging docker-compose.yml complete."
-    trap 'rm -f "${SCRIPTPATH}/compose/docker-compose.sh"' EXIT
+    rm -f "${RUNFILE}"
 }

--- a/scripts/install_docker.sh
+++ b/scripts/install_docker.sh
@@ -12,8 +12,6 @@ install_docker() {
     FORCE=${1:-}
     if [[ "${AVAILABLE_DOCKER}" != "${INSTALLED_DOCKER}" ]] || [[ -n ${FORCE} ]]; then
         info "Installing latest docker. Please be patient, this will take a while."
-        curl -fsSL get.docker.com -o get-docker.sh > /dev/null 2>&1
-        sh get-docker.sh > /dev/null 2>&1
-        trap 'rm -f get-docker.sh' EXIT
+        curl -fsSL get.docker.com | sh > /dev/null 2>&1
     fi
 }


### PR DESCRIPTION
The docker install shell script was being left behind at times. This was likely due to the trap command so I replaced all trap commands.