### PR TITLE
Use new DuckDNS images for ARMHF/AARCH64

### DIFF
--- a/compose/.apps/duckdns/duckdns.arm64.yml
+++ b/compose/.apps/duckdns/duckdns.arm64.yml
@@ -1,3 +1,3 @@
 services:
   duckdns:
-    image:  lsioarmhf/duckdns-aarch64
+    image:  linuxserver/duckdns

--- a/compose/.apps/duckdns/duckdns.armhf.yml
+++ b/compose/.apps/duckdns/duckdns.armhf.yml
@@ -1,3 +1,3 @@
 services:
   duckdns:
-    image:  lsioarmhf/duckdns
+    image:  linuxserver/duckdns


### PR DESCRIPTION
## Purpose
This closes #343 

## Approach
Replace the image used in the ARMHF and AARCH64 files with the new supported image.

#### Learning
https://hub.docker.com/r/linuxserver/duckdns/

## Requirements
- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
