### PR TITLE
Fix logarr config

### DIFF
--- a/compose/.apps/logarr/logarr.yml
+++ b/compose/.apps/logarr/logarr.yml
@@ -11,6 +11,6 @@ services:
       - TZ=${TZ}
     volumes:
       - /etc/localtime:/etc/localtime:ro
-      - ${DOCKERCONFDIR}/logarr:/app
+      - ${DOCKERCONFDIR}/logarr:/config
       - ${DOCKERCONFDIR}:/var/log/logarrlogs:ro
       - ${DOCKERSHAREDDIR}:/shared


### PR DESCRIPTION
## Purpose

Somehow we mapped `/app`, this is incorrect.

#### Learning

https://github.com/Monitorr/logarr/wiki/(03)-Docker
https://hub.docker.com/r/monitorr/logarr/dockerfile

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
