### PR TITLE
New OrganizrTools repo

### DIFF
--- a/compose/.apps/organizr/organizr.armhf.yml
+++ b/compose/.apps/organizr/organizr.armhf.yml
@@ -1,3 +1,3 @@
 services:
   organizr:
-    image:   tronyx/docker-organizr-v2:armhf
+    image:   organizrtools/organizr-v2:armhf

--- a/compose/.apps/organizr/organizr.yml
+++ b/compose/.apps/organizr/organizr.yml
@@ -1,6 +1,6 @@
 services:
   organizr:
-    image:           tronyx/docker-organizr-v2:php-fpm
+    image:           organizrtools/organizr-v2:php-fpm
     container_name:  organizr
     restart:         unless-stopped
     environment:


### PR DESCRIPTION
## Purpose
The organizr team has released a new repo for the v2 docker image

## Approach
Replace the existing image with the new repo

#### Learning
https://hub.docker.com/r/organizrtools/organizr-v2/

## Requirements
- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
