### PR TITLE
Add beerpay.io to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,6 @@ Please add new features and vote to help steer the direction of DockSTARTer. Cur
 -   [SmartHomeBeginner.com](https://www.smarthomebeginner.com/) for creating [AtoMiC-ToolKit](https://github.com/htpcBeginner/AtoMiC-ToolKit) that served as this project's primary inspiration, and later [this](https://www.smarthomebeginner.com/docker-home-media-server-2018-basic/) guide that provided some initial direction with Docker.
 -   [LinuxServer.io](https://www.linuxserver.io/) for maintaining the majority of the Docker images used in this project.
 
-## Credits [![GitHub contributors](https://img.shields.io/github/contributors/GhostWriters/DockSTARTer.svg)](https://GitHub.com/GhostWriters/DockSTARTer/graphs/contributors/)
+## Supporters [![Beerpay](https://img.shields.io/beerpay/hashdog/scrapfy-chrome-extension.svg)](https://beerpay.io/GhostWriters/DockSTARTer) / Contributors [![GitHub contributors](https://img.shields.io/github/contributors/GhostWriters/DockSTARTer.svg)](https://GitHub.com/GhostWriters/DockSTARTer/graphs/contributors/)
 
 This project is primarily maintained by [nemchik](https://github.com/GhostWriters/DockSTARTer/commits?author=nemchik) and [TommyE123](https://github.com/GhostWriters/DockSTARTer/commits?author=TommyE123)

--- a/README.md
+++ b/README.md
@@ -42,6 +42,6 @@ Please add new features and vote to help steer the direction of DockSTARTer. Cur
 -   [SmartHomeBeginner.com](https://www.smarthomebeginner.com/) for creating [AtoMiC-ToolKit](https://github.com/htpcBeginner/AtoMiC-ToolKit) that served as this project's primary inspiration, and later [this](https://www.smarthomebeginner.com/docker-home-media-server-2018-basic/) guide that provided some initial direction with Docker.
 -   [LinuxServer.io](https://www.linuxserver.io/) for maintaining the majority of the Docker images used in this project.
 
-## Supporters [![Beerpay](https://img.shields.io/beerpay/hashdog/scrapfy-chrome-extension.svg)](https://beerpay.io/GhostWriters/DockSTARTer) / Contributors [![GitHub contributors](https://img.shields.io/github/contributors/GhostWriters/DockSTARTer.svg)](https://GitHub.com/GhostWriters/DockSTARTer/graphs/contributors/)
+## Supporters [![Beerpay](https://img.shields.io/beerpay/GhostWriters/DockSTARTer.svg)](https://beerpay.io/GhostWriters/DockSTARTer) / Contributors [![GitHub contributors](https://img.shields.io/github/contributors/GhostWriters/DockSTARTer.svg)](https://GitHub.com/GhostWriters/DockSTARTer/graphs/contributors/)
 
 This project is primarily maintained by [nemchik](https://github.com/GhostWriters/DockSTARTer/commits?author=nemchik) and [TommyE123](https://github.com/GhostWriters/DockSTARTer/commits?author=TommyE123)


### PR DESCRIPTION
## Purpose
Add beerpay.io to the readme. 

## Approach
Beerpay lists all contributors to the repo as optional recipients and supporters can choose who to donate to. Supporters can also choose to put a wish (bounty) on a specific issue on GitHub and I think whoever closes the issue gets the bounty. Contributors will need to sign up for beerpay.io and link a Stripe account in order to receive donations from Supporters.

#### Open Questions and Pre-Merge TODOs
- [ ] Tom needs to sign up with beerpay (and link a Stripe account)

#### Learning
https://beerpay.io/GhostWriters/DockSTARTer

## Requirements
- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
