### PR TITLE
Remove redundant aarch64 yml

### DIFF
--- a/compose/.apps/emby/emby.arm64.yml
+++ b/compose/.apps/emby/emby.arm64.yml
@@ -1,3 +1,0 @@
-services:
-  emby:
-    image:  emby/embyserver_arm32v7:latest

--- a/compose/.apps/portainer/portainer.arm64.yml
+++ b/compose/.apps/portainer/portainer.arm64.yml
@@ -1,3 +1,0 @@
-services:
-  portainer:
-    image:    portainer/portainer

--- a/compose/.apps/watchtower/watchtower.arm64.yml
+++ b/compose/.apps/watchtower/watchtower.arm64.yml
@@ -1,3 +1,0 @@
-services:
-  watchtower:
-    image:     v2tec/watchtower:armhf-latest


### PR DESCRIPTION
## Purpose
Emby, Portainer, and Watchtower do not have aarch64 images. These files should be removed since they are redundant to the armhf files which are used automatically on aarch64 systems when needed.

## Approach
Remove the files that are not needed because the generator pulls armhf images for aarch64 systems if there is no aarch64 yml file.

#### Standards
- [x] This PR meets all of the repo [standards](https://github.com/GhostWriters/DockSTARTer/wiki/Standards).
