### PR TITLE
Adjust pip failures

### DIFF
--- a/.scripts/install_compose.sh
+++ b/.scripts/install_compose.sh
@@ -17,8 +17,8 @@ install_compose() {
         pip uninstall docker-py > /dev/null 2>&1 || true
 
         info "Installing latest docker-compose."
-        pip install -IU setuptools > /dev/null 2>&1 || fatal "Failed to install setuptools from pip."
-        pip install -IU "urllib3[secure]" > /dev/null 2>&1 || fatal "Failed to install urllib3[secure] from pip."
+        pip install -IU setuptools > /dev/null 2>&1 || warning "Failed to install setuptools from pip."
+        pip install -IU "urllib3[secure]" > /dev/null 2>&1 || warning "Failed to install urllib3[secure] from pip."
         pip install -IU docker-compose > /dev/null 2>&1 || fatal "Failed to install docker-compose from pip."
 
         local UPDATED_COMPOSE


### PR DESCRIPTION
## Purpose

Fix compose install failure due to pip issues.

## Approach

The pip dependencies will try to install but are ok to fail because compose itself will also try to install its own dependencies. DS installing pip dependencies is more of a helping hand than a requirement.

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
