### PR TITLE
Replace -g/--generate with -c/--compose

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -69,29 +69,29 @@ fi
 #/ For regular usage you can run without providing any options.
 #/
 #/    -b --backup <min/med/max>     create a backup snapshot of your configs (see wiki more information)
+#/    -c --compose                  run the docker-compose yml generator
 #/    -e --env                      update your .env file with new variables
-#/    -g --generate                 run the docker-compose yml generator
 #/    -h --help                     show this usage information
 #/    -i --install                  install docker and dependencies
 #/    -p --prune                    remove all unused containers, networks, volumes, images and build cache
 #/    -t --test <test_name>         run tests to check the program
 #/    -u --update                   update DockSTARTer
-#/    -v --verbose                  verbose
+##/    -v --verbose                  verbose
 #/    -x --debug                    debug
 #/
 #/
 #/ Examples:
-#/    Run env, generate, install, prune, update:
-#/    ds --install
+#/    Run compose, env, help, install, prune, update:
+#/    ds --compose
 #/    or
-#/    ds -i
+#/    ds -c
 #/
 #/    Run backup:
 #/    ds --backup min
 #/    or
 #/    ds -b min
 #/
-#/    Debug or verbose can be combined with any option but should be indicated before other options:
+#/    Debug can be combined with any option but should be indicated before other options:
 #/    ds --debug --update
 #/    or
 #/    ds -xu

--- a/scripts/cmdline.sh
+++ b/scripts/cmdline.sh
@@ -12,7 +12,9 @@ cmdline() {
         case "${ARG}" in
                 #translate --gnu-long-options to -g (short options)
             --backup)         LOCAL_ARGS="${LOCAL_ARGS}-b " ;;
+            --compose)        LOCAL_ARGS="${LOCAL_ARGS}-c " ;;
             --env)            LOCAL_ARGS="${LOCAL_ARGS}-e " ;;
+# TODO: Remove after 18.11
             --generate)       LOCAL_ARGS="${LOCAL_ARGS}-g " ;;
             --help)           LOCAL_ARGS="${LOCAL_ARGS}-h " ;;
             --install)        LOCAL_ARGS="${LOCAL_ARGS}-i " ;;
@@ -30,7 +32,7 @@ cmdline() {
     #Reset the positional parameters to the short options
     eval set -- "${LOCAL_ARGS:-}"
 
-    while getopts "b:eghipt:uvx" OPTION; do
+    while getopts "b:ceghipt:uvx" OPTION; do
         case ${OPTION} in
             b)
                 case ${OPTARG} in
@@ -49,10 +51,16 @@ cmdline() {
                 esac
                 exit
                 ;;
+            c)
+                run_script 'generate_yml'
+                run_script 'run_compose'
+                exit
+                ;;
             e)
                 run_script 'env_update'
                 exit
                 ;;
+# TODO: Remove after 18.11
             g)
                 run_script 'generate_yml'
                 run_script 'run_compose'

--- a/tests/run_generate_slim.sh
+++ b/tests/run_generate_slim.sh
@@ -6,7 +6,7 @@ run_generate_slim() {
     run_script 'update_system'
     run_script 'env_update'
     info "Running generator."
-    bash "${SCRIPTPATH}/main.sh" -g
+    bash "${SCRIPTPATH}/main.sh" -c
     echo
     cat "${SCRIPTPATH}/compose/docker-compose.yml" || fatal "${SCRIPTPATH}/compose/docker-compose.yml not found."
     echo


### PR DESCRIPTION
## Purpose
Add `-c` and `--compose` to reduce confusion. Eventually deprecate `-g`, but not with this PR.

## Approach
Add the code required for -c and replace all references to -g but keep -g in cmdline until it is deprecated.

## Requirements
- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
