### PR TITLE
Add netdata config volume

### DIFF
--- a/compose/.apps/netdata/netdata.yml
+++ b/compose/.apps/netdata/netdata.yml
@@ -11,6 +11,7 @@ services:
       - /proc:/host/proc:ro
       - /sys:/host/sys:ro
       - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ${DOCKERCONFDIR}/netdata:/etc/netdata
       - ${DOCKERSHAREDDIR}:/shared
     cap_add:
       - SYS_PTRACE


### PR DESCRIPTION
## Purpose
Netdata will work with a config directory volume to `/etc/netdata`

## Approach
Add the volume.

#### Learning
https://github.com/firehol/netdata/issues/4125#issuecomment-422157585

## Requirements
- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
