### PR TITLE
Make PROMPT readonly

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -150,6 +150,7 @@ main() {
     # shellcheck source=scripts/cmdline.sh
     source "${SCRIPTPATH}/scripts/cmdline.sh"
     cmdline "${ARGS[@]:-}"
+    readonly PROMPT="menu"
     run_script 'menu_main'
 }
 main

--- a/scripts/env_backup.sh
+++ b/scripts/env_backup.sh
@@ -3,8 +3,6 @@ set -euo pipefail
 IFS=$'\n\t'
 
 env_backup() {
-    local PROMPT
-    PROMPT=${1:-}
     if [[ -f ${SCRIPTPATH}/compose/.env ]]; then
         local BACKUPTIME
         BACKUPTIME=$(date +"%Y%m%d%H%M%S")
@@ -19,6 +17,6 @@ env_backup() {
         PGID=$(run_script 'env_get' PGID)
         run_script 'set_permissions' "${SCRIPTPATH}" "${PUID}" "${PGID}"
     else
-        run_script 'env_create' "${PROMPT}"
+        run_script 'env_create'
     fi
 }

--- a/scripts/env_create.sh
+++ b/scripts/env_create.sh
@@ -3,20 +3,18 @@ set -euo pipefail
 IFS=$'\n\t'
 
 env_create() {
-    local PROMPT
-    PROMPT=${1:-}
     if [[ -f ${SCRIPTPATH}/compose/.env ]]; then
         info "${SCRIPTPATH}/compose/.env found."
     else
         warning "${SCRIPTPATH}/compose/.env not found. Copying example template."
         cp "${SCRIPTPATH}/compose/.env.example" "${SCRIPTPATH}/compose/.env" || fatal "${SCRIPTPATH}/compose/.env could not be copied."
         run_script 'set_permissions'
-        [[ ${PROMPT} != "menu" ]] && info "You should exit the script and edit ${SCRIPTPATH}/compose/.env before continuing. Exit now?"
+        [[ ${PROMPT:-} != "menu" ]] && info "You should exit the script and edit ${SCRIPTPATH}/compose/.env before continuing. Exit now?"
         local YN
         while true; do
             if [[ ${CI:-} == true ]] && [[ ${TRAVIS:-} == true ]]; then
                 YN=N
-            elif [[ ${PROMPT} == "menu" ]]; then
+            elif [[ ${PROMPT:-} == "menu" ]]; then
                 YN=N
             else
                 read -rp "[Yn]" YN

--- a/scripts/env_update.sh
+++ b/scripts/env_update.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 IFS=$'\n\t'
 
 env_update() {
-    run_script 'env_backup' menu
+    run_script 'env_backup'
     info "Locating newest .env file backup."
     local NEWEST_ENV
     for f in "${SCRIPTPATH}"/compose/.env.backups/.env.*; do

--- a/scripts/menu_config.sh
+++ b/scripts/menu_config.sh
@@ -16,26 +16,26 @@ menu_config() {
 
     case "${CONFIGCHOICE}" in
         "Full Setup ")
-            run_script 'env_update' menu
+            run_script 'env_update'
             run_script 'menu_app_select' || run_script 'menu_config'
             run_script 'ui_config_apps' || run_script 'menu_config'
             run_script 'ui_config_vpn' || run_script 'menu_config'
             run_script 'ui_config_globals' || run_script 'menu_config'
             ;;
         "Select Apps ")
-            run_script 'env_update' menu
+            run_script 'env_update'
             run_script 'menu_app_select' || run_script 'menu_config'
             ;;
         "Set App Variables ")
-            run_script 'env_update' menu
+            run_script 'env_update'
             run_script 'ui_config_apps' || run_script 'menu_config'
             ;;
         "Set VPN Variables ")
-            run_script 'env_update' menu
+            run_script 'env_update'
             run_script 'ui_config_vpn' || run_script 'menu_config'
             ;;
         "Set Global Variables ")
-            run_script 'env_update' menu
+            run_script 'env_update'
             run_script 'ui_config_globals' || run_script 'menu_config'
             ;;
         "Cancel")
@@ -48,5 +48,5 @@ menu_config() {
     esac
 
     run_script 'generate_yml' || return 1
-    run_script 'run_compose' menu || return 1
+    run_script 'run_compose' || return 1
 }

--- a/scripts/menu_main.sh
+++ b/scripts/menu_main.sh
@@ -22,13 +22,13 @@ menu_main() {
             run_script 'ui_install' || run_script 'menu_main'
             ;;
         "Update DockSTARTer ")
-            run_script 'update_self' menu || run_script 'menu_main'
+            run_script 'update_self' || run_script 'menu_main'
             ;;
         "Backup Environment ")
-            run_script 'env_backup' menu || run_script 'menu_main'
+            run_script 'env_backup' || run_script 'menu_main'
             ;;
         "Prune Docker System ")
-            run_script 'prune_docker' menu || run_script 'menu_main'
+            run_script 'prune_docker' || run_script 'menu_main'
             ;;
         "Cancel")
             info "Exiting DockSTARTer."

--- a/scripts/prune_docker.sh
+++ b/scripts/prune_docker.sh
@@ -3,8 +3,6 @@ set -euo pipefail
 IFS=$'\n\t'
 
 prune_docker() {
-    local PROMPT
-    PROMPT=${1:-}
     local QUESTION
     QUESTION="Would you like to remove all unused containers, networks, volumes, images and build cache?"
     info "${QUESTION}"
@@ -13,7 +11,7 @@ prune_docker() {
         if [[ ${CI:-} == true ]] && [[ ${TRAVIS:-} == true ]]; then
             info "Travis will not run this."
             return
-        elif [[ ${PROMPT} == "menu" ]]; then
+        elif [[ ${PROMPT:-} == "menu" ]]; then
             local ANSWER
             set +e
             ANSWER=$(whiptail --fb --clear --title "DockSTARTer" --yesno "${QUESTION}" 0 0 3>&1 1>&2 2>&3; echo $?)

--- a/scripts/request_reboot.sh
+++ b/scripts/request_reboot.sh
@@ -3,8 +3,6 @@ set -euo pipefail
 IFS=$'\n\t'
 
 request_reboot() {
-    local PROMPT
-    PROMPT=${1:-}
     local QUESTION
     QUESTION="Your system needs to reboot for changes to take effect. Would you like to reboot now?"
     info "${QUESTION}"
@@ -13,7 +11,7 @@ request_reboot() {
         if [[ ${CI:-} == true ]] && [[ ${TRAVIS:-} == true ]]; then
             info "Travis will not run this."
             return
-        elif [[ ${PROMPT} == "menu" ]]; then
+        elif [[ ${PROMPT:-} == "menu" ]]; then
             local ANSWER
             set +e
             ANSWER=$(whiptail --fb --clear --title "DockSTARTer" --yesno "${QUESTION}" 0 0 3>&1 1>&2 2>&3; echo $?)

--- a/scripts/run_compose.sh
+++ b/scripts/run_compose.sh
@@ -3,8 +3,6 @@ set -euo pipefail
 IFS=$'\n\t'
 
 run_compose() {
-    local PROMPT
-    PROMPT=${1:-}
     local QUESTION
     QUESTION="Would you like to run your selected containers now?"
     info "${QUESTION}"
@@ -13,7 +11,7 @@ run_compose() {
         if [[ ${CI:-} == true ]] && [[ ${TRAVIS:-} == true ]]; then
             info "Travis will not run this."
             return
-        elif [[ ${PROMPT} == "menu" ]]; then
+        elif [[ ${PROMPT:-} == "menu" ]]; then
             local ANSWER
             set +e
             ANSWER=$(whiptail --fb --clear --title "DockSTARTer" --yesno "${QUESTION}" 0 0 3>&1 1>&2 2>&3; echo $?)

--- a/scripts/ui_install.sh
+++ b/scripts/ui_install.sh
@@ -11,5 +11,5 @@ ui_install() {
     run_script 'install_compose_completion'
     run_script 'setup_docker_group'
     run_script 'enable_docker_systemd'
-    run_script 'request_reboot' menu || return 1
+    run_script 'request_reboot' || return 1
 }

--- a/scripts/update_self.sh
+++ b/scripts/update_self.sh
@@ -3,8 +3,6 @@ set -euo pipefail
 IFS=$'\n\t'
 
 update_self() {
-    local PROMPT
-    PROMPT=${1:-}
     local QUESTION
     QUESTION="Would you like to update DockSTARTer now?"
     info "${QUESTION}"
@@ -13,7 +11,7 @@ update_self() {
         if [[ ${CI:-} == true ]] && [[ ${TRAVIS:-} == true ]]; then
             info "Travis will not run this."
             return
-        elif [[ ${PROMPT} == "menu" ]]; then
+        elif [[ ${PROMPT:-} == "menu" ]]; then
             local ANSWER
             set +e
             ANSWER=$(whiptail --fb --clear --title "DockSTARTer" --yesno "${QUESTION}" 0 0 3>&1 1>&2 2>&3; echo $?)


### PR DESCRIPTION
## Purpose
If we're running in menu mode it should just be known globally and not defined in each function.

## Approach
Declare `PROMPT` as global using `readonly`. Remove individual functions `local PROMPT` lines. Remove `menu` from arguments on function calls.

## Requirements
- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
