### PR TITLE
Only root check with interactive shell

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -120,8 +120,10 @@ main() {
         fatal "Unsupported architecture."
     fi
     # Root Check
-    if [[ ${DETECTED_PUID} == "0" ]] || [[ ${DETECTED_HOMEDIR} == "/root" ]]; then
-        fatal "Running as root is not supported. Please run as a standard user with sudo."
+    if [[ -n ${PS1:-} ]] || [[ ${-} == *"i"* ]]; then
+        if [[ ${DETECTED_PUID} == "0" ]] || [[ ${DETECTED_HOMEDIR} == "/root" ]]; then
+            fatal "Running as root is not supported. Please run as a standard user with sudo."
+        fi
     fi
     if [[ ${CI:-} != true ]] && [[ ${TRAVIS:-} != true ]] && [[ -z ${ARGS[*]:-} ]]; then
         if [[ ! -d ${DETECTED_HOMEDIR}/.docker/.git ]]; then


### PR DESCRIPTION
## Purpose

Backups being triggered via root cron were not running due to being blocked by our anti-run-as-root code. This resolves the issue by skipping the anti-run-as-root check when running in a non interactive shell.

## Approach

Only run the root check when running in an interactive shell.

#### Learning

http://techdoc.kvindesland.no/linux/gnubooks/bash/bashref_54.html

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
