### PR TITLE
Better handling of Docker GID

### DIFF
--- a/compose/.apps/netdata/netdata.yml
+++ b/compose/.apps/netdata/netdata.yml
@@ -4,8 +4,7 @@ services:
     container_name:  netdata
     restart:         always
     environment:
-      - PGID=${PGID}
-      - PUID=${PUID}
+      - PGID=${DOCKERGID}
       - TZ=${TZ}
     volumes:
       - /etc/localtime:/etc/localtime:ro

--- a/compose/.env.example
+++ b/compose/.env.example
@@ -1,5 +1,6 @@
 # Universal Settings
 DOCKERCONFDIR=~/.docker/config
+DOCKERGID=999
 DOCKERSHAREDDIR=~/.docker/config/shared
 DOWNLOADSDIR=/mnt/downloads
 MEDIADIR_BOOKS=/mnt/medialibrary/books

--- a/main.sh
+++ b/main.sh
@@ -6,46 +6,46 @@ readonly SCRIPTNAME="$(basename "${0}")"
 readonly SCRIPTPATH="$(readlink -m "$(dirname "${0}")")"
 readonly ARGS=("$@")
 
-# # Colors
+# Colors
 readonly BLU='\e[34m'
 readonly GRN='\e[32m'
 readonly RED='\e[31m'
 readonly YLW='\e[33m'
 readonly ENDCOLOR='\e[0m'
 
-# # Log Functions
+# Log Functions
 readonly LOG_FILE="/tmp/dockstarter.log"
 info()    { echo -e "$(date +"%F %T") ${BLU}[INFO]${ENDCOLOR}       $*" | tee -a "${LOG_FILE}" >&2 ; }
 warning() { echo -e "$(date +"%F %T") ${YLW}[WARNING]${ENDCOLOR}    $*" | tee -a "${LOG_FILE}" >&2 ; }
 error()   { echo -e "$(date +"%F %T") ${RED}[ERROR]${ENDCOLOR}      $*" | tee -a "${LOG_FILE}" >&2 ; }
 fatal()   { echo -e "$(date +"%F %T") ${RED}[FATAL]${ENDCOLOR}      $*" | tee -a "${LOG_FILE}" >&2 ; exit 1 ; }
 
-# # Check Arch
+# Check Arch
 readonly ARCH=$(uname -m)
 if [[ ${ARCH} != "aarch64" ]] && [[ ${ARCH} != "armv7l" ]] && [[ ${ARCH} != "x86_64" ]]; then
     fatal "Unsupported architecture."
 fi
 
-# # User/Group Information
+# User/Group Information
 readonly DETECTED_PUID=${SUDO_UID:-$UID}
 readonly DETECTED_UNAME=$(id -un "${DETECTED_PUID}" 2> /dev/null || true)
 readonly DETECTED_PGID=$(id -g "${DETECTED_PUID}" 2> /dev/null || true)
 readonly DETECTED_UGROUP=$(id -gn "${DETECTED_PUID}" 2> /dev/null || true)
 readonly DETECTED_HOMEDIR=$(eval echo "~${DETECTED_UNAME}" 2> /dev/null || true)
 
-# # Github Token for Travis CI
+# Github Token for Travis CI
 if [[ ${CI:-} == true ]] && [[ ${TRAVIS:-} == true ]] && [[ ${TRAVIS_SECURE_ENV_VARS} == true ]]; then
     readonly GH_HEADER="Authorization: token ${GH_TOKEN}"
 fi
 
-# # Check Systemd
+# Check Systemd
 if [[ -L "/sbin/init" ]]; then
     readonly ISSYSTEMD=true
 else
     readonly ISSYSTEMD=false
 fi
 
-# # Usage Information
+# Usage Information
 #/ usage: main.sh options
 #/
 #/ This is the main DockSTARTer script.
@@ -83,7 +83,7 @@ usage() {
     grep '^#/' "${SCRIPTPATH}/${SCRIPTNAME}" | cut -c4-
 }
 
-# # Script Runner Function
+# Script Runner Function
 run_script() {
     local SCRIPTSNAME="${1:-}"; shift
     if [[ -f ${SCRIPTPATH}/scripts/${SCRIPTSNAME}.sh ]]; then
@@ -95,7 +95,7 @@ run_script() {
     fi
 }
 
-# # Test Runner Function
+# Test Runner Function
 run_test() {
     local TESTSNAME="${1:-}"; shift
     if [[ -f ${SCRIPTPATH}/tests/${TESTSNAME}.sh ]]; then
@@ -107,7 +107,7 @@ run_test() {
     fi
 }
 
-# # Main Function
+# Main Function
 main() {
     run_script 'root_check'
     # shellcheck source=scripts/cmdline.sh

--- a/scripts/enable_docker_systemd.sh
+++ b/scripts/enable_docker_systemd.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 IFS=$'\n\t'
 
 enable_docker_systemd() {
-    # # https://docs.docker.com/install/linux/linux-postinstall/
+    # https://docs.docker.com/install/linux/linux-postinstall/
     if [[ ${ISSYSTEMD} == true ]]; then
         info "Systemd detected. Enabling docker service."
         systemctl enable docker > /dev/null 2>&1

--- a/scripts/install_compose.sh
+++ b/scripts/install_compose.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 IFS=$'\n\t'
 
 install_compose() {
-    # # https://docs.docker.com/compose/install/ OR https://github.com/javabean/arm-compose
+    # https://docs.docker.com/compose/install/ OR https://github.com/javabean/arm-compose
     local AVAILABLE_COMPOSE
     AVAILABLE_COMPOSE=$(curl -H "${GH_HEADER:-}" -s "https://api.github.com/repos/docker/compose/releases/latest" | grep -Po '"tag_name": "[Vv]?\K.*?(?=")')
     local INSTALLED_COMPOSE

--- a/scripts/install_compose_completion.sh
+++ b/scripts/install_compose_completion.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 IFS=$'\n\t'
 
 install_compose_completion() {
-    # # https://docs.docker.com/compose/completion/
+    # https://docs.docker.com/compose/completion/
     local AVAILABLE_COMPOSE_COMPLETION
     AVAILABLE_COMPOSE_COMPLETION=$(curl -H "${GH_HEADER:-}" -s "https://api.github.com/repos/docker/compose/releases/latest" | grep -Po '"tag_name": "\K.*?(?=")')
     info "Installing docker compose completion."

--- a/scripts/install_docker.sh
+++ b/scripts/install_docker.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 IFS=$'\n\t'
 
 install_docker() {
-    # # https://github.com/docker/docker-install
+    # https://github.com/docker/docker-install
     local AVAILABLE_DOCKER
     AVAILABLE_DOCKER=$(curl -H "${GH_HEADER:-}" -s "https://api.github.com/repos/docker/docker-ce/releases/latest" | grep -Po '"tag_name": "[Vv]?\K.*?(?=")')
     local INSTALLED_DOCKER

--- a/scripts/install_machine_completion.sh
+++ b/scripts/install_machine_completion.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 IFS=$'\n\t'
 
 install_machine_completion() {
-    # # https://docs.docker.com/machine/completion/
+    # https://docs.docker.com/machine/completion/
     local AVAILABLE_MACHINE_COMPLETION
     AVAILABLE_MACHINE_COMPLETION=$(curl -H "${GH_HEADER:-}" -s "https://api.github.com/repos/docker/machine/releases/latest" | grep -Po '"tag_name": "\K.*?(?=")')
     info "Installing docker machine completion."

--- a/scripts/install_yq.sh
+++ b/scripts/install_yq.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 IFS=$'\n\t'
 
 install_yq() {
-    # # https://github.com/mikefarah/yq
+    # https://github.com/mikefarah/yq
     local AVAILABLE_YQ
     AVAILABLE_YQ=$(curl -H "${GH_HEADER:-}" -s "https://api.github.com/repos/mikefarah/yq/releases/latest" | grep -Po '"tag_name": "[Vv]?\K.*?(?=")')
     local INSTALLED_YQ

--- a/scripts/setup_docker_group.sh
+++ b/scripts/setup_docker_group.sh
@@ -3,9 +3,25 @@ set -euo pipefail
 IFS=$'\n\t'
 
 setup_docker_group() {
-    # # https://docs.docker.com/install/linux/linux-postinstall/
-    info "Creating docker group."
-    groupadd docker > /dev/null 2>&1 || true
-    info "Adding ${DETECTED_UNAME} to docker group."
-    usermod -aG docker "${DETECTED_UNAME}" > /dev/null 2>&1 || true
+    # https://docs.docker.com/install/linux/linux-postinstall/
+    # https://github.com/jenkinsci/docker/issues/196#issuecomment-179486312
+    local DOCKER_SOCKET=/var/run/docker.sock
+    local DOCKER_GROUP=docker
+
+    if [[ -S ${DOCKER_SOCKET} ]]; then
+        DOCKER_GID=$(stat -c '%g' ${DOCKER_SOCKET})
+        info "Creating ${DOCKER_GROUP} group."
+        groupadd -for -g "${DOCKER_GID}" "${DOCKER_GROUP}" > /dev/null 2>&1 || fatal "Could not create ${DOCKER_GROUP} group."
+        if [[ ${CI:-} == true ]] && [[ ${TRAVIS:-} == true ]]; then
+            info "Skipping usermod on Travis."
+        else
+            info "Adding ${DETECTED_UNAME} to ${DOCKER_GROUP} group."
+            usermod -aG "${DOCKER_GROUP}" "${DETECTED_UNAME}" > /dev/null 2>&1 || fatal "Could not add ${DETECTED_UNAME} to ${DOCKER_GROUP} group."
+        fi
+        info "Setting DOCKERGID to ${DOCKER_GID} in ${SCRIPTPATH}/compose/.env file."
+        run_script 'env_create'
+        run_script 'env_set' "DOCKERGID" "${DOCKER_GID}"
+    else
+        fatal "Docker is not installed correctly. Please retry the installation."
+    fi
 }


### PR DESCRIPTION
## Purpose
Netdata uses the docker group ID rather than the detected user group ID. We need a safe way to detect this and set it so it can be used in yml files as an environment variable.

## Approach
- Add a new .env var `DOCKERGID`
- Change `setup_docker_group` to handle creating the group differently and set the new variable

#### Learning
https://github.com/jenkinsci/docker/issues/196#issuecomment-179486312

## Requirements
- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
