### PR TITLE
Tilde fix

### DIFF
--- a/scripts/env_backup.sh
+++ b/scripts/env_backup.sh
@@ -3,23 +3,14 @@ set -euo pipefail
 IFS=$'\n\t'
 
 env_backup() {
-    if [[ -f ${SCRIPTPATH}/compose/.env ]]; then
-        local DOCKERCONFDIR
-        DOCKERCONFDIR=$(run_script 'env_get' DOCKERCONFDIR)
-        local BACKUPTIME
-        BACKUPTIME=$(date +"%Y%m%d%H%M%S")
-        info "${SCRIPTPATH}/compose/.env found. Copying to ${DOCKERCONFDIR}/.env.backups/.env.${BACKUPTIME}"
-        mkdir -p "${DOCKERCONFDIR}/.env.backups" || fatal "${DOCKERCONFDIR}/.env.backups folder could not be created."
-        cp "${SCRIPTPATH}/compose/.env" "${DOCKERCONFDIR}/.env.backups/.env.${BACKUPTIME}" || fatal "${DOCKERCONFDIR}/.env.backups/.env.${BACKUPTIME} could not be copied."
-        info "Removing old .env backups."
-        find "${DOCKERCONFDIR}/.env.backups/.env.*" -mtime +3 -type f -delete > /dev/null 2>&1 || warning "Old .env backups not removed."
-        local PUID
-        PUID=$(run_script 'env_get' PUID)
-        local PGID
-        PGID=$(run_script 'env_get' PGID)
-        run_script 'set_permissions' "${SCRIPTPATH}" "${PUID}" "${PGID}"
-        run_script 'set_permissions' "${DOCKERCONFDIR}" "${PUID}" "${PGID}"
-    else
-        run_script 'env_create'
-    fi
+    run_script 'env_create'
+    local DOCKERCONFDIR
+    DOCKERCONFDIR=$(run_script 'env_get' DOCKERCONFDIR)
+    local BACKUPTIME
+    BACKUPTIME=$(date +"%Y%m%d%H%M%S")
+    info "Copying .env file to ${DOCKERCONFDIR}/.env.backups/.env.${BACKUPTIME}"
+    mkdir -p "${DOCKERCONFDIR}/.env.backups" || fatal "${DOCKERCONFDIR}/.env.backups folder could not be created."
+    cp "${SCRIPTPATH}/compose/.env" "${DOCKERCONFDIR}/.env.backups/.env.${BACKUPTIME}" || fatal "${DOCKERCONFDIR}/.env.backups/.env.${BACKUPTIME} could not be copied."
+    info "Removing old .env backups."
+    find "${DOCKERCONFDIR}/.env.backups/.env.*" -mtime +3 -type f -delete > /dev/null 2>&1 || warning "Old .env backups not removed."
 }

--- a/scripts/env_create.sh
+++ b/scripts/env_create.sh
@@ -8,6 +8,6 @@ env_create() {
     else
         warning "${SCRIPTPATH}/compose/.env not found. Copying example template."
         cp "${SCRIPTPATH}/compose/.env.example" "${SCRIPTPATH}/compose/.env" || fatal "${SCRIPTPATH}/compose/.env could not be copied."
-        run_script 'set_permissions'
     fi
+    run_script 'env_sanitize'
 }

--- a/scripts/env_sanitize.sh
+++ b/scripts/env_sanitize.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+env_sanitize() {
+    if grep -q '=~' "${SCRIPTPATH}/compose/.env"; then
+        info "Replacing ~ with ${DETECTED_HOMEDIR} in ${SCRIPTPATH}/compose/.env file."
+        sed -i "s/=~/=$(echo "${DETECTED_HOMEDIR}" | sed -e 's/[\/&]/\\&/g')/g" "${SCRIPTPATH}/compose/.env" | warning "Please verify that ~ is not used in ${SCRIPTPATH}/compose/.env file."
+    fi
+}

--- a/scripts/env_update.sh
+++ b/scripts/env_update.sh
@@ -19,11 +19,6 @@ env_update() {
         info "Replacing current .env file with latest template."
         rm -f "${SCRIPTPATH}/compose/.env" || warning "${SCRIPTPATH}/compose/.env could not be removed."
         cp "${SCRIPTPATH}/compose/.env.example" "${SCRIPTPATH}/compose/.env" || fatal "${SCRIPTPATH}/compose/.env could not be copied."
-        local PUID
-        PUID=$(run_script 'env_get' PUID)
-        local PGID
-        PGID=$(run_script 'env_get' PGID)
-        run_script 'set_permissions' "${SCRIPTPATH}" "${PUID}" "${PGID}"
         info "Writing values from .env file backup."
         while IFS= read -r line; do
             local SET_VAR
@@ -36,8 +31,11 @@ env_update() {
                 echo "${line}" >> "${SCRIPTPATH}/compose/.env"
             fi
         done < <(grep '=' < "${NEWEST_ENV}")
+        run_script 'env_sanitize'
         info "Environment file update complete."
     else
         warning "No .env file backups found in ${DOCKERCONFDIR}/.env.backups/"
     fi
+    run_script 'set_permissions' "${SCRIPTPATH}"
+    run_script 'set_permissions' "${DOCKERCONFDIR}"
 }

--- a/scripts/generate_yml.sh
+++ b/scripts/generate_yml.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 IFS=$'\n\t'
 
 generate_yml() {
+    run_script 'env_update'
     info "Generating docker-compose.yml file."
     local RUNFILE
     RUNFILE="${SCRIPTPATH}/compose/docker-compose.sh"
@@ -14,7 +15,6 @@ generate_yml() {
         echo "${SCRIPTPATH}/compose/.reqs/v2.yml \\"
     } >> "${RUNFILE}"
     info "Required files included."
-    run_script 'env_update'
     info "Checking for enabled apps."
     while IFS= read -r line; do
         local APPNAME

--- a/tests/run_generate_slim.sh
+++ b/tests/run_generate_slim.sh
@@ -4,8 +4,7 @@ IFS=$'\n\t'
 
 run_generate_slim() {
     run_script 'update_system'
-    run_script 'env_update'
-    info "Running generator."
+    info "Running compose."
     bash "${SCRIPTPATH}/main.sh" -c
     echo
     cat "${SCRIPTPATH}/compose/docker-compose.yml" || fatal "${SCRIPTPATH}/compose/docker-compose.yml not found."


### PR DESCRIPTION
## Purpose
Force replace `~` in `.env`. Try to ensure that when updates are run that bring new variables into a user's `.env` file the values of those variables are properly setup to replace `~`.

## Approach
- Create an `env_sanitize` function to replace `~` with `${DETECTED_HOMEDIR}`
- Call the `env_sanitize` function from `env_update` -> `env_backup` -> `env_create` -> `env_sanitize` with each function calling the next in line at the top of itself so that the actions are completed before proceeding through the rest of the function
- Also call `env_sanitize` directly in `env_update` when the `.env` file is actually updated
- Rearrange and reduce the number of times the `set_permissions` functions are called.

## Requirements
- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
