### PR TITLE
Update Netdata

### DIFF
--- a/compose/.apps/netdata/netdata.armhf.yml
+++ b/compose/.apps/netdata/netdata.armhf.yml
@@ -1,3 +1,3 @@
 services:
   netdata:
-    image:  firehol/netdata:armv7hf
+    image:  firehol/netdata:armhf

--- a/compose/.apps/netdata/netdata.yml
+++ b/compose/.apps/netdata/netdata.yml
@@ -4,6 +4,8 @@ services:
     container_name:  netdata
     restart:         always
     environment:
+      - PGID=${PGID}
+      - PUID=${PUID}
       - TZ=${TZ}
     volumes:
       - /etc/localtime:/etc/localtime:ro


### PR DESCRIPTION
## Purpose
Netdata has changed their armhf tag name. Also their wiki has information about docker group being specified in env.

## Approach
Added PGID and PUID vars in hopes that netdata will detect container names. We aren't sending the docker group like the wiki specifies, but rather the group of the user that DS puts in the docker group. Also use the new armhf tag.

#### Learning
https://github.com/firehol/netdata/wiki/Install-netdata-with-Docker
https://github.com/firehol/netdata/pull/3995

## Requirements
- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
