### PR TITLE
Improve handling of root_check

### DIFF
--- a/scripts/root_check.sh
+++ b/scripts/root_check.sh
@@ -5,6 +5,7 @@ IFS=$'\n\t'
 root_check() {
     info "Checking root permissions."
     if [[ ${EUID} -ne 0 ]]; then
-        fatal "Please run as root using sudo."
+        sudo bash "${SCRIPTNAME:-}" "${ARGS[@]:-}" || fatal "Please run as root using sudo ds ${ARGS[*]:-}"
+        exit
     fi
 }


### PR DESCRIPTION
## Purpose
If the users forgets sudo we should try to gracefully include it for them.

## Approach
Rather than `fatal` we will try and run the script with sudo for the user. If they fail to enter the password correctly we will display the "run as root" message using fatal. Also improve the "run as root" message to include `ARGS` correctly.

## Requirements
- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
