### PR TITLE
Remove runfile before attempting to create it

### DIFF
--- a/scripts/generate_yml.sh
+++ b/scripts/generate_yml.sh
@@ -6,6 +6,7 @@ generate_yml() {
     info "Generating docker-compose.yml file."
     local RUNFILE
     RUNFILE="${SCRIPTPATH}/compose/docker-compose.sh"
+    rm -f "${RUNFILE}" || fatal "Could not remove ${RUNFILE} file."
     echo "#!/bin/bash" > "${RUNFILE}"
     {
         echo "yq m \\"
@@ -76,5 +77,5 @@ generate_yml() {
     run_script 'install_yq'
     bash "${RUNFILE}"
     info "Merging docker-compose.yml complete."
-    rm -f "${RUNFILE}"
+    rm -f "${RUNFILE}" || error "Could not remove ${RUNFILE} file."
 }


### PR DESCRIPTION
## Purpose
`compose/docker-compose.sh` is leftover for some users occasionally with no warning. We should at least warn the user if the file is not removed.

## Approach
Attempt to remove the file before creating it and include a fatal if it fails. Add an error (no exit) to the attempt at removing it after it's been run.

## Requirements
- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
