### PR TITLE
Use shellcheck directives with sourcing

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -84,6 +84,7 @@ usage() {
 run_script() {
     local SCRIPTSNAME="${1:-}"; shift
     if [[ -f ${SCRIPTPATH}/scripts/${SCRIPTSNAME}.sh ]]; then
+        # shellcheck source=/dev/null
         source "${SCRIPTPATH}/scripts/${SCRIPTSNAME}.sh"
         ${SCRIPTSNAME} "$@";
     else
@@ -95,6 +96,7 @@ run_script() {
 run_test() {
     local TESTSNAME="${1:-}"; shift
     if [[ -f ${SCRIPTPATH}/tests/${TESTSNAME}.sh ]]; then
+        # shellcheck source=/dev/null
         source "${SCRIPTPATH}/tests/${TESTSNAME}.sh"
         ${TESTSNAME} "$@";
     else
@@ -105,6 +107,7 @@ run_test() {
 # # Main Function
 main() {
     run_script 'root_check'
+    # shellcheck source=scripts/cmdline.sh
     source "${SCRIPTPATH}/scripts/cmdline.sh"
     cmdline "${ARGS[@]:-}"
     run_script 'menu_main'

--- a/tests/validate_shellcheck.sh
+++ b/tests/validate_shellcheck.sh
@@ -15,7 +15,7 @@ validate_shellcheck() {
     local SCERRORS
     SCERRORS=$(find . -name '*.sh' -print0 | xargs -0 shellcheck -e SC1090 -e SC1091 -e SC2034 || true)
     if [[ -n ${SCERRORS} ]]; then
-        find . -name '*.sh' -print0 | xargs -0 shellcheck -e SC1090 -e SC1091 -e SC2034
+        find . -name '*.sh' -print0 | xargs -0 shellcheck -e SC2034
         fatal "Shellcheck validation failure."
     fi
 


### PR DESCRIPTION
## Purpose
Since Codacy now seems to have all validations from Shellcheck 0.5.0 builds will fail there until this is merged.

## Approach
Use directives as described in Shellcheck's wiki to let Shellcheck know what we're doing with source files. The ones that source based on parameter input will use /dev/null while any that point to a permanent location will use that in the directive relative to the path of the script containing the directive.

#### Learning
https://github.com/koalaman/shellcheck/wiki/SC1090
https://github.com/koalaman/shellcheck/wiki/SC1091
https://github.com/koalaman/shellcheck/wiki/Directive

## Requirements
- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
