### PR TITLE
Include git pull in update_self

### DIFF
--- a/scripts/update_self.sh
+++ b/scripts/update_self.sh
@@ -27,6 +27,7 @@ update_self() {
                 info "Updating DockSTARTer."
                 git -C "${SCRIPTPATH}" fetch --all > /dev/null 2>&1
                 git -C "${SCRIPTPATH}" reset --hard origin/master > /dev/null 2>&1
+                git -C "${SCRIPTPATH}" pull > /dev/null 2>&1
                 run_script 'env_update'
                 break
                 ;;


### PR DESCRIPTION
## Purpose
I noticed that the update function was fetching the remote changes (from the master branch of the repo) but not actually applying them to the locally checked out master branch.

## Approach
After doing a hard reset (which we were already going) a pull should run without issue and either actually pull or do nothing if there are no updates.

#### Learning
https://stackoverflow.com/questions/1125968/how-do-i-force-git-pull-to-overwrite-local-files
https://stackoverflow.com/questions/6335681/git-how-do-i-get-the-latest-version-of-my-code
Per the answers in these two discussions it looks like others trying to accomplish the same thing are using similar methods. The key difference is that some of the answers instruct how to get the branch clean so that a pull can be performed but the examples they provide do not actually instruct that a pull should be done after getting the branch prepped for the pull.

## Requirements
- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
