### PR TITLE
Travis failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,10 @@ jobs:
     script: sudo bash ./main.sh -t run_install
   - stage: run
     script: sudo bash ./main.sh -t run_generate
+  - stage: run
+    script: sudo bash ./main.sh -t run_generate_full
 matrix:
   fast_finish: true
   allow_failures:
   - stage: run
-    script: sudo bash ./main.sh -t run_generate
+    script: sudo bash ./main.sh -t run_generate_full

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,6 @@ jobs:
     script: sudo bash ./main.sh -t run_generate
 matrix:
   fast_finish: true
+  allow_failures:
+  - stage: run
+    script: sudo bash ./main.sh -t run_generate

--- a/tests/run_generate.sh
+++ b/tests/run_generate.sh
@@ -5,22 +5,6 @@ IFS=$'\n\t'
 run_generate() {
     run_script 'run_apt'
     run_script 'env_create'
-    info "Enabling all apps."
-    sed -i 's/_ENABLED=false/_ENABLED=true/' "${SCRIPTPATH}/compose/.env"
-    info "Adjusting ports to prevent conflicts."
-    sed -i 's/DELUGEVPN_PORT_58846=58846/DELUGEVPN_PORT_58846=58847/' "${SCRIPTPATH}/compose/.env"
-    sed -i 's/DELUGEVPN_PORT_58946=58946/DELUGEVPN_PORT_58946=58947/' "${SCRIPTPATH}/compose/.env"
-    sed -i 's/DELUGEVPN_PORT_8112=8112/DELUGEVPN_PORT_8112=18112/' "${SCRIPTPATH}/compose/.env"
-    sed -i 's/HEADPHONES_PORT_8181=8181/HEADPHONES_PORT_8181=18181/' "${SCRIPTPATH}/compose/.env"
-    sed -i 's/PLEX_PORT_1900=1900/PLEX_PORT_1900=11900/' "${SCRIPTPATH}/compose/.env"
-    sed -i 's/RUTORRENT_PORT_51413=51413/RUTORRENT_PORT_51413=41413/' "${SCRIPTPATH}/compose/.env"
-    sed -i 's/RUTORRENT_PORT_6881=6881/RUTORRENT_PORT_6881=16881/' "${SCRIPTPATH}/compose/.env"
-    sed -i 's/SICKRAGE_PORT_8081=8081/SICKRAGE_PORT_8081=28081/' "${SCRIPTPATH}/compose/.env"
-    sed -i 's/TRANSMISSIONVPN_PORT_9091=9091/TRANSMISSIONVPN_PORT_9091=19091/' "${SCRIPTPATH}/compose/.env"
-    sed -i 's/UNIFI_PORT_6789=6789/UNIFI_PORT_6789=16789/' "${SCRIPTPATH}/compose/.env"
-    sed -i 's/UNIFI_PORT_7878=7878/UNIFI_PORT_7878=17878/' "${SCRIPTPATH}/compose/.env"
-    sed -i 's/UNIFI_PORT_8080=8080/UNIFI_PORT_8080=18080/' "${SCRIPTPATH}/compose/.env"
-    sed -i 's/UNIFI_PORT_8081=8081/UNIFI_PORT_8081=18081/' "${SCRIPTPATH}/compose/.env"
     info "Running generator."
     bash "${SCRIPTPATH}/main.sh" -g
     echo

--- a/tests/run_generate_full.sh
+++ b/tests/run_generate_full.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+run_generate_full() {
+    run_script 'run_apt'
+    run_script 'env_create'
+    info "Enabling all apps."
+    sed -i 's/_ENABLED=false/_ENABLED=true/' "${SCRIPTPATH}/compose/.env"
+    info "Adjusting ports to prevent conflicts."
+    sed -i 's/DELUGEVPN_PORT_58846=58846/DELUGEVPN_PORT_58846=58847/' "${SCRIPTPATH}/compose/.env"
+    sed -i 's/DELUGEVPN_PORT_58946=58946/DELUGEVPN_PORT_58946=58947/' "${SCRIPTPATH}/compose/.env"
+    sed -i 's/DELUGEVPN_PORT_8112=8112/DELUGEVPN_PORT_8112=18112/' "${SCRIPTPATH}/compose/.env"
+    sed -i 's/HEADPHONES_PORT_8181=8181/HEADPHONES_PORT_8181=18181/' "${SCRIPTPATH}/compose/.env"
+    sed -i 's/PLEX_PORT_1900=1900/PLEX_PORT_1900=11900/' "${SCRIPTPATH}/compose/.env"
+    sed -i 's/RUTORRENT_PORT_51413=51413/RUTORRENT_PORT_51413=41413/' "${SCRIPTPATH}/compose/.env"
+    sed -i 's/RUTORRENT_PORT_6881=6881/RUTORRENT_PORT_6881=16881/' "${SCRIPTPATH}/compose/.env"
+    sed -i 's/SICKRAGE_PORT_8081=8081/SICKRAGE_PORT_8081=28081/' "${SCRIPTPATH}/compose/.env"
+    sed -i 's/TRANSMISSIONVPN_PORT_9091=9091/TRANSMISSIONVPN_PORT_9091=19091/' "${SCRIPTPATH}/compose/.env"
+    sed -i 's/UNIFI_PORT_6789=6789/UNIFI_PORT_6789=16789/' "${SCRIPTPATH}/compose/.env"
+    sed -i 's/UNIFI_PORT_7878=7878/UNIFI_PORT_7878=17878/' "${SCRIPTPATH}/compose/.env"
+    sed -i 's/UNIFI_PORT_8080=8080/UNIFI_PORT_8080=18080/' "${SCRIPTPATH}/compose/.env"
+    sed -i 's/UNIFI_PORT_8081=8081/UNIFI_PORT_8081=18081/' "${SCRIPTPATH}/compose/.env"
+    info "Running generator."
+    bash "${SCRIPTPATH}/main.sh" -g
+    echo
+    cat "${SCRIPTPATH}/compose/docker-compose.yml" || fatal "${SCRIPTPATH}/compose/docker-compose.yml not found."
+    echo
+    cd "${SCRIPTPATH}/compose/" || fatal "Could not change to ${SCRIPTPATH}/compose/ directory."
+    docker-compose up -d || fatal "Docker Compose failed."
+    cd "${SCRIPTPATH}" || fatal "Could not change to ${SCRIPTPATH} directory."
+}


### PR DESCRIPTION
## Purpose
Use `allow_failures` in `.travis.yml` on the `run_generate` step so that `fast_finish` actually has an effect.

## Approach
We still want to test the generator and fail a build if it doesn't work, so I have split `run_generate` and created `run_generate_full` which is identical to what `run_generate` used to be and I have slimmed `run_generate` down to just portainer and watchtower. Builds complete much faster now (under 3 minutes as opposed to around 10) and we can still review the builds to see if `run_generate_full` fails, which would be caused by an individual app having trouble.

#### Open Questions and Pre-Merge TODOs
- [ ] Merge this with squash.

#### Learning
https://docs.travis-ci.com/user/customizing-the-build/#rows-that-are-allowed-to-fail
https://docs.travis-ci.com/user/build-stages

## Requirements
- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
