### PR TITLE
 expose communication ports to docker containers

### DIFF
--- a/compose/.apps/airdcpp/airdcpp.ports.yml
+++ b/compose/.apps/airdcpp/airdcpp.ports.yml
@@ -6,3 +6,6 @@ services:
       - "${AIRDCPP_PORT_21249}:21249"
       - "${AIRDCPP_PORT_5600}:5600"
       - "${AIRDCPP_PORT_5601}:5601"
+    expose:
+      - ${AIRDCPP_PORT_5600}
+      - ${AIRDCPP_PORT_5601}

--- a/compose/.apps/airsonic/airsonic.ports.yml
+++ b/compose/.apps/airsonic/airsonic.ports.yml
@@ -2,3 +2,5 @@ services:
   airsonic:
     ports:
       - "${AIRSONIC_PORT_4040}:4040"
+    expose:
+      - ${COUCHPOTATO_PORT_5050}

--- a/compose/.apps/bazarr/bazarr.ports.yml
+++ b/compose/.apps/bazarr/bazarr.ports.yml
@@ -2,3 +2,5 @@ services:
   bazarr:
     ports:
       - "${BAZARR_PORT_6767}:6767"
+    expose:
+      - ${BAZARR_PORT_6767}

--- a/compose/.apps/calibreweb/calibreweb.ports.yml
+++ b/compose/.apps/calibreweb/calibreweb.ports.yml
@@ -2,3 +2,5 @@ services:
   calibreweb:
     ports:
       - "${CALIBREWEB_PORT_8083}:8083"
+    expose:
+      - ${CALIBREWEB_PORT_8083}

--- a/compose/.apps/couchpotato/couchpotato.ports.yml
+++ b/compose/.apps/couchpotato/couchpotato.ports.yml
@@ -2,3 +2,5 @@ services:
   couchpotato:
     ports:
       - "${COUCHPOTATO_PORT_5050}:5050"
+    expose:
+      - ${COUCHPOTATO_PORT_5050}

--- a/compose/.apps/deluge/deluge.ports.yml
+++ b/compose/.apps/deluge/deluge.ports.yml
@@ -4,3 +4,5 @@ services:
       - "${DELUGE_PORT_58846}:58846"
       - "${DELUGE_PORT_58946}:58946"
       - "${DELUGE_PORT_8112}:8112"
+    expose:
+      - ${DELUGE_PORT_8112}

--- a/compose/.apps/delugevpn/delugevpn.ports.yml
+++ b/compose/.apps/delugevpn/delugevpn.ports.yml
@@ -4,3 +4,5 @@ services:
       - "${DELUGEVPN_PORT_58846}:58846"
       - "${DELUGEVPN_PORT_58946}:58946"
       - "${DELUGEVPN_PORT_8112}:8112"
+    expose:
+      - ${DELUGEVPN_PORT_8112}

--- a/compose/.apps/duplicati/duplicati.ports.yml
+++ b/compose/.apps/duplicati/duplicati.ports.yml
@@ -2,3 +2,5 @@ services:
   duplicati:
     ports:
       - "${DUPLICATI_PORT_8200}:8200"
+    expose: 
+      - ${DUPLICATI_PORT_8200}

--- a/compose/.apps/emby/emby.ports.yml
+++ b/compose/.apps/emby/emby.ports.yml
@@ -3,3 +3,5 @@ services:
     ports:
       - "${EMBY_PORT_8096}:8096"
       - "${EMBY_PORT_8920}:8920"
+    expose:
+      - ${EMBY_PORT_8096}

--- a/compose/.apps/glances/glances.ports.yml
+++ b/compose/.apps/glances/glances.ports.yml
@@ -3,3 +3,6 @@ services:
     ports:
       - "${GLANCES_PORT_61208}:61208"
       - "${GLANCES_PORT_61209}:61209"
+    expose:
+      - ${GLANCES_PORT_61208}
+      - ${GLANCES_PORT_61209}

--- a/compose/.apps/guacamole/guacamole.ports.yml
+++ b/compose/.apps/guacamole/guacamole.ports.yml
@@ -2,3 +2,5 @@ services:
   guacamole:
     ports:
       - "${GUACAMOLE_PORT_8080}:8080"
+    expose:
+      - ${GUACAMOLE_PORT_8080}

--- a/compose/.apps/headphones/headphones.ports.yml
+++ b/compose/.apps/headphones/headphones.ports.yml
@@ -2,3 +2,5 @@ services:
   headphones:
     ports:
       - "${HEADPHONES_PORT_8181}:8181"
+    expose:
+      - ${HEADPHONES_PORT_8181}

--- a/compose/.apps/heimdall/heimdall.ports.yml
+++ b/compose/.apps/heimdall/heimdall.ports.yml
@@ -3,3 +3,6 @@ services:
     ports:
       - "${HEIMDALL_PORT_443}:443"
       - "${HEIMDALL_PORT_80}:80"
+    expose:
+      - ${HEIMDALL_PORT_80}
+      - ${HEIMDALL_PORT_443}

--- a/compose/.apps/homeassistant/homeassistant.ports.yml
+++ b/compose/.apps/homeassistant/homeassistant.ports.yml
@@ -2,3 +2,5 @@ services:
   homeassistant:
     ports:
       - "${HOMEASSISTANT_PORT_8123}:8123"
+    expose:
+      - ${HOMEASSISTANT_PORT_8123}

--- a/compose/.apps/htpcmanager/htpcmanager.ports.yml
+++ b/compose/.apps/htpcmanager/htpcmanager.ports.yml
@@ -2,3 +2,5 @@ services:
   htpcmanager:
     ports:
       - "${HTPCMANAGER_PORT_8085}:8085"
+    expose:
+      - ${HTPCMANAGER_PORT_8085}

--- a/compose/.apps/hydra2/hydra2.ports.yml
+++ b/compose/.apps/hydra2/hydra2.ports.yml
@@ -2,3 +2,5 @@ services:
   hydra2:
     ports:
       - "${HYDRA2_PORT_5076}:5076"
+    expose:
+      - ${HYDRA2_PORT_5076}

--- a/compose/.apps/lazylibrarian/lazylibrarian.ports.yml
+++ b/compose/.apps/lazylibrarian/lazylibrarian.ports.yml
@@ -2,3 +2,5 @@ services:
   lazylibrarian:
     ports:
       - "${LAZYLIBRARIAN_PORT_5299}:5299"
+    expose:
+      - ${LAZYLIBRARIAN_PORT_5299}

--- a/compose/.apps/letsencrypt/letsencrypt.ports.yml
+++ b/compose/.apps/letsencrypt/letsencrypt.ports.yml
@@ -3,3 +3,6 @@ services:
     ports:
       - "${LETSENCRYPT_PORT_443}:443"
       - "${LETSENCRYPT_PORT_80}:80"
+    expose:
+      - "${LETSENCRYPT_PORT_443}:443"
+      - "${LETSENCRYPT_PORT_80}:80"

--- a/compose/.apps/lidarr/lidarr.ports.yml
+++ b/compose/.apps/lidarr/lidarr.ports.yml
@@ -2,3 +2,5 @@ services:
   lidarr:
     ports:
       - "${LIDARR_PORT_8686}:8686"
+    expose:
+      - ${LIDARR_PORT_8686}

--- a/compose/.apps/logarr/logarr.ports.yml
+++ b/compose/.apps/logarr/logarr.ports.yml
@@ -2,3 +2,5 @@ services:
   logarr:
     ports:
       - "${LOGARR_PORT_80}:80"
+    expose:
+      - ${LOGARR_PORT_80}

--- a/compose/.apps/mariadb/mariadb.ports.yml
+++ b/compose/.apps/mariadb/mariadb.ports.yml
@@ -2,3 +2,5 @@ services:
   mariadb:
     ports:
       - "${MARIADB_PORT_3306}:3306"
+    expose:
+      - ${MARIADB_PORT_3306}

--- a/compose/.apps/mcmyadmin2/mcmyadmin2.ports.yml
+++ b/compose/.apps/mcmyadmin2/mcmyadmin2.ports.yml
@@ -3,3 +3,5 @@ services:
     ports:
       - "${MCMYADMIN2_PORT_25565}:25565"
       - "${MCMYADMIN2_PORT_8080}:8080"
+    expose:
+      - ${MCMYADMIN2_PORT_8080}

--- a/compose/.apps/medusa/medusa.ports.yml
+++ b/compose/.apps/medusa/medusa.ports.yml
@@ -2,3 +2,5 @@ services:
   medusa:
     ports:
       - "${MEDUSA_PORT_8081}:8081"
+    expose:
+      - ${MEDUSA_PORT_8081}

--- a/compose/.apps/monitorr/monitorr.ports.yml
+++ b/compose/.apps/monitorr/monitorr.ports.yml
@@ -2,3 +2,5 @@ services:
   monitorr:
     ports:
       - "${MONITORR_PORT_80}:80"
+    expose:
+      - ${MONITORR_PORT_80}

--- a/compose/.apps/mylar/mylar.ports.yml
+++ b/compose/.apps/mylar/mylar.ports.yml
@@ -2,3 +2,5 @@ services:
   mylar:
     ports:
       - "${MYLAR_PORT_8090}:8090"
+    expose:
+      - ${MYLAR_PORT_8090}

--- a/compose/.apps/nextcloud/nextcloud.ports.yml
+++ b/compose/.apps/nextcloud/nextcloud.ports.yml
@@ -2,3 +2,5 @@ services:
   nextcloud:
     ports:
       - "${NEXTCLOUD_PORT_443}:443"
+    expose:
+      - ${NEXTCLOUD_PORT_443}

--- a/compose/.apps/nzbget/nzbget.ports.yml
+++ b/compose/.apps/nzbget/nzbget.ports.yml
@@ -2,3 +2,5 @@ services:
   nzbget:
     ports:
       - "${NZBGET_PORT_6789}:6789"
+    expose:
+      - ${NZBGET_PORT_6789}

--- a/compose/.apps/ombi/ombi.ports.yml
+++ b/compose/.apps/ombi/ombi.ports.yml
@@ -2,3 +2,5 @@ services:
   ombi:
     ports:
       - "${OMBI_PORT_3579}:3579"
+    expose:
+      - ${OMBI_PORT_3579}

--- a/compose/.apps/organizr/organizr.ports.yml
+++ b/compose/.apps/organizr/organizr.ports.yml
@@ -2,3 +2,5 @@ services:
   organizr:
     ports:
       - "${ORGANIZR_PORT_80}:80"
+    expose:
+      - ${ORGANIZR_PORT_80}

--- a/compose/.apps/phpmyadmin/phpmyadmin.ports.yml
+++ b/compose/.apps/phpmyadmin/phpmyadmin.ports.yml
@@ -2,3 +2,5 @@ services:
   phpmyadmin:
     ports:
       - "${PHPMYADMIN_PORT_80}:80"
+    expose:
+      - ${PHPMYADMIN_PORT_80}

--- a/compose/.apps/pihole/pihole.ports.yml
+++ b/compose/.apps/pihole/pihole.ports.yml
@@ -6,3 +6,6 @@ services:
       - "${PIHOLE_PORT_53}:53/udp"
       - "${PIHOLE_PORT_67}:67/udp"
       - "${PIHOLE_PORT_80}:80"
+    expose:
+      - ${PIHOLE_PORT_80}
+      - ${PIHOLE_PORT_443}

--- a/compose/.apps/plex/plex.ports.yml
+++ b/compose/.apps/plex/plex.ports.yml
@@ -12,3 +12,5 @@ services:
       - "${PLEX_PORT_33400}:33400"
       - "${PLEX_PORT_5353}:5353/udp"
       - "${PLEX_PORT_8324}:8324/tcp"
+    expose:
+      - ${PLEX_PORT_32400}

--- a/compose/.apps/plexrequests/plexrequests.ports.yml
+++ b/compose/.apps/plexrequests/plexrequests.ports.yml
@@ -2,3 +2,5 @@ services:
   plexrequests:
     ports:
       - "${PLEXREQUESTS_PORT_3000}:3000"
+    expose:
+      - ${PLEXREQUESTS_PORT_3000}

--- a/compose/.apps/portainer/portainer.ports.yml
+++ b/compose/.apps/portainer/portainer.ports.yml
@@ -2,3 +2,5 @@ services:
   portainer:
     ports:
       - "${PORTAINER_PORT_9000}:9000"
+    expose:
+      - ${PORTAINER_PORT_9000}

--- a/compose/.apps/portaineragent/portaineragent.ports.yml
+++ b/compose/.apps/portaineragent/portaineragent.ports.yml
@@ -2,3 +2,5 @@ services:
   portaineragent:
     ports:
       - "${PORTAINERAGENT_PORT_9001}:9001"
+    expose:
+      - ${PORTAINERAGENT_PORT_9001}

--- a/compose/.apps/qbittorrent/qbittorrent.ports.yml
+++ b/compose/.apps/qbittorrent/qbittorrent.ports.yml
@@ -3,3 +3,5 @@ services:
     ports:
       - "${QBITTORRENT_PORT_6881}:6881"
       - "${QBITTORRENT_PORT_8080}:8080"
+    expose:
+      - ${QBITTORRENT_PORT_8080}

--- a/compose/.apps/radarr/radarr.ports.yml
+++ b/compose/.apps/radarr/radarr.ports.yml
@@ -2,3 +2,5 @@ services:
   radarr:
     ports:
       - "${RADARR_PORT_7878}:7878"
+    expose:
+      - ${RADARR_PORT_7878}

--- a/compose/.apps/rtorrentvpn/rtorrentvpn.ports.yml
+++ b/compose/.apps/rtorrentvpn/rtorrentvpn.ports.yml
@@ -4,3 +4,5 @@ services:
       - "${RTORRENTVPN_PORT_3000}:3000"
       - "${RTORRENTVPN_PORT_9080}:9080"
       - "${RTORRENTVPN_PORT_9443}:9443"
+    expose:
+      - ${RTORRENTVPN_PORT_3000}

--- a/compose/.apps/rutorrent/rutorrent.ports.yml
+++ b/compose/.apps/rutorrent/rutorrent.ports.yml
@@ -5,3 +5,6 @@ services:
       - "${RUTORRENT_PORT_51413}:51413"
       - "${RUTORRENT_PORT_6881}:6881/udp"
       - "${RUTORRENT_PORT_80}:80"
+    expose:
+      - ${RUTORRENT_PORT_5000}
+      - ${RUTORRENT_PORT_80}

--- a/compose/.apps/sabnzbd/sabnzbd.ports.yml
+++ b/compose/.apps/sabnzbd/sabnzbd.ports.yml
@@ -2,3 +2,5 @@ services:
   sabnzbd:
     ports:
       - "${SABNZBD_PORT_8080}:8080"
+    expose:
+      - ${SABNZBD_PORT_8080}

--- a/compose/.apps/sabnzbdvpn/sabnzbdvpn.ports.yml
+++ b/compose/.apps/sabnzbdvpn/sabnzbdvpn.ports.yml
@@ -3,3 +3,5 @@ services:
     ports:
       - "${SABNZBDVPN_PORT_8080}:8080"
       - "${SABNZBDVPN_PORT_8090}:8090"
+    expose:
+      - ${SABNZBDVPN_PORT_8080}

--- a/compose/.apps/sickrage/sickrage.ports.yml
+++ b/compose/.apps/sickrage/sickrage.ports.yml
@@ -2,3 +2,5 @@ services:
   sickrage:
     ports:
       - "${SICKRAGE_PORT_8081}:8081"
+    expose:
+      - ${SICKRAGE_PORT_8081}

--- a/compose/.apps/sonarr/sonarr.ports.yml
+++ b/compose/.apps/sonarr/sonarr.ports.yml
@@ -2,3 +2,5 @@ services:
   sonarr:
     ports:
       - "${SONARR_PORT_8989}:8989"
+    expose:
+      - ${SONARR_PORT_8989}

--- a/compose/.apps/syncthing/syncthing.ports.yml
+++ b/compose/.apps/syncthing/syncthing.ports.yml
@@ -4,3 +4,5 @@ services:
       - "${SYNCTHING_PORT_21027}:21027/udp"
       - "${SYNCTHING_PORT_22000}:22000"
       - "${SYNCTHING_PORT_8384}:8384"
+    expose:
+      - ${SYNCTHING_PORT_8384}

--- a/compose/.apps/tautulli/tautulli.ports.yml
+++ b/compose/.apps/tautulli/tautulli.ports.yml
@@ -2,3 +2,5 @@ services:
   tautulli:
     ports:
       - "${TAUTULLI_PORT_8181}:8181"
+    expose:
+      - ${TAUTULLI_PORT_8181}

--- a/compose/.apps/thelounge/thelounge.ports.yml
+++ b/compose/.apps/thelounge/thelounge.ports.yml
@@ -2,3 +2,5 @@ services:
   thelounge:
     ports:
       - "${THELOUNGE_PORT_9000}:9000"
+    expose:
+      - ${THELOUNGE_PORT_9000}

--- a/compose/.apps/transmission/transmission.ports.yml
+++ b/compose/.apps/transmission/transmission.ports.yml
@@ -3,3 +3,5 @@ services:
     ports:
       - "${TRANSMISSION_PORT_51413}:51413"
       - "${TRANSMISSION_PORT_9091}:9091"
+    expose:
+      - ${TRANSMISSION_PORT_9091}

--- a/compose/.apps/transmissionvpn/transmissionvpn.ports.yml
+++ b/compose/.apps/transmissionvpn/transmissionvpn.ports.yml
@@ -2,3 +2,5 @@ services:
   transmissionvpn:
     ports:
       - "${TRANSMISSIONVPN_PORT_9091}:9091"
+    expose:
+      - ${TRANSMISSIONVPN_PORT_9091}

--- a/compose/.apps/ubooquity/ubooquity.ports.yml
+++ b/compose/.apps/ubooquity/ubooquity.ports.yml
@@ -3,3 +3,6 @@ services:
     ports:
       - "${UBOOQUITY_PORT_2202}:2202"
       - "${UBOOQUITY_PORT_2203}:2203"
+    expose:
+      - ${UBOOQUITY_PORT_2202}
+      - ${UBOOQUITY_PORT_2202}

--- a/compose/.apps/unifi/unifi.ports.yml
+++ b/compose/.apps/unifi/unifi.ports.yml
@@ -10,3 +10,5 @@ services:
       - "${UNIFI_PORT_8443}:8443"
       - "${UNIFI_PORT_8843}:8843"
       - "${UNIFI_PORT_8880}:8880"
+    expose:
+      - ${UNIFI_PORT_8080}


### PR DESCRIPTION
## Purpose
Expose allows other docker containers to  access other docker containers.
Although this isn't required when using port, if you we're using traefik,  you won't need to publish ports to the host! This may be useful for https://github.com/aschzero/hera too

## Approach
_How does this change address the problem?_
Adds expose as a way to document the primary inner communication ports.

#### Open Questions and Pre-Merge TODOs
- [ ] how to disable ports with override?
- [ ] Should these be appname.expose.yml instead of being in ports?

#### Learning
https://medium.freecodecamp.org/expose-vs-publish-docker-port-commands-explained-simply-434593dbc9a3

## Requirements
- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
