### PR TITLE
Reduce one time setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,38 +12,30 @@ You may choose to rely on DockSTARTer for various changes to your Docker system,
 ## Getting Started
 
 ### One Time Setup (required)
-##### Update your system
 -   APT Systems (Debian/Ubuntu/Raspbian/etc)
 ```
-sudo apt-get update
-sudo apt-get install curl git grep sed whiptail
-sudo apt-get dist-upgrade
+sudo apt-get install git
+bash -c "$(curl -fsSL https://get.dockstarter.com)"
+sudo reboot
 ```
 -   DNF Systems (Fedora)
 ```
-sudo dnf install curl git grep newt sed
-sudo dnf upgrade --refresh
+sudo dnf install git
+bash -c "$(curl -fsSL https://get.dockstarter.com)"
+sudo reboot
 ```
 -   YUM Systems (CentOS)
 ```
-sudo yum install curl git grep newt sed
-sudo yum upgrade
-```
-##### Reboot your system
-```
+sudo yum install git
+bash -c "$(curl -fsSL https://get.dockstarter.com)"
 sudo reboot
 ```
 
 ### Running DockSTARTer
--   First run
-```
-bash -c "$(curl -fsSL https://get.dockstarter.com)"
-```
--   Subsequent runs
 ```
 sudo ds
 ```
-On your first run DockSTARTer should Install Dependencies for you and then prompt you to reboot (required). After the reboot run DockSTARTer again using the subsequent runs command. You should now see the main menu from the screenshots. Select `Configuration` and then `Full Setup` and you will be guided through selecting apps and starting containers.
+To run DockSTARTer use the command above. You should now see the main menu from the screenshots. Select `Configuration` and then `Full Setup` and you will be guided through selecting apps and starting containers.
 
 See our [Wiki](https://github.com/GhostWriters/DockSTARTer/wiki/) for more detailed information.
 

--- a/scripts/request_reboot.sh
+++ b/scripts/request_reboot.sh
@@ -27,6 +27,9 @@ request_reboot() {
                 ;;
             [Nn]*)
                 info "Your system will not reboot."
+                warning "If this is your first run the installation will fail."
+                warning "Please run the installation again and choose Yes to reboot at the end."
+                info "If this is not your first run you may disregard this message."
                 return 1
                 ;;
             *)


### PR DESCRIPTION
## Purpose
Recent updates to the script to handle installing dependencies on first run allow us to reduce and rearrange the one time setup instructions.

## Approach
Each system type (APT/DNF/YUM) will include instructions just to install `git` and then run DS which would install the remaining dependencies. The script will prompt for reboot, but in case the user selects not to reboot we will still include `sudo reboot` instructions in the readme.

#### Open Questions and Pre-Merge TODOs
- [x] Reword the `fatal` that informs the user that the installation failed if they elect not to reboot (possibly rework the functionality of how that is handled).

## Requirements
- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
