### PR TITLE
Proper fix for curl logging

### DIFF
--- a/.scripts/install_compose.sh
+++ b/.scripts/install_compose.sh
@@ -5,7 +5,7 @@ IFS=$'\n\t'
 install_compose() {
     # https://docs.docker.com/compose/install/ OR https://github.com/javabean/arm-compose
     local AVAILABLE_COMPOSE
-    AVAILABLE_COMPOSE=$( (curl -H "${GH_HEADER:-}" -s "https://api.github.com/repos/docker/compose/releases/latest" || fatal "Failed to check latest available docker-compose version.") | grep -Po '"tag_name": "[Vv]?\K.*?(?=")')
+    AVAILABLE_COMPOSE=$(curl -H "${GH_HEADER:-}" -s "https://api.github.com/repos/docker/compose/releases/latest" | grep -Po '"tag_name": "[Vv]?\K.*?(?=")') || fatal "Failed to check latest available docker-compose version."
     local INSTALLED_COMPOSE
     INSTALLED_COMPOSE=$( (docker-compose --version 2> /dev/null || true) | sed -E 's/.* version ([^,]*)(, build .*)?/\1/')
     local FORCE

--- a/.scripts/install_compose_completion.sh
+++ b/.scripts/install_compose_completion.sh
@@ -5,7 +5,7 @@ IFS=$'\n\t'
 install_compose_completion() {
     # https://docs.docker.com/compose/completion/
     local AVAILABLE_COMPOSE_COMPLETION
-    AVAILABLE_COMPOSE_COMPLETION=$( (curl -H "${GH_HEADER:-}" -s "https://api.github.com/repos/docker/compose/releases/latest" || fatal "Failed to check latest available docker-compose completion version.") | grep -Po '"tag_name": "\K.*?(?=")')
+    AVAILABLE_COMPOSE_COMPLETION=$(curl -H "${GH_HEADER:-}" -s "https://api.github.com/repos/docker/compose/releases/latest" | grep -Po '"tag_name": "\K.*?(?=")') || fatal "Failed to check latest available docker-compose completion version."
     info "Installing docker-compose completion."
     curl -H "${GH_HEADER:-}" -L "https://raw.githubusercontent.com/docker/compose/${AVAILABLE_COMPOSE_COMPLETION}/contrib/completion/bash/docker-compose" -o /etc/bash_completion.d/docker-compose > /dev/null 2>&1 || fatal "Failed to install docker-compose completion."
 }

--- a/.scripts/install_docker.sh
+++ b/.scripts/install_docker.sh
@@ -5,7 +5,7 @@ IFS=$'\n\t'
 install_docker() {
     # https://github.com/docker/docker-install
     local AVAILABLE_DOCKER
-    AVAILABLE_DOCKER=$( (curl -H "${GH_HEADER:-}" -s "https://api.github.com/repos/docker/docker-ce/releases/latest" || fatal "Failed to check latest available docker version.") | grep -Po '"tag_name": "[Vv]?\K.*?(?=")')
+    AVAILABLE_DOCKER=$(curl -H "${GH_HEADER:-}" -s "https://api.github.com/repos/docker/docker-ce/releases/latest" | grep -Po '"tag_name": "[Vv]?\K.*?(?=")') || fatal "Failed to check latest available docker version."
     local INSTALLED_DOCKER
     INSTALLED_DOCKER=$( (docker --version 2> /dev/null || true) | sed -E 's/.* version ([^,]*)(, build .*)?/\1/')
     local FORCE

--- a/.scripts/install_machine_completion.sh
+++ b/.scripts/install_machine_completion.sh
@@ -5,7 +5,7 @@ IFS=$'\n\t'
 install_machine_completion() {
     # https://docs.docker.com/machine/completion/
     local AVAILABLE_MACHINE_COMPLETION
-    AVAILABLE_MACHINE_COMPLETION=$( (curl -H "${GH_HEADER:-}" -s "https://api.github.com/repos/docker/machine/releases/latest" || fatal "Failed to check latest available docker machine completion version.") | grep -Po '"tag_name": "\K.*?(?=")')
+    AVAILABLE_MACHINE_COMPLETION=$(curl -H "${GH_HEADER:-}" -s "https://api.github.com/repos/docker/machine/releases/latest" | grep -Po '"tag_name": "\K.*?(?=")') || fatal "Failed to check latest available docker machine completion version."
     info "Installing docker machine completion."
     curl -H "${GH_HEADER:-}" -L "https://raw.githubusercontent.com/docker/machine/${AVAILABLE_MACHINE_COMPLETION}/contrib/completion/bash/docker-machine.bash" -o /etc/bash_completion.d/docker-machine > /dev/null 2>&1 || fatal "Failed to install docker machine completion."
 }

--- a/.scripts/install_yq.sh
+++ b/.scripts/install_yq.sh
@@ -5,7 +5,7 @@ IFS=$'\n\t'
 install_yq() {
     # https://github.com/mikefarah/yq
     local AVAILABLE_YQ
-    AVAILABLE_YQ=$( (curl -H "${GH_HEADER:-}" -s "https://api.github.com/repos/mikefarah/yq/releases/latest" || fatal "Failed to check latest available yq version.") | grep -Po '"tag_name": "[Vv]?\K.*?(?=")')
+    AVAILABLE_YQ=$(curl -H "${GH_HEADER:-}" -s "https://api.github.com/repos/mikefarah/yq/releases/latest" | grep -Po '"tag_name": "[Vv]?\K.*?(?=")') || fatal "Failed to check latest available yq version."
     local INSTALLED_YQ
     INSTALLED_YQ=$( (yq --version 2> /dev/null || true) | sed -E 's/.* version ([^,]*)(, build .*)?/\1/')
     local FORCE


### PR DESCRIPTION
## Purpose

Follow up to #460 since it did not actually work as expected. #460 did not cause any issues, but it did not accomplish the intended goal.

## Approach

With #460 the `fatal` messages were suppressed inside the subshell rather than displayed to the console. This resolves the issue by moving the `fatal` piping to the end of the command which results in the intended logic of "Set this variable or else".

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
