### PR TITLE
Add root directory volumes for plex

### DIFF
--- a/compose/.apps/plex/plex.yml
+++ b/compose/.apps/plex/plex.yml
@@ -16,6 +16,9 @@ services:
       - ${DOCKERCONFDIR}/plex:/config
       - ${DOCKERSHAREDDIR}:/shared
       - ${MEDIADIR_MOVIES}:/data/movies
+      - ${MEDIADIR_MOVIES}:/movies
       - ${MEDIADIR_MUSIC}:/data/music
+      - ${MEDIADIR_MUSIC}:/music
       - ${MEDIADIR_TV}:/data/tv
+      - ${MEDIADIR_TV}:/tv
       - ${PLEX_TRANSCODEDIR}:/transcode


### PR DESCRIPTION
## Purpose

Keep original volumes as well so we don't break backwards compatibility, but let users use either one they prefer since the root ones are common to most other containers using media

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
