### PR TITLE
Create PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+## Purpose
+_Describe the problem or feature in addition to a link to the issues._
+
+## Approach
+_How does this change address the problem?_
+
+#### Open Questions and Pre-Merge TODOs
+- [ ] Use github checklists. When solved, check the box and explain the answer.
+
+## Learning
+_Describe the research stage_
+
+_Links to blog posts, patterns, libraries or addons used to solve this problem_
+
+#### Standards
+- [ ] This PR meets all of the repo [standards](https://github.com/GhostWriters/DockSTARTer/wiki/Standards).


### PR DESCRIPTION
## Purpose
Now that we've had our first PR from someone who isn't already a repo admin it's probably time to get a PR template in place. This resolves #142

## Approach
This adds the `PULL_REQUEST_TEMPLATE.md` file to the `.github` directory of the repo so it should prefill pull requests with the template being used to fill out this PR.

#### Open Questions and Pre-Merge TODOs
- [x] Nothing needed here since we already use reviews, but future PRs might require extra care such as `squash with merge` or `please run additional human tests before merge`.

## Learning
https://github.com/flexyford/pull-request-template

#### Standards
- [x] This PR meets all of the repo [standards](https://github.com/GhostWriters/DockSTARTer/wiki/Standards).