### PR TITLE
Symlink to /usr/bin

### DIFF
--- a/.scripts/install_compose.sh
+++ b/.scripts/install_compose.sh
@@ -29,6 +29,9 @@ install_compose() {
         fi
         if [[ ${ARCH} == "x86_64" ]]; then
             curl -H "${GH_HEADER:-}" -L "https://github.com/docker/compose/releases/download/${AVAILABLE_COMPOSE}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose > /dev/null 2>&1 || fatal "Failed to install docker-compose."
+            if [[ ! -L "/usr/bin/docker-compose" ]]; then
+                ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose || fatal "Failed to create /usr/bin/docker-compose symlink."
+            fi
             chmod +x /usr/local/bin/docker-compose > /dev/null 2>&1 || true
             if [[ -n "$(command -v dnf)" ]]; then
                 dnf -y install docker-compose > /dev/null 2>&1 || fatal "Failed to install docker-compose from dnf."

--- a/.scripts/install_yq.sh
+++ b/.scripts/install_yq.sh
@@ -18,6 +18,9 @@ install_yq() {
         if [[ ${ARCH} == "x86_64" ]]; then
             curl -H "${GH_HEADER:-}" -L "https://github.com/mikefarah/yq/releases/download/${AVAILABLE_YQ}/yq_linux_amd64" -o /usr/local/bin/yq > /dev/null 2>&1 || fatal "Failed to install yq."
         fi
+        if [[ ! -L "/usr/bin/yq" ]]; then
+            ln -s /usr/local/bin/yq /usr/bin/yq || fatal "Failed to create /usr/bin/yq symlink."
+        fi
         chmod +x /usr/local/bin/yq > /dev/null 2>&1 || true
         local UPDATED_YQ
         UPDATED_YQ=$( (yq --version 2> /dev/null || true) | sed -E 's/.* version ([^,]*)(, build .*)?/\1/')

--- a/.scripts/symlink_ds.sh
+++ b/.scripts/symlink_ds.sh
@@ -3,15 +3,25 @@ set -euo pipefail
 IFS=$'\n\t'
 
 symlink_ds() {
+    # /usr/bin/ds
+    if [[ -L "/usr/bin/ds" ]] && [[ ${SCRIPTNAME} != "$(readlink -f /usr/bin/ds)" ]]; then
+        info "Attempting to remove /usr/bin/ds symlink."
+        rm "/usr/bin/ds" || fatal "Failed to remove /usr/bin/ds"
+    fi
+    if [[ ! -L "/usr/bin/ds" ]]; then
+        info "Creating /usr/bin/ds symbolic link for DockSTARTer."
+        ln -s -T "${SCRIPTNAME}" /usr/bin/ds || fatal "Failed to create /usr/bin/ds symlink."
+        chmod +x "${SCRIPTNAME}" > /dev/null 2>&1 || fatal "ds must be executable."
+    fi
+
+    # /usr/local/bin/ds
     if [[ -L "/usr/local/bin/ds" ]] && [[ ${SCRIPTNAME} != "$(readlink -f /usr/local/bin/ds)" ]]; then
-        info "Attempting to remove ds symlink found at /usr/local/bin/ds"
+        info "Attempting to remove /usr/local/bin/ds symlink."
         rm "/usr/local/bin/ds" || fatal "Failed to remove /usr/local/bin/ds"
     fi
     if [[ ! -L "/usr/local/bin/ds" ]]; then
-        info "Creating symbolic link for DockSTARTer."
-        ln -s -T "${SCRIPTNAME}" /usr/local/bin/ds || fatal "Failed to create ds symlink."
+        info "Creating /usr/local/bin/ds symbolic link for DockSTARTer."
+        ln -s -T "${SCRIPTNAME}" /usr/local/bin/ds || fatal "Failed to create /usr/local/bin/ds symlink."
         chmod +x "${SCRIPTNAME}" > /dev/null 2>&1 || fatal "ds must be executable."
-        info "DockSTARTer can be run from anywhere with the following command:"
-        info "sudo ds"
     fi
 }


### PR DESCRIPTION
## Purpose

This closes #469 
CentOS (and maybe other OS) do not have `/usr/local/bin/` in their path variable, but do have `/usr/bin/`.

## Approach

Symlink installed binaries from `/usr/local/bin/` to `/usr/bin/`. This is recommended by docker in the compose install documentation, and works for yq as well.

#### Open Questions and Pre-Merge TODOs

- [ ] Confirm with users of CentOS that this resolved the issue.

#### Learning

https://docs.docker.com/compose/install/
https://en.wikipedia.org/wiki/Unix_filesystem

## Requirements

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
