### PR TITLE
Source fix

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -38,7 +38,7 @@ fi
 get_scriptname() {
     local SOURCE
     local DIR
-    SOURCE="${BASH_SOURCE[0]}"
+    SOURCE="${BASH_SOURCE[0]:-$0}" # https://stackoverflow.com/questions/35006457/choosing-between-0-and-bash-source
     while [[ -L ${SOURCE} ]]; do # resolve ${SOURCE} until the file is no longer a symlink
         DIR="$(cd -P "$(dirname "${SOURCE}")" > /dev/null && pwd)"
         SOURCE="$(readlink "${SOURCE}")"


### PR DESCRIPTION
## Purpose

Address the source issue on CentOS 

## Approach

CentOS and possibly others don't seem to do well with `$BASH_SOURCE` so we fall back on `$0`

#### Learning

https://stackoverflow.com/questions/35006457/choosing-between-0-and-bash-source

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
