### PR TITLE
Switch Heimdall to LSIO Multi-Arch

### DIFF
--- a/compose/.apps/heimdall/heimdall.arm64.yml
+++ b/compose/.apps/heimdall/heimdall.arm64.yml
@@ -1,3 +1,3 @@
 services:
   heimdall:
-    image:   lsioarmhf/heimdall-aarch64
+    image:   linuxserver/heimdall

--- a/compose/.apps/heimdall/heimdall.armhf.yml
+++ b/compose/.apps/heimdall/heimdall.armhf.yml
@@ -1,3 +1,3 @@
 services:
   heimdall:
-    image:   lsioarmhf/heimdall
+    image:   linuxserver/heimdall


### PR DESCRIPTION
## Purpose
Use the new multi-arch images just released by LSIO for Heimdall.

## Approach
Set all of the arch yml files to use the same image.

#### Learning
https://github.com/linuxserver/docker-heimdall/pull/9

## Requirements
- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
