### PR TITLE
Root improvements

### DIFF
--- a/scripts/root_check.sh
+++ b/scripts/root_check.sh
@@ -5,7 +5,7 @@ IFS=$'\n\t'
 root_check() {
     info "Checking root permissions."
     if [[ ${EUID} -ne 0 ]]; then
-        sudo bash "${SCRIPTNAME:-}" "${ARGS[@]:-}" || fatal "Please run as root using sudo ds ${ARGS[*]:-}"
+        (sudo bash "${SCRIPTNAME:-}" "${ARGS[@]:-}") || true
         exit
     fi
 }


### PR DESCRIPTION
## Purpose
Running without sudo would show an error even in circumstances where nothing was wrong. Ex: first run if the user elects not to reboot, choosing no would result in an error that the script much be run as root even though it already was.

## Approach
Use a subshell and return true even if the script returns false. The script inside the subshell should handle reporting is there was an issue.

## Requirements
- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
