### PR TITLE
Use minimal travis environment

### DIFF
--- a/.tests/run_generate_full.sh
+++ b/.tests/run_generate_full.sh
@@ -3,9 +3,6 @@ set -euo pipefail
 IFS=$'\n\t'
 
 run_generate_full() {
-    if [[ ${CI:-} == true ]] && [[ ${TRAVIS:-} == true ]] && [[ ${TRAVIS_SECURE_ENV_VARS} == true ]]; then
-        service mysql stop
-    fi
     run_script 'env_update'
     while IFS= read -r line; do
         local APPNAME

--- a/.tests/validate_bashate.sh
+++ b/.tests/validate_bashate.sh
@@ -14,7 +14,7 @@ validate_bashate() {
     VALIDATIONFLAGS="-i E006"
 
     # https://github.com/caarlos0/shell-ci-build
-    echo "Linting all executables and .*sh files with ${VALIDATOR}..."
+    info "Linting all executables and .*sh files with ${VALIDATOR}..."
     while IFS= read -r line; do
         if head -n1 "${line}" | grep -q -E -w "sh|bash|dash|ksh"; then
             eval "${VALIDATOR} ${VALIDATIONFLAGS} ${SCRIPTPATH}/${line}" || fatal "Linting ${line}"

--- a/.tests/validate_shellcheck.sh
+++ b/.tests/validate_shellcheck.sh
@@ -19,7 +19,7 @@ validate_shellcheck() {
     VALIDATIONFLAGS="-x"
 
     # https://github.com/caarlos0/shell-ci-build
-    echo "Linting all executables and .*sh files with ${VALIDATOR}..."
+    info "Linting all executables and .*sh files with ${VALIDATOR}..."
     while IFS= read -r line; do
         if head -n1 "${line}" | grep -q -E -w "sh|bash|dash|ksh"; then
             eval "${VALIDATOR} ${VALIDATIONFLAGS} ${SCRIPTPATH}/${line}" || fatal "Linting ${line}"

--- a/.tests/validate_shfmt.sh
+++ b/.tests/validate_shfmt.sh
@@ -21,7 +21,7 @@ validate_shfmt() {
     VALIDATIONFLAGS="-s -i 4 -ci -sr -d"
 
     # https://github.com/caarlos0/shell-ci-build
-    echo "Linting all executables and .*sh files with ${VALIDATOR}..."
+    info "Linting all executables and .*sh files with ${VALIDATOR}..."
     while IFS= read -r line; do
         if head -n1 "${line}" | grep -q -E -w "sh|bash|dash|ksh"; then
             eval "${VALIDATOR} ${VALIDATIONFLAGS} ${SCRIPTPATH}/${line}" || fatal "Linting ${line}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 dist: trusty
 group: travis_latest
-language: generic
+language: minimal
 jobs:
   include:
     - stage: validate


### PR DESCRIPTION
## Purpose

Using the minimal Travis CI environment that comes with less preinstalled should help further prove that the scripts in the repo are doing their job.

## Approach

Update the travis configuration. The minimal environment does not include mysql so we remove the code that handled stopping the mysql service.

#### Learning

https://docs.travis-ci.com/user/languages/minimal-and-generic/

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
