### PR TITLE
Use LSIO Bazarr images

### DIFF
--- a/compose/.apps/bazarr/bazarr.arm64.yml
+++ b/compose/.apps/bazarr/bazarr.arm64.yml
@@ -1,3 +1,3 @@
 services:
   bazarr:
-    image:      morpheus65535/bazarr:arm64-latest
+    image:  linuxserver/bazarr:arm64v8-latest

--- a/compose/.apps/bazarr/bazarr.armhf.yml
+++ b/compose/.apps/bazarr/bazarr.armhf.yml
@@ -1,3 +1,3 @@
 services:
   bazarr:
-    image:      morpheus65535/bazarr:armhf-latest
+    image:  linuxserver/bazarr:arm32v6-latest

--- a/compose/.apps/bazarr/bazarr.yml
+++ b/compose/.apps/bazarr/bazarr.yml
@@ -1,6 +1,6 @@
 services:
   bazarr:
-    image:           morpheus65535/bazarr
+    image:           linuxserver/bazarr
     container_name:  bazarr
     restart:         always
     environment:
@@ -9,7 +9,7 @@ services:
       - TZ=${TZ}
     volumes:
       - /etc/localtime:/etc/localtime:ro
-      - ${DOCKERCONFDIR}/bazarr:/bazarr/data
+      - ${DOCKERCONFDIR}/bazarr:/config
       - ${DOCKERSHAREDDIR}:/shared
       - ${MEDIADIR_MOVIES}:/movies
       - ${MEDIADIR_TV}:/tv


### PR DESCRIPTION
## Purpose
Switch DS to LSIO images for Bazarr

## Approach
Change the existing files to use the new images

#### Open Questions and Pre-Merge TODOs
- [x] Wait until LSIO officially releases the image before merging.

#### Learning
https://hub.docker.com/r/linuxserver/bazarr/
The above link will not work until the images are released and even then we should wait until Bazarr is listed on https://www.linuxserver.io/our-images/

LSIO's new build system uses a single repo with tags for multi-arch support, so we no longer use the separate arm images.

## Requirements
- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
