### PR TITLE
Various cleanup and reordering

### DIFF
--- a/.scripts/cmdline.sh
+++ b/.scripts/cmdline.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 IFS=$'\n\t'
 
 cmdline() {
-    # got this idea from here:
+    # http://www.kfirlavi.com/blog/2012/11/14/defensive-bash-programming/
     # http://kirk.webfinish.com/2009/10/bash-shell-script-to-use-getopts-with-gnu-style-long-positional-parameters/
     local ARG=
     local LOCAL_ARGS

--- a/.scripts/enable_docker_systemd.sh
+++ b/.scripts/enable_docker_systemd.sh
@@ -4,7 +4,7 @@ IFS=$'\n\t'
 
 enable_docker_systemd() {
     # https://docs.docker.com/install/linux/linux-postinstall/
-    if [[ ${ISSYSTEMD} == true ]]; then
+    if [[ -L "/sbin/init" ]]; then
         info "Systemd detected. Enabling docker service."
         systemctl enable docker > /dev/null 2>&1 || fatal "Failed to enable docker service."
         systemctl stop docker > /dev/null 2>&1 || true


### PR DESCRIPTION
## Purpose

Simply and update usage and make it easier to find.

## Approach

Move the usage comments to the top of `main.sh`, include up/down/restart/pull, move Arch church into main function, move Travis vars up, move systemd check to the only function that uses systemd.

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
