### PR TITLE
Apply regex fix to env_get

### DIFF
--- a/scripts/env_get.sh
+++ b/scripts/env_get.sh
@@ -6,6 +6,6 @@ env_get() {
     local GET_VAR
     GET_VAR=${1:-}
     local VAR_VAL
-    VAR_VAL=$(grep "${GET_VAR}" "${SCRIPTPATH}/compose/.env" | xargs || true)
+    VAR_VAL=$(grep "^${GET_VAR}=" "${SCRIPTPATH}/compose/.env" | xargs || true)
     echo "${VAR_VAL#*=}"
 }


### PR DESCRIPTION
## Purpose
Follow up to the emergency fix. This could be affected the same way, so the same fix is needed.

## Approach
Use proper regex with grep for env_get

## Requirements
- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
