### PR TITLE
Test core installations after install

### DIFF
--- a/.scripts/install_compose.sh
+++ b/.scripts/install_compose.sh
@@ -34,5 +34,10 @@ install_compose() {
                 dnf -y install docker-compose > /dev/null 2>&1 || fatal "Failed to install docker-compose from dnf."
             fi
         fi
+        local UPDATED_COMPOSE
+        UPDATED_COMPOSE=$( (docker-compose --version 2> /dev/null || true) | sed -E 's/.* version ([^,]*)(, build .*)?/\1/')
+        if [[ "${AVAILABLE_COMPOSE}" != "${UPDATED_COMPOSE}" ]]; then
+            fatal "Failed to install the latest compose."
+        fi
     fi
 }

--- a/.scripts/install_docker.sh
+++ b/.scripts/install_docker.sh
@@ -13,5 +13,12 @@ install_docker() {
     if [[ "${AVAILABLE_DOCKER}" != "${INSTALLED_DOCKER}" ]] || [[ -n ${FORCE} ]]; then
         info "Installing latest docker. Please be patient, this will take a while."
         curl -fsSL get.docker.com | sh > /dev/null 2>&1 || fatal "Failed to install Docker."
+        local UPDATED_DOCKER
+        UPDATED_DOCKER=$( (docker --version 2> /dev/null || true) | sed -E 's/.* version ([^,]*)(, build .*)?/\1/')
+        if [[ "${AVAILABLE_DOCKER}" != "${UPDATED_DOCKER}" ]]; then
+            #TODO: Better detection of most recently available version is required before this can be used.
+            echo # placeholder
+            #fatal "Failed to install the latest docker."
+        fi
     fi
 }

--- a/.scripts/install_yq.sh
+++ b/.scripts/install_yq.sh
@@ -19,5 +19,10 @@ install_yq() {
             curl -H "${GH_HEADER:-}" -L "https://github.com/mikefarah/yq/releases/download/${AVAILABLE_YQ}/yq_linux_amd64" -o /usr/local/bin/yq > /dev/null 2>&1 || fatal "Failed to install yq."
         fi
         chmod +x /usr/local/bin/yq > /dev/null 2>&1 || true
+        local UPDATED_YQ
+        UPDATED_YQ=$( (yq --version 2> /dev/null || true) | sed -E 's/.* version ([^,]*)(, build .*)?/\1/')
+        if [[ "${AVAILABLE_YQ}" != "${UPDATED_YQ}" ]]; then
+            fatal "Failed to install the latest yq."
+        fi
     fi
 }


### PR DESCRIPTION
## Purpose
We should test that the latest available version of the core dependencies (`docker`, `docker-compose`, and `yq`) are installed after their respective installation processes run.

## Approach
Add a check in each installation function. Minor reordering of a few functions.

#### Open Questions and Pre-Merge TODOs
- The latest release of `docker` is not always available for every distro that is otherwise supported. Currently the check we use will result in unnecessary installation on systems that don't have an update available. After investigation I have not found a suitable way to resolve this issue. I will keep this note here but remove the checkbox as it is no longer actionable.

## Requirements
- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
