### PR TITLE
Fix validations

### DIFF
--- a/.tests/validate_bashate.sh
+++ b/.tests/validate_bashate.sh
@@ -16,11 +16,11 @@ validate_bashate() {
     # https://github.com/caarlos0/shell-ci-build
     echo "Linting all executables and .*sh files with ${VALIDATOR}..."
     while IFS= read -r line; do
-        if grep -q -E -w "sh|bash|dash|ksh" "${line}"; then
+        if head -n1 "${line}" | grep -q -E -w "sh|bash|dash|ksh"; then
             eval "${VALIDATOR} ${VALIDATIONFLAGS} ${SCRIPTPATH}/${line}" || fatal "Linting ${line}"
             info "Linting ${line}"
         else
-            info "Skipping ${line}..."
+            warning "Skipping ${line}..."
         fi
     done < <(git ls-tree -r HEAD | grep -E '^1007|.*\..*sh$' | awk '{print $4}')
     info "${VALIDATOR} validation complete."

--- a/.tests/validate_shellcheck.sh
+++ b/.tests/validate_shellcheck.sh
@@ -21,11 +21,11 @@ validate_shellcheck() {
     # https://github.com/caarlos0/shell-ci-build
     echo "Linting all executables and .*sh files with ${VALIDATOR}..."
     while IFS= read -r line; do
-        if grep -q -E -w "sh|bash|dash|ksh" "${line}"; then
+        if head -n1 "${line}" | grep -q -E -w "sh|bash|dash|ksh"; then
             eval "${VALIDATOR} ${VALIDATIONFLAGS} ${SCRIPTPATH}/${line}" || fatal "Linting ${line}"
             info "Linting ${line}"
         else
-            info "Skipping ${line}..."
+            warning "Skipping ${line}..."
         fi
     done < <(git ls-tree -r HEAD | grep -E '^1007|.*\..*sh$' | awk '{print $4}')
     info "${VALIDATOR} validation complete."


### PR DESCRIPTION
## Purpose

Validation skipping should be done by reading the top line of the file, not the file name.

## Approach

Use the `head` command as it's used in https://github.com/caarlos0/shell-ci-build

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
