### PR TITLE
Add wording to VPN prompt

### DIFF
--- a/.scripts/config_vpn.sh
+++ b/.scripts/config_vpn.sh
@@ -15,14 +15,14 @@ config_vpn() {
     if grep -q 'VPN_ENABLED=true$' "${SCRIPTPATH}/compose/.env"; then
         set +e
         ANSWER=$(
-            whiptail --fb --clear --title "DockSTARTer" --defaultno --yesno "Would you like to keep these settings for ${APPNAME}?\\n\\n${APPVARS}" 0 0 3>&1 1>&2 2>&3
+            whiptail --fb --clear --title "DockSTARTer" --defaultno --yesno "Would you like to keep these settings for ${APPNAME}?\\n You have apps enabled that will use these variables.\\n\\n${APPVARS}" 0 0 3>&1 1>&2 2>&3
             echo $?
         )
         set -e
     else
         set +e
         ANSWER=$(
-            whiptail --fb --clear --title "DockSTARTer" --yesno "Would you like to keep these settings for ${APPNAME}?\\n\\n${APPVARS}" 0 0 3>&1 1>&2 2>&3
+            whiptail --fb --clear --title "DockSTARTer" --yesno "Would you like to keep these settings for ${APPNAME}?\\n You do not have apps enabled that will use these variables.\\n\\n${APPVARS}" 0 0 3>&1 1>&2 2>&3
             echo $?
         )
         set -e


### PR DESCRIPTION
## Purpose

To inform users if they have apps enabled that would actually use the variables they are being prompted to keep or change

## Requirements

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
