### PR TITLE
Add compose options

### DIFF
--- a/scripts/cmdline.sh
+++ b/scripts/cmdline.sh
@@ -11,18 +11,18 @@ cmdline() {
         local DELIM=""
         case "${ARG}" in
                 #translate --gnu-long-options to -g (short options)
-            --backup)         LOCAL_ARGS="${LOCAL_ARGS}-b " ;;
-            --compose)        LOCAL_ARGS="${LOCAL_ARGS}-c " ;;
-            --env)            LOCAL_ARGS="${LOCAL_ARGS}-e " ;;
+            --backup)         LOCAL_ARGS="${LOCAL_ARGS:-}-b " ;;
+            --compose)        LOCAL_ARGS="${LOCAL_ARGS:-}-c " ;;
+            --env)            LOCAL_ARGS="${LOCAL_ARGS:-}-e " ;;
 # TODO: Remove after 18.11
-            --generate)       LOCAL_ARGS="${LOCAL_ARGS}-g " ;;
-            --help)           LOCAL_ARGS="${LOCAL_ARGS}-h " ;;
-            --install)        LOCAL_ARGS="${LOCAL_ARGS}-i " ;;
-            --prune)          LOCAL_ARGS="${LOCAL_ARGS}-p " ;;
-            --test)           LOCAL_ARGS="${LOCAL_ARGS}-t " ;;
-            --update)         LOCAL_ARGS="${LOCAL_ARGS}-u " ;;
-            --verbose)        LOCAL_ARGS="${LOCAL_ARGS}-v " ;;
-            --debug)          LOCAL_ARGS="${LOCAL_ARGS}-x " ;;
+            --generate)       LOCAL_ARGS="${LOCAL_ARGS:-}-g " ;;
+            --help)           LOCAL_ARGS="${LOCAL_ARGS:-}-h " ;;
+            --install)        LOCAL_ARGS="${LOCAL_ARGS:-}-i " ;;
+            --prune)          LOCAL_ARGS="${LOCAL_ARGS:-}-p " ;;
+            --test)           LOCAL_ARGS="${LOCAL_ARGS:-}-t " ;;
+            --update)         LOCAL_ARGS="${LOCAL_ARGS:-}-u " ;;
+            --verbose)        LOCAL_ARGS="${LOCAL_ARGS:-}-v " ;;
+            --debug)          LOCAL_ARGS="${LOCAL_ARGS:-}-x " ;;
                 #pass through anything else
             *) [[ "${ARG:0:1}" == "-" ]] || DELIM="\""
                 LOCAL_ARGS="${LOCAL_ARGS:-}${DELIM}${ARG}${DELIM} " ;;

--- a/scripts/cmdline.sh
+++ b/scripts/cmdline.sh
@@ -53,15 +53,23 @@ cmdline() {
                 ;;
             c)
                 case ${OPTARG} in
-                    up)
-                        run_script 'generate_yml'
-                        run_script 'run_compose' up
-                        ;;
                     down)
                         run_script 'run_compose' down
                         ;;
                     generate)
                         run_script 'generate_yml'
+                        ;;
+                    pull)
+                        run_script 'generate_yml'
+                        run_script 'run_compose' pull
+                        ;;
+                    restart)
+                        run_script 'generate_yml'
+                        run_script 'run_compose' restart
+                        ;;
+                    up)
+                        run_script 'generate_yml'
+                        run_script 'run_compose' up
                         ;;
                     *)
                         fatal "Invalid backup option."
@@ -76,7 +84,7 @@ cmdline() {
 # TODO: Remove after 18.11
             g)
                 run_script 'generate_yml'
-                run_script 'run_compose' up
+                run_script 'run_compose'
                 exit
                 ;;
             h)
@@ -110,7 +118,7 @@ cmdline() {
                 case ${OPTARG} in
                     c)
                         run_script 'generate_yml'
-                        run_script 'run_compose' up
+                        run_script 'run_compose'
                         ;;
                     *)
                         fatal "${OPTARG} requires an option."

--- a/scripts/cmdline.sh
+++ b/scripts/cmdline.sh
@@ -32,7 +32,7 @@ cmdline() {
     #Reset the positional parameters to the short options
     eval set -- "${LOCAL_ARGS:-}"
 
-    while getopts "b:ceghipt:uvx" OPTION; do
+    while getopts ":b:c:eghipt:uvx" OPTION; do
         case ${OPTION} in
             b)
                 case ${OPTARG} in
@@ -52,8 +52,21 @@ cmdline() {
                 exit
                 ;;
             c)
-                run_script 'generate_yml'
-                run_script 'run_compose'
+                case ${OPTARG} in
+                    up)
+                        run_script 'generate_yml'
+                        run_script 'run_compose' up
+                        ;;
+                    down)
+                        run_script 'run_compose' down
+                        ;;
+                    generate)
+                        run_script 'generate_yml'
+                        ;;
+                    *)
+                        fatal "Invalid backup option."
+                        ;;
+                esac
                 exit
                 ;;
             e)
@@ -63,7 +76,7 @@ cmdline() {
 # TODO: Remove after 18.11
             g)
                 run_script 'generate_yml'
-                run_script 'run_compose'
+                run_script 'run_compose' up
                 exit
                 ;;
             h)
@@ -92,6 +105,18 @@ cmdline() {
             x)
                 readonly DEBUG='-x'
                 set -x
+                ;;
+            :)
+                case ${OPTARG} in
+                    c)
+                        run_script 'generate_yml'
+                        run_script 'run_compose' up
+                        ;;
+                    *)
+                        fatal "${OPTARG} requires an option."
+                        ;;
+                esac
+                exit
                 ;;
             *)
                 usage

--- a/scripts/run_compose.sh
+++ b/scripts/run_compose.sh
@@ -3,31 +3,55 @@ set -euo pipefail
 IFS=$'\n\t'
 
 run_compose() {
-    local UPDOWN
-    UPDOWN=${1:-up}
+    local COMPOSECOMMAND
+    COMPOSECOMMAND=${1:-}
+    local FORCE
     local QUESTION
-    if [[ $UPDOWN == "up" ]]; then
-        QUESTION="Would you like to run your selected containers now?"
-        UPDOWN="up -d"
-    else
-        QUESTION="Containers will be stopped and removed."
-    fi
+    case ${COMPOSECOMMAND} in
+        down)
+            COMPOSECOMMAND="down --remove-orphans"
+            FORCE=Y
+            QUESTION="Stoping and removing containers, networks, volumes, and images created by DockSTARTer."
+            ;;
+        pull)
+            COMPOSECOMMAND="pull --include-deps"
+            FORCE=Y
+            QUESTION="Pulling the latest images for all enabled services."
+            ;;
+        restart)
+            COMPOSECOMMAND="restart"
+            FORCE=Y
+            QUESTION="Restarting all stopped and running services."
+            ;;
+        up)
+            COMPOSECOMMAND="up -d --remove-orphans"
+            FORCE=Y
+            QUESTION="Creating containers for all enabled services."
+            ;;
+        *)
+            COMPOSECOMMAND="up -d --remove-orphans"
+            FORCE=N
+            QUESTION="Would you like to create containers for all enabled services now?"
+            ;;
+    esac
     info "${QUESTION}"
     local YN
     while true; do
-        if [[ $UPDOWN == "down" ]]; then
-            YN=Y
-        elif [[ ${CI:-} == true ]] && [[ ${TRAVIS:-} == true ]]; then
-            info "Travis will not run this."
-            return
-        elif [[ ${PROMPT:-} == "menu" ]]; then
-            local ANSWER
-            set +e
-            ANSWER=$(whiptail --fb --clear --title "DockSTARTer" --yesno "${QUESTION}" 0 0 3>&1 1>&2 2>&3; echo $?)
-            set -e
-            [[ ${ANSWER} == 0 ]] && YN=Y || YN=N
+        if [[ ${FORCE} != "Y" ]]; then
+            if [[ ${CI:-} == true ]] && [[ ${TRAVIS:-} == true ]]; then
+                info "Travis will not run this."
+                return
+            elif [[ ${PROMPT:-} == "menu" ]]; then
+                local ANSWER
+                set +e
+                ANSWER=$(whiptail --fb --clear --title "DockSTARTer" --yesno "${QUESTION}" 0 0 3>&1 1>&2 2>&3; echo $?)
+                set -e
+                [[ ${ANSWER} == 0 ]] && YN=Y || YN=N
+            else
+                read -rp "[Yn]" YN
+            fi
         else
-            read -rp "[Yn]" YN
+            YN=Y
         fi
         case ${YN} in
             [Yy]*)
@@ -39,7 +63,7 @@ run_compose() {
                 PGID=$(run_script 'env_get' PGID)
                 run_script 'set_permissions' "${SCRIPTPATH}" "${PUID}" "${PGID}"
                 cd "${SCRIPTPATH}/compose/" || fatal "Failed to change directory to ${SCRIPTPATH}/compose/"
-                su "${DETECTED_UNAME}" -c "docker-compose ${UPDOWN} --remove-orphans" || fatal "Docker Compose failed."
+                su "${DETECTED_UNAME}" -c "docker-compose ${COMPOSECOMMAND}" || fatal "Docker Compose failed."
                 cd "${SCRIPTPATH}" || fatal "Failed to change directory to ${SCRIPTPATH}"
                 break
                 ;;


### PR DESCRIPTION
## Purpose
Since we have `-c`/`--compose` now we should allow options such as up/down and possibly others. Keep it simple, don't require common options to be specified, but possibly allow them to be specified (this may be overkill).

## Approach
- [x] Allow `-c up`, `-c down`, `-c restart`, and `-c pull`
- [x] Default to up if no option is specified, this keeps backward compatibility with current behavior

## Requirements
- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
