### PR TITLE
Add armhf template for transmissionvpn

### DIFF
--- a/compose/.apps/transmissionvpn/transmissionvpn.armhf.yml
+++ b/compose/.apps/transmissionvpn/transmissionvpn.armhf.yml
@@ -1,0 +1,3 @@
+services:
+  transmissionvpn:
+    image:           haugene/transmission-openvpn:latest-armhf


### PR DESCRIPTION
## Purpose
This closes #222 
Haugene has added armhf images to his automated builds. We will include this option.

## Approach
Add the yml template containing the image for transmissionvpn on armhf.

#### Learning
https://github.com/haugene/docker-transmission-openvpn/issues/571#issuecomment-436232687

## Requirements
- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
