### PR TITLE
Rework prompts for global and vpn vars

### DIFF
--- a/scripts/ui_config_globals.sh
+++ b/scripts/ui_config_globals.sh
@@ -3,15 +3,21 @@ set -euo pipefail
 IFS=$'\n\t'
 
 ui_config_globals() {
-    run_script 'menu_value_prompt' TZ || return 1
-    run_script 'menu_value_prompt' PUID || return 1
-    run_script 'menu_value_prompt' PGID || return 1
-    run_script 'menu_value_prompt' DOCKERCONFDIR || return 1
-    run_script 'menu_value_prompt' DOCKERSHAREDDIR || return 1
-    run_script 'menu_value_prompt' DOWNLOADSDIR || return 1
-    run_script 'menu_value_prompt' MEDIADIR_BOOKS || return 1
-    run_script 'menu_value_prompt' MEDIADIR_COMICS || return 1
-    run_script 'menu_value_prompt' MEDIADIR_MOVIES || return 1
-    run_script 'menu_value_prompt' MEDIADIR_MUSIC || return 1
-    run_script 'menu_value_prompt' MEDIADIR_TV || return 1
+    local APPNAME
+    APPNAME="Globals"
+    local VARNAMES
+    VARNAMES=(TZ PUID PGID DOCKERCONFDIR DOWNLOADSDIR MEDIADIR_BOOKS MEDIADIR_COMICS MEDIADIR_MOVIES MEDIADIR_MUSIC MEDIADIR_TV DOCKERSHAREDDIR)
+    local APPVARS
+    APPVARS=$(for v in "${VARNAMES[@]}"; do echo "${v}=$(run_script 'env_get' "${v}")"; done)
+
+    local ANSWER
+    set +e
+    ANSWER=$(whiptail --fb --clear --title "DockSTARTer" --defaultno --yesno "Would you like to keep these settings for ${APPNAME}?\\n\\n${APPVARS}" 0 0 3>&1 1>&2 2>&3; echo $?)
+    set -e
+    if [[ ${ANSWER} != 0 ]]; then
+        while IFS= read -r line; do
+            SET_VAR=${line/=*/}
+            run_script 'menu_value_prompt' "${SET_VAR}" || return 1
+        done < <(echo "${APPVARS}")
+    fi
 }

--- a/scripts/ui_config_vpn.sh
+++ b/scripts/ui_config_vpn.sh
@@ -3,12 +3,27 @@ set -euo pipefail
 IFS=$'\n\t'
 
 ui_config_vpn() {
-    run_script 'menu_value_prompt' LAN_NETWORK || return 1
-    run_script 'menu_value_prompt' NS1 || return 1
-    run_script 'menu_value_prompt' NS2 || return 1
-    run_script 'menu_value_prompt' VPN_ENABLE || return 1
-    run_script 'menu_value_prompt' VPN_OPTIONS || return 1
-    run_script 'menu_value_prompt' VPN_PASS || return 1
-    run_script 'menu_value_prompt' VPN_PROV || return 1
-    run_script 'menu_value_prompt' VPN_USER || return 1
+    local APPNAME
+    APPNAME="VPN"
+    local VARNAMES
+    VARNAMES=(LAN_NETWORK NS1 NS2 VPN_ENABLE VPN_USER VPN_PASS VPN_PROV VPN_OPTIONS)
+    local APPVARS
+    APPVARS=$(for v in "${VARNAMES[@]}"; do echo "${v}=$(run_script 'env_get' "${v}")"; done)
+
+    local ANSWER
+    if grep -q 'VPN_ENABLED=true$' "${SCRIPTPATH}/compose/.env"; then
+        set +e
+        ANSWER=$(whiptail --fb --clear --title "DockSTARTer" --defaultno --yesno "Would you like to keep these settings for ${APPNAME}?\\n\\n${APPVARS}" 0 0 3>&1 1>&2 2>&3; echo $?)
+        set -e
+    else
+        set +e
+        ANSWER=$(whiptail --fb --clear --title "DockSTARTer" --yesno "Would you like to keep these settings for ${APPNAME}?\\n\\n${APPVARS}" 0 0 3>&1 1>&2 2>&3; echo $?)
+        set -e
+    fi
+    if [[ ${ANSWER} != 0 ]]; then
+        while IFS= read -r line; do
+            SET_VAR=${line/=*/}
+            run_script 'menu_value_prompt' "${SET_VAR}" || return 1
+        done < <(echo "${APPVARS}")
+    fi
 }


### PR DESCRIPTION
## Purpose
Make the global and vpn vars show an overview screen like appears. Allow users to skip the whole section. Reorder a few prompts.

## Approach
- Write a routine to put together the overview screen
- Add some logic to default yes or no for VPN based on whether the user has VPN apps enabled (so that pressing enter for the default on first run takes users to the right place
- Default no to keep globals so that users will set those on their first run

## Requirements
- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
