### PR TITLE
Cleanup old .env backups

### DIFF
--- a/scripts/env_backup.sh
+++ b/scripts/env_backup.sh
@@ -11,6 +11,8 @@ env_backup() {
         info "${SCRIPTPATH}/compose/.env found. Copying to ${SCRIPTPATH}/compose/.env.backups/.env.${BACKUPTIME}"
         mkdir -p "${SCRIPTPATH}/compose/.env.backups" || fatal "${SCRIPTPATH}/compose/.env.backups folder could not be created."
         cp "${SCRIPTPATH}/compose/.env" "${SCRIPTPATH}/compose/.env.backups/.env.${BACKUPTIME}" || fatal "${SCRIPTPATH}/compose/.env.backups/.env.${BACKUPTIME} could not be copied."
+        info "Removing old .env backups."
+        find "${SCRIPTPATH}/compose/.env.backups/.env.*" -mtime +21 -type f -delete || error "Failed to remove old .env backups."
         local PUID
         PUID=$(run_script 'env_get' PUID)
         local PGID


### PR DESCRIPTION
## Purpose
This closes #286 
The .env backups would eventually take up a lot of space. DS should clean up the folder.

## Approach
This removes backups that haven't been modified in the past 21 days using the file modified attribute. We don't use the date in the file name, which represents the creation date. There could be any number of backups left based on how often and when the user created the backups.

## Requirements
- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
