### PR TITLE
Minor cleanup to ISSUE_TEMPLATE

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,15 +1,8 @@
-<!---
-name: Feature request
-about: Suggest an idea for this project
-
+<!--
 Please keep all feature requests on FeatHub.
 https://feathub.com/GhostWriters/DockSTARTer
---->
-<!---
-name: Bug report
-about: Create a report to help us improve
+-->
 
---->
 **Describe the bug**
 A clear and concise description of what the bug is.
 


### PR DESCRIPTION
## Purpose
This cleans up the unnecessary comments at the top of the ISSUE_TEMPLATE

## Approach
Remove the comments about which template is being used. This shortens the whole of the ISSUE_TEMPLATE and should hopefully be less confusing

#### Standards
- [x] This PR meets all of the repo [standards](https://github.com/GhostWriters/DockSTARTer/wiki/Standards).
