### PR TITLE
Remove orphans with compose up

### DIFF
--- a/scripts/run_compose.sh
+++ b/scripts/run_compose.sh
@@ -32,7 +32,7 @@ run_compose() {
                 PGID=$(run_script 'env_get' PGID)
                 run_script 'set_permissions' "${SCRIPTPATH}" "${PUID}" "${PGID}"
                 cd "${SCRIPTPATH}/compose/" || fatal "Unable to change directory to ${SCRIPTPATH}/compose/"
-                su -c "docker-compose up -d" "${DETECTED_UNAME}"
+                su -c "docker-compose up -d --remove-orphans" "${DETECTED_UNAME}"
                 cd "${SCRIPTPATH}" || fatal "Unable to change directory to ${SCRIPTPATH}"
                 break
                 ;;


### PR DESCRIPTION
## Purpose
Revisit https://feathub.com/GhostWriters/DockSTARTer/+14 and actually remove orphans using the build in option with compose. The prune option that was considered to resolve the request does not actually remove orphans, it only cleans up unused objects after the container is stopped. Without using the build in remove orphans option the container is left running.

## Approach
Add the remove orphans option to compose up. This will Stop and remove a container that is no longer considered part of the stack. The existing prune option will clean up unused resources such as the image that the container used (this is not automatically removed when an orphan container is removed).

#### Learning
https://docs.docker.com/compose/reference/up/

## Requirements
- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
