### PR TITLE
Fix port conflict in full tests

### DIFF
--- a/tests/run_generate_full.sh
+++ b/tests/run_generate_full.sh
@@ -13,7 +13,7 @@ run_generate_full() {
     run_script 'env_set' "GUACAMOLE_PORT_8080" "48080"
     run_script 'env_set' "HEADPHONES_PORT_8181" "18181"
     run_script 'env_set' "MARIADB_PORT_3306" "13306"
-    run_script 'env_set' "MCMYADMIN2_PORT_8080" "48080"
+    run_script 'env_set' "MCMYADMIN2_PORT_8080" "58080"
     run_script 'env_set' "MEDUSA_PORT_8081" "18081"
     run_script 'env_set' "MYLAR_PORT_8090" "18090"
     run_script 'env_set' "PLEXREQUESTS_PORT_3000" "13000"


### PR DESCRIPTION
## Purpose
Fix port conflict in full generator tests.

## Approach
Change port for mcmyadmin2

#### Learning
These two apps were added to DS in two separate branches at the same time, both were passing full builds in their own branches. When merging to master I must have overlooked the port conflict since they worked in their individual branches.

## Requirements
- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
