### PR TITLE
Aircdpp port

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,18 +5,24 @@ group: travis_latest
 jobs:
   include:
   - stage: validate
+    env:
+      - TEST=validate
     script:
     - sudo bash ./main.sh -t validate_newline
     - sudo bash ./main.sh -t validate_bashate
     - sudo bash ./main.sh -t validate_shellcheck
   - stage: run
-    script: sudo bash ./main.sh -t run_install
+    env: TEST=run_install
+    script: sudo bash ./main.sh -t ${TEST}
   - stage: run
-    script: sudo bash ./main.sh -t run_generate_slim
+    env: TEST=run_generate_slim
+    script: sudo bash ./main.sh -t ${TEST}
   - stage: run
-    script: sudo bash ./main.sh -t run_generate_full
+    env: TEST=run_generate_full
+    script: sudo bash ./main.sh -t ${TEST}
 matrix:
   fast_finish: true
   allow_failures:
   - stage: run
-    script: sudo bash ./main.sh -t run_generate_full
+    env: TEST=run_generate_full
+    script: sudo bash ./main.sh -t ${TEST}

--- a/compose/.apps/airdcpp/airdcpp.ports.yml
+++ b/compose/.apps/airdcpp/airdcpp.ports.yml
@@ -2,7 +2,7 @@ services:
   airdcpp:
     ports:
       - "${AIRDCPP_PORT_21248}:21248"
-      - "${AIRDCPP_PORT_21248}:21248/utp"
+      - "${AIRDCPP_PORT_21248}:21248/udp"
       - "${AIRDCPP_PORT_21249}:21249"
       - "${AIRDCPP_PORT_5600}:5600"
       - "${AIRDCPP_PORT_5601}:5601"

--- a/main.sh
+++ b/main.sh
@@ -130,7 +130,7 @@ cleanup() {
         warning "TRAVIS_SECURE_ENV_VARS is false for Pull Requests from remote branches. Please retry failed builds!"
     fi
 }
-trap cleanup ERR EXIT INT QUIT TERM
+trap 'cleanup' 0 1 2 3 6 14 15
 
 # Main Function
 main() {
@@ -138,10 +138,10 @@ main() {
         warning "Attempting to clone DockSTARTer repo to ${DETECTED_HOMEDIR}/.docker location."
         git clone https://github.com/GhostWriters/DockSTARTer "${DETECTED_HOMEDIR}/.docker" || fatal "Could not clone DockSTARTer repo to ${DETECTED_HOMEDIR}/.docker location."
     fi
-    if [[ ${SCRIPTPATH} != "${DETECTED_HOMEDIR}/.docker" ]]; then
+    if [[ ${CI:-} != true ]] && [[ ${TRAVIS:-} != true ]] && [[ ${SCRIPTPATH} != "${DETECTED_HOMEDIR}/.docker" ]]; then
         warning "Attempting to run DockSTARTer from ${DETECTED_HOMEDIR}/.docker location."
         (sudo bash "${DETECTED_HOMEDIR}/.docker/main.sh" "${ARGS[@]:-}") || true
-        exit 0
+        exit
     fi
     run_script 'root_check'
     run_script 'symlink_ds'

--- a/scripts/cmdline.sh
+++ b/scripts/cmdline.sh
@@ -33,31 +33,31 @@ cmdline() {
         case ${OPTION} in
             b)
                 run_script 'env_backup'
-                exit 0
+                exit
                 ;;
             e)
                 run_script 'env_update'
-                exit 0
+                exit
                 ;;
             g)
                 run_script 'cmd_generate'
-                exit 0
+                exit
                 ;;
             i)
                 run_script 'cmd_install'
-                exit 0
+                exit
                 ;;
             p)
                 run_script 'prune_docker'
-                exit 0
+                exit
                 ;;
             t)
                 run_test "${OPTARG}"
-                exit 0
+                exit
                 ;;
             u)
                 run_script 'update_self'
-                exit 0
+                exit
                 ;;
             v)
                 readonly VERBOSE=1
@@ -68,7 +68,7 @@ cmdline() {
                 ;;
             *)
                 usage
-                exit 0
+                exit
                 ;;
         esac
     done

--- a/scripts/env_create.sh
+++ b/scripts/env_create.sh
@@ -24,7 +24,7 @@ env_create() {
             case ${YN} in
                 [Yy]* )
                     info "Please edit ${SCRIPTPATH}/compose/.env and rerun the script."
-                    exit 0
+                    exit
                     ;;
                 [Nn]* )
                     warning "Defaults from ${SCRIPTPATH}/compose/.env.example will be used."

--- a/tests/run_generate_full.sh
+++ b/tests/run_generate_full.sh
@@ -3,7 +3,6 @@ set -euo pipefail
 IFS=$'\n\t'
 
 run_generate_full() {
-    #run_script 'update_system'
     run_script 'env_update'
     info "Enabling all apps."
     sed -i 's/_ENABLED=false/_ENABLED=true/' "${SCRIPTPATH}/compose/.env"


### PR DESCRIPTION
## Purpose
Fix AirDCpp port and Travis buids and exit codes.

## Approach
- Fix spelling error with AirDCpp
- Adjust Travis builds to include an env var showing which test they are running
- Fix how exit codes are handled so that Travis builds actually fail
- Ensure that Travis is NOT pulling the master branch for each test

## Requirements
- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
