### PR TITLE
Add DOCKERSHAREDDIR prompt

### DIFF
--- a/scripts/ui_config.sh
+++ b/scripts/ui_config.sh
@@ -9,6 +9,7 @@ ui_config() {
     run_script 'menu_value_prompt' PUID || return 1
     run_script 'menu_value_prompt' PGID || return 1
     run_script 'menu_value_prompt' DOCKERCONFDIR || return 1
+    run_script 'menu_value_prompt' DOCKERSHAREDDIR || return 1
     run_script 'menu_value_prompt' DOWNLOADSDIR || return 1
     run_script 'menu_value_prompt' MEDIADIR_BOOKS || return 1
     run_script 'menu_value_prompt' MEDIADIR_MOVIES || return 1


### PR DESCRIPTION
## Purpose
Add `DOCKERSHAREDDIR` prompt to the UI. This variable was added a while ago but no prompt was added to the UI for it.

## Approach
Add the appropriate line to prompt for this folder.

## Requirements
- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
