### PR TITLE
Use privileged instead of NET_ADMIN on qBittorrentVPN

### DIFF
--- a/compose/.apps/qbittorrentvpn/qbittorrentvpn.yml
+++ b/compose/.apps/qbittorrentvpn/qbittorrentvpn.yml
@@ -23,5 +23,4 @@ services:
       - ${DOCKERCONFDIR}/qbittorrentvpn:/config
       - ${DOCKERSHAREDDIR}:/shared
       - ${DOWNLOADSDIR}:/data
-    cap_add:
-      - NET_ADMIN
+    privileged: true


### PR DESCRIPTION
## Purpose

This closes #464
Properly this time with the new information. Thanks @stevenflang 

## Approach

Replace the NET_ADMIN with privileged

#### Learning

https://github.com/binhex/arch-qbittorrentvpn/commit/391f1a23467203df0c041b60dafecb3bea995570
https://github.com/binhex/arch-delugevpn

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
