### PR TITLE
Fix .env.backups not deleting

### DIFF
--- a/.scripts/env_backup.sh
+++ b/.scripts/env_backup.sh
@@ -12,5 +12,5 @@ env_backup() {
     mkdir -p "${DOCKERCONFDIR}/.env.backups" || fatal "${DOCKERCONFDIR}/.env.backups folder could not be created."
     cp "${SCRIPTPATH}/compose/.env" "${DOCKERCONFDIR}/.env.backups/.env.${BACKUPTIME}" || fatal "${DOCKERCONFDIR}/.env.backups/.env.${BACKUPTIME} could not be copied."
     info "Removing old .env backups."
-    find "${DOCKERCONFDIR}/.env.backups/.env.*" -mtime +3 -type f -delete > /dev/null 2>&1 || warning "Old .env backups not removed."
+    find "${DOCKERCONFDIR}/.env.backups" -type f -name ".env.*" -mtime +3 -delete > /dev/null 2>&1 || warning "Old .env backups not removed."
 }


### PR DESCRIPTION
## Purpose

.env.backups were not being deleted. The files were small but can add up to a few MB over time.

## Approach

The `find` command will search a specified folder, but needs to use the `-name` flag to be useful for matching partial file names.

## Requirements

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
