### PR TITLE
Use docker-compose config to validate yml

### DIFF
--- a/tests/run_generate_slim.sh
+++ b/tests/run_generate_slim.sh
@@ -6,10 +6,9 @@ run_generate_slim() {
     run_script 'update_system'
     info "Running compose."
     bash "${SCRIPTPATH}/main.sh" -c
-    echo
-    cat "${SCRIPTPATH}/compose/docker-compose.yml" || fatal "${SCRIPTPATH}/compose/docker-compose.yml not found."
-    echo
     cd "${SCRIPTPATH}/compose/" || fatal "Failed to change to ${SCRIPTPATH}/compose/ directory."
+    docker-compose config || fatal "Failed to validate ${SCRIPTPATH}/compose/docker-compose.yml file."
+    echo
     docker-compose up -d || fatal "Docker Compose failed."
     cd "${SCRIPTPATH}" || fatal "Failed to change to ${SCRIPTPATH} directory."
     info "Generator test complete."


### PR DESCRIPTION
## Purpose
Use `docker-compose config` rather than just `cat` to confirm the compose file is valid.

#### Open Questions and Pre-Merge TODOs
- [x] Verify that the full app test completes.

#### Learning
https://docs.docker.com/compose/reference/config/

## Requirements
- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
