### PR TITLE
Run compose as detected uname

### DIFF
--- a/scripts/run_compose.sh
+++ b/scripts/run_compose.sh
@@ -32,7 +32,7 @@ run_compose() {
                 PGID=$(run_script 'env_get' PGID)
                 run_script 'set_permissions' "${SCRIPTPATH}" "${PUID}" "${PGID}"
                 cd "${SCRIPTPATH}/compose/" || fatal "Unable to change directory to ${SCRIPTPATH}/compose/"
-                docker-compose up -d
+                su -c "docker-compose up -d" "${DETECTED_UNAME}"
                 cd "${SCRIPTPATH}" || fatal "Unable to change directory to ${SCRIPTPATH}"
                 break
                 ;;


### PR DESCRIPTION
## Purpose
Run compose as the user running DS. This is safer than running as root (which is what we currently do). Docker itself still runs via systemd and is setup to run as whatever user the official get.docker.com script configures.

## Approach
Use `su -c`. Has been fully tested by myself and others.

## Requirements
- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
