### PR TITLE
Fix tilde match

### DIFF
--- a/scripts/menu_value_prompt.sh
+++ b/scripts/menu_value_prompt.sh
@@ -181,7 +181,7 @@ menu_value_prompt() {
                 if [[ ${INPUT} == "/" ]]; then
                     whiptail --fb --clear --title "DockSTARTer" --msgbox "Cannot use / for ${SET_VAR}. Please select another folder." 0 0
                     menu_value_prompt "${SET_VAR}"
-                elif [[ ${INPUT} == "~*" ]]; then
+                elif [[ ${INPUT} == ~* ]]; then
                     local CORRECTED_DIR
                     CORRECTED_DIR="${DETECTED_HOMEDIR}${INPUT/*~/}"
                     local ANSWER


### PR DESCRIPTION
## Purpose
Fix tilde not matching.

## Approach
Unquote it.

#### Learning
https://stackoverflow.com/a/2172367/1384186
```
[[ $a == z* ]] # True if $a starts with a "z" (wildcard matching).
[[ $a == "z*" ]] # True if $a is equal to z* (literal matching).
 ```

## Requirements
- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
