### PR TITLE
Switch to xenial for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
-dist: trusty
-group: travis_latest
+dist: xenial
 language: minimal
 jobs:
   include:


### PR DESCRIPTION
## Purpose

Resolve broken builds since get.docker.com updated.

## Approach

Switch to `xenial` builds on Travis CI.

#### Learning

https://docs.travis-ci.com/user/reference/xenial
https://blog.travis-ci.com/2018-11-08-xenial-release

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
