### PR TITLE
Fix env_update permissions

### DIFF
--- a/scripts/env_update.sh
+++ b/scripts/env_update.sh
@@ -25,8 +25,12 @@ env_update() {
     rm -f "${CURRENTENV}" || warning "Temporary .env file could not be removed."
     run_script 'env_sanitize'
     info "Environment file update complete."
-    run_script 'set_permissions' "${SCRIPTPATH}"
+    local PUID
+    PUID=$(run_script 'env_get' PUID)
+    local PGID
+    PGID=$(run_script 'env_get' PGID)
+    run_script 'set_permissions' "${SCRIPTPATH}" "${PUID}" "${PGID}"
     local DOCKERCONFDIR
     DOCKERCONFDIR=$(run_script 'env_get' DOCKERCONFDIR)
-    run_script 'set_permissions' "${DOCKERCONFDIR}"
+    run_script 'set_permissions' "${DOCKERCONFDIR}" "${PUID}" "${PGID}"
 }


### PR DESCRIPTION
## Purpose
Backups running as root cron would take ownership of files as root. Files need to be owned by the user in `.env`

## Approach
The permissions were being set to root ownership due to recent changes in the `env_update` script. This adds code to use the user/group from `.env`

## Requirements
- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
