### PR TITLE
Display a warning on Travis builds from remote branches

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -35,7 +35,7 @@ readonly ENDCOLOR='\e[0m'
 
 # Log Functions
 readonly LOG_FILE="/tmp/dockstarter.log"
-sudo chown -R "${DETECTED_PUID}":"${DETECTED_PGID}" "${LOG_FILE}" || true # This is the only line that should always use sudo
+sudo chown -R "${DETECTED_PUID:-$DETECTED_UNAME}":"${DETECTED_PGID:-$DETECTED_UGROUP}" "${LOG_FILE}" > /dev/null 2>&1 || true # This line should always use sudo
 info()    { echo -e "$(date +"%F %T") ${BLU}[INFO]${ENDCOLOR}       $*" | tee -a "${LOG_FILE}" >&2 ; }
 warning() { echo -e "$(date +"%F %T") ${YLW}[WARNING]${ENDCOLOR}    $*" | tee -a "${LOG_FILE}" >&2 ; }
 error()   { echo -e "$(date +"%F %T") ${RED}[ERROR]${ENDCOLOR}      $*" | tee -a "${LOG_FILE}" >&2 ; }
@@ -124,6 +124,9 @@ run_test() {
 # Cleanup Function
 cleanup() {
     chmod +x "${SCRIPTNAME}" > /dev/null 2>&1 || fatal "ds must be executable."
+    if [[ ${CI:-} == true ]] && [[ ${TRAVIS:-} == true ]] && [[ ${TRAVIS_SECURE_ENV_VARS} == false ]]; then
+        warning "TRAVIS_SECURE_ENV_VARS is false for Pull Requests from remote branches. Please retry failed builds!"
+    fi
 }
 trap cleanup ERR EXIT INT QUIT TERM
 

--- a/scripts/set_permissions.sh
+++ b/scripts/set_permissions.sh
@@ -15,7 +15,7 @@ set_permissions() {
         CH_PGID=${DETECTED_UGROUP}
     fi
     info "Taking ownership of ${CH_PATH} for user ${CH_PUID} and group ${CH_PGID}"
-    chown -R "${CH_PUID}":"${CH_PGID}" "${CH_PATH}"
+    chown -R "${CH_PUID}":"${CH_PGID}" "${CH_PATH}" > /dev/null 2>&1 || true
     info "Setting file and folder permissions in ${CH_PATH}"
     chmod -R a=,a+rX,u+w,g+w "${CH_PATH}" > /dev/null 2>&1 || true
     chmod +x "${SCRIPTNAME}" > /dev/null 2>&1 || fatal "ds must be executable."

--- a/scripts/update_system.sh
+++ b/scripts/update_system.sh
@@ -4,13 +4,13 @@ IFS=$'\n\t'
 
 update_system() {
     if [[ -n "$(command -v apt-get)" ]]; then
-        info "APT package manager detectec."
+        info "APT package manager detected."
         run_script 'run_apt'
     elif [[ -n "$(command -v dnf)" ]]; then
-        info "DNF package manager detectec."
+        info "DNF package manager detected."
         run_script 'run_dnf'
     elif [[ -n "$(command -v yum)" ]]; then
-        info "YUM package manager detectec."
+        info "YUM package manager detected."
         run_script 'run_yum'
     else
         fatal "Package manager not detected!"


### PR DESCRIPTION
## Purpose
Travis should display a warning when a PR from a remote branch runs. The only time anyone will bother looking to see this warning is if the build fails, which can be caused by lack of GH tokens and the build might just need to rerun.

## Approach
Add a warning message on clean up if we're running in travis without the secure vars (GH token). Also fixes some minor spelling errors.

## Requirements
- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
