### PR TITLE
Remove enhancement from stale exemption

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -6,7 +6,6 @@ daysUntilClose: 7
 exemptLabels:
   - pinned
   - security
-  - enhancement
 # Label to use when marking an issue as stale
 staleLabel: wontfix
 # Comment to post when marking an issue as stale. Set to `false` to disable


### PR DESCRIPTION
## Purpose
We're currently using the enhancement label for issues or pull requests involving new features. Allowing them to become stale should result in email notifications so that we can determine if the issue/PR is being actively worked on or if it has been abandoned. New activity after a stale notice would prevent the issue from being automatically closed.

## Approach
See above.

## Requirements
- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
