### PR TITLE
Add keyboard instructions to app select menu

### DIFF
--- a/scripts/menu_app_select.sh
+++ b/scripts/menu_app_select.sh
@@ -217,7 +217,7 @@ menu_app_select() {
     done < <(grep '_ENABLED=' < "${SCRIPTPATH}/compose/.env")
 
     if [[ ${CI:-} != true ]] && [[ ${TRAVIS:-} != true ]]; then
-        SELECTEDAPPS=$(whiptail --fb --clear --title "DockSTARTer" --separate-output --checklist "Choose which apps you would like to install:" 0 0 0 "${APPLIST[@]}" 3>&1 1>&2 2>&3 || echo "Cancel")
+        SELECTEDAPPS=$(whiptail --fb --clear --title "DockSTARTer" --separate-output --checklist "Choose which apps you would like to install:\\n Use [up], [down], and [space] to select apps, and [tab] to switch to the buttons at the bottom." 0 0 0 "${APPLIST[@]}" 3>&1 1>&2 2>&3 || echo "Cancel")
         if [[ ${SELECTEDAPPS} == "Cancel" ]]; then
             return 1
         else


### PR DESCRIPTION
## Purpose
This closes #305

## Approach
Add some descriptive text to the app select menu about keys used to navigate.

## Requirements
- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
