### PR TITLE
Lan network

### DIFF
--- a/.scripts/menu_value_prompt.sh
+++ b/.scripts/menu_value_prompt.sh
@@ -33,24 +33,24 @@ menu_value_prompt() {
             VALUEOPTIONS+=("Use System " "${SYSTEM_VAL}")
             ;;
         MEDIADIR_BOOKS)
-            SYSTEM_VAL="${DETECTED_HOMEDIR}/Books"
-            VALUEOPTIONS+=("Use System " "${SYSTEM_VAL}")
+            HOME_VAL="${DETECTED_HOMEDIR}/Books"
+            VALUEOPTIONS+=("Use Home " "${HOME_VAL}")
             ;;
         MEDIADIR_COMICS)
-            SYSTEM_VAL="${DETECTED_HOMEDIR}/Comics"
-            VALUEOPTIONS+=("Use System " "${SYSTEM_VAL}")
+            HOME_VAL="${DETECTED_HOMEDIR}/Comics"
+            VALUEOPTIONS+=("Use Home " "${HOME_VAL}")
             ;;
         MEDIADIR_MOVIES)
-            SYSTEM_VAL="${DETECTED_HOMEDIR}/Movies"
-            VALUEOPTIONS+=("Use System " "${SYSTEM_VAL}")
+            HOME_VAL="${DETECTED_HOMEDIR}/Movies"
+            VALUEOPTIONS+=("Use Home " "${HOME_VAL}")
             ;;
         MEDIADIR_MUSIC)
-            SYSTEM_VAL="${DETECTED_HOMEDIR}/Music"
-            VALUEOPTIONS+=("Use System " "${SYSTEM_VAL}")
+            HOME_VAL="${DETECTED_HOMEDIR}/Music"
+            VALUEOPTIONS+=("Use Home " "${HOME_VAL}")
             ;;
         MEDIADIR_TV)
-            SYSTEM_VAL="${DETECTED_HOMEDIR}/TV"
-            VALUEOPTIONS+=("Use System " "${SYSTEM_VAL}")
+            HOME_VAL="${DETECTED_HOMEDIR}/TV"
+            VALUEOPTIONS+=("Use Home " "${HOME_VAL}")
             ;;
         PGID)
             SYSTEM_VAL="${DETECTED_PGID}"
@@ -127,6 +127,10 @@ menu_value_prompt() {
             VALUEDESCRIPTION=""
             ;;
     esac
+
+    if [[ -n ${SYSTEM_VAL} ]]; then
+        VALUEDESCRIPTION="\n\n System detected values are recommended.${VALUEDESCRIPTION}"
+    fi
 
     local SELECTEDVALUE
     if [[ ${CI:-} == true ]] && [[ ${TRAVIS:-} == true ]]; then

--- a/.scripts/menu_value_prompt.sh
+++ b/.scripts/menu_value_prompt.sh
@@ -134,7 +134,7 @@ menu_value_prompt() {
             ;;
     esac
 
-    if [[ -n ${SYSTEM_VAL} ]]; then
+    if [[ -n ${SYSTEM_VAL:-} ]]; then
         VALUEDESCRIPTION="\n\n System detected values are recommended.${VALUEDESCRIPTION}"
     fi
 

--- a/.scripts/menu_value_prompt.sh
+++ b/.scripts/menu_value_prompt.sh
@@ -32,6 +32,12 @@ menu_value_prompt() {
             SYSTEM_VAL="${DETECTED_HOMEDIR}/Downloads"
             VALUEOPTIONS+=("Use System " "${SYSTEM_VAL}")
             ;;
+        LAN_NETWORK)
+            # https://github.com/tom472/mediabox/commit/d6a3317c9513ac9907715c76fb4459cba426da18
+            # https://stackoverflow.com/questions/13322485/how-to-get-the-primary-ip-address-of-the-local-machine-on-linux-and-os-x#comment89955893_25851186
+            SYSTEM_VAL=$(ip a | grep -Po "$(ip route get 1 | sed -n 's/^.*src \([0-9.]*\) .*$/\1/p')\/\d+" | sed 's/[0-9]*\//0\//')
+            VALUEOPTIONS+=("Use System " "${SYSTEM_VAL}")
+            ;;
         MEDIADIR_BOOKS)
             HOME_VAL="${DETECTED_HOMEDIR}/Books"
             VALUEOPTIONS+=("Use Home " "${HOME_VAL}")


### PR DESCRIPTION
## Purpose

This closes #379 
Take the guesswork out of setting LAN_NETWORK

## Approach

System detect the LAN_NETWORK value for the menu. Replace "Use System" with "Use Home" for all MEDIADIR prompts. Add a message whenever a system detected option is present to indicate that the system detected value is recommended.

#### Learning

https://github.com/tom472/mediabox/commit/d6a3317c9513ac9907715c76fb4459cba426da18
https://stackoverflow.com/questions/13322485/how-to-get-the-primary-ip-address-of-the-local-machine-on-linux-and-os-x#comment89955893_25851186

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
