### PR TITLE
Update PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,5 +12,6 @@ _Describe the research stage_
 
 _Links to blog posts, patterns, libraries or addons used to solve this problem_
 
-#### Standards
-- [ ] This PR meets all of the repo [standards](https://github.com/GhostWriters/DockSTARTer/wiki/Standards).
+#### Requirements
+- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
+- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,11 +7,11 @@ _How does this change address the problem?_
 #### Open Questions and Pre-Merge TODOs
 - [ ] Use github checklists. When solved, check the box and explain the answer.
 
-## Learning
+#### Learning
 _Describe the research stage_
 
 _Links to blog posts, patterns, libraries or addons used to solve this problem_
 
-#### Requirements
+## Requirements
 - [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
 - [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).


### PR DESCRIPTION
## Purpose
Follow up on #145 to update the PR template after it has merged.

## Approach
Update PR template with links to the proper contributing and code of conduct files in the repo. Side note; the wiki is now open to the community for editing without approval, so certain documents like this are better kept in the repo where approval is required.

#### Standards
- [x] This PR meets all of the repo [standards](https://github.com/GhostWriters/DockSTARTer/wiki/Standards).
