### PR TITLE
Use new multiarch Deluge image from LSIO

### DIFF
--- a/compose/.apps/deluge/deluge.arm64.yml
+++ b/compose/.apps/deluge/deluge.arm64.yml
@@ -1,3 +1,3 @@
 services:
   deluge:
-    image: lsioarmhf/deluge-aarch64
+    image: linuxserver/deluge

--- a/compose/.apps/deluge/deluge.armhf.yml
+++ b/compose/.apps/deluge/deluge.armhf.yml
@@ -1,3 +1,3 @@
 services:
   deluge:
-    image: lsioarmhf/deluge
+    image: linuxserver/deluge


### PR DESCRIPTION
## Purpose

LSIO has discontinued the arch specific Deluge images and is now releasing multiarch images under `linuxserver/deluge`

## Approach

Use the multiarch image in all templates.

#### Learning

https://hub.docker.com/r/linuxserver/deluge/

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
