### PR TITLE
Add COMPOSE_HTTP_TIMEOUT

### DIFF
--- a/compose/.env.example
+++ b/compose/.env.example
@@ -1,4 +1,5 @@
 # Universal Settings
+COMPOSE_HTTP_TIMEOUT=60
 DOCKERCONFDIR=~/.docker/config
 DOCKERGID=999
 DOCKERSHAREDDIR=~/.docker/config/shared


### PR DESCRIPTION
## Purpose

This closes #443 
Allow the user to specify their own `COMPOSE_HTTP_TIMEOUT` if they ever see this

```
ERROR: An HTTP request took too long to complete. Retry with --verbose to obtain debug information.
If you encounter this issue regularly because of slow network conditions, consider setting COMPOSE_HTTP_TIMEOUT to a higher value (current value: 60).
```

## Approach

Add the variable to .env but do not include it in the editable menus. This is an advanced option that normally should not need to be modified. If the user frequently has this issue there is likely another issue at play that should be addressed before encouraging users to adjust this.

#### Learning

https://docs.docker.com/compose/reference/envvars/#compose_http_timeout
https://stackoverflow.com/questions/36488209/how-to-override-the-default-value-of-compose-http-timeout-with-docker-compose-co

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
