### PR TITLE
Format the su command a bit cleaner

### DIFF
--- a/scripts/run_compose.sh
+++ b/scripts/run_compose.sh
@@ -30,7 +30,7 @@ run_compose() {
                 PGID=$(run_script 'env_get' PGID)
                 run_script 'set_permissions' "${SCRIPTPATH}" "${PUID}" "${PGID}"
                 cd "${SCRIPTPATH}/compose/" || fatal "Failed to change directory to ${SCRIPTPATH}/compose/"
-                su -c "docker-compose up -d --remove-orphans" "${DETECTED_UNAME}" || fatal "Docker Compose failed."
+                su "${DETECTED_UNAME}" -c "docker-compose up -d --remove-orphans" || fatal "Docker Compose failed."
                 cd "${SCRIPTPATH}" || fatal "Failed to change directory to ${SCRIPTPATH}"
                 break
                 ;;


### PR DESCRIPTION
## Purpose
Move the username in the su command to be more inline with the representation from the documentation

#### Learning
http://man7.org/linux/man-pages/man1/su.1.html

## Requirements
- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
