### PR TITLE
Skip clone and run from different location if args are specified

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -142,11 +142,11 @@ trap 'cleanup' 0 1 2 3 6 14 15
 
 # Main Function
 main() {
-    if [[ ! -d ${DETECTED_HOMEDIR}/.docker/.git ]]; then
+    if [[ ! -d ${DETECTED_HOMEDIR}/.docker/.git ]] && [[ -z ${ARGS[*]:-} ]]; then
         warning "Attempting to clone DockSTARTer repo to ${DETECTED_HOMEDIR}/.docker location."
         git clone https://github.com/GhostWriters/DockSTARTer "${DETECTED_HOMEDIR}/.docker" || fatal "Failed to clone DockSTARTer repo to ${DETECTED_HOMEDIR}/.docker location."
     fi
-    if [[ ${CI:-} != true ]] && [[ ${TRAVIS:-} != true ]] && [[ ${SCRIPTPATH} != "${DETECTED_HOMEDIR}/.docker" ]]; then
+    if [[ ${CI:-} != true ]] && [[ ${TRAVIS:-} != true ]] && [[ ${SCRIPTPATH} != "${DETECTED_HOMEDIR}/.docker" ]] && [[ -z ${ARGS[*]:-} ]]; then
         warning "Attempting to run DockSTARTer from ${DETECTED_HOMEDIR}/.docker location."
         (sudo bash "${DETECTED_HOMEDIR}/.docker/main.sh" "${ARGS[@]:-}") || true
         exit


### PR DESCRIPTION
## Purpose
Running backups in `sudo crontab` would result in DS cloning it's repo to `/root/.docker` and making backups of `/root/.docker/config` regardless of the actual user who the script should be run as. Adding these checks will make it so that running DS with arguments will bypass the clone and run-from checks and allow backups and other operations to complete successfully.

## Approach
Checks if ARGS are set before taking action that would clone the repo and run from another location.

## Requirements
- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
