### PR TITLE
Remove OS specification from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-dist: xenial
 language: minimal
 jobs:
   include:


### PR DESCRIPTION
## Purpose

It seems Trusty isn't actually broken (yet). Not specifying the `dist` or OS lets the Travis build system decide what distro to build on. It might also make sense to setup travis to test both for stage 2, or split stage 2 into 2 and 3 where one would be Trusty and one would be Xenial.

This will probably remain open for a while until a decision is made about what direction to go with it.

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
