### PR TITLE
Proper handling of equal sign in .env

### DIFF
--- a/.scripts/backup_max.sh
+++ b/.scripts/backup_max.sh
@@ -12,7 +12,7 @@ backup_max() {
     DOCKERCONFDIR=$(run_script 'env_get' DOCKERCONFDIR)
     while IFS= read -r line; do
         local APPNAME
-        APPNAME=${line/_ENABLED=true/}
+        APPNAME=${line}
         local FILENAME
         FILENAME=${APPNAME,,}
         local BACKUP_CONFIG

--- a/.scripts/backup_med.sh
+++ b/.scripts/backup_med.sh
@@ -11,7 +11,7 @@ backup_med() {
     run_script 'backup_create' ".env.backups"
     while IFS= read -r line; do
         local APPNAME
-        APPNAME=${line/_ENABLED=true/}
+        APPNAME=${line%%_ENABLED=true}
         local FILENAME
         FILENAME=${APPNAME,,}
         local BACKUP_CONFIG
@@ -27,7 +27,7 @@ backup_med() {
         else
             warning "${APPNAME}_BACKUP_CONFIG is false. ${APPNAME} will not be backed up."
         fi
-    done < <(grep '_ENABLED=true' < "${SCRIPTPATH}/compose/.env")
+    done < <(grep '_ENABLED=true$' < "${SCRIPTPATH}/compose/.env")
     local BACKUP_CMD_POST_RUN
     BACKUP_CMD_POST_RUN=$(run_script 'env_get' BACKUP_CMD_POST_RUN)
     eval "${BACKUP_CMD_POST_RUN}" || error "Failed to execute BACKUP_CMD_POST_RUN."

--- a/.scripts/config_apps.sh
+++ b/.scripts/config_apps.sh
@@ -6,7 +6,7 @@ config_apps() {
     info "Configuring .env variables for enabled apps."
     while IFS= read -r line; do
         local APPNAME
-        APPNAME=${line/_ENABLED=true/}
+        APPNAME=${line%%_ENABLED=true}
         run_script 'menu_app_vars' "${APPNAME}" || return 1
-    done < <(grep '_ENABLED=true' < "${SCRIPTPATH}/compose/.env")
+    done < <(grep '_ENABLED=true$' < "${SCRIPTPATH}/compose/.env")
 }

--- a/.scripts/config_globals.sh
+++ b/.scripts/config_globals.sh
@@ -20,7 +20,7 @@ config_globals() {
     set -e
     if [[ ${ANSWER} != 0 ]]; then
         while IFS= read -r line; do
-            SET_VAR=${line/=*/}
+            SET_VAR=${line%%=*}
             run_script 'menu_value_prompt' "${SET_VAR}" || return 1
         done < <(echo "${APPVARS}")
     fi

--- a/.scripts/config_vpn.sh
+++ b/.scripts/config_vpn.sh
@@ -29,7 +29,7 @@ config_vpn() {
     fi
     if [[ ${ANSWER} != 0 ]]; then
         while IFS= read -r line; do
-            SET_VAR=${line/=*/}
+            SET_VAR=${line%%=*}
             run_script 'menu_value_prompt' "${SET_VAR}" || return 1
         done < <(echo "${APPVARS}")
     fi

--- a/.scripts/env_update.sh
+++ b/.scripts/env_update.sh
@@ -13,9 +13,9 @@ env_update() {
     info "Merging previous values into new .env file."
     while IFS= read -r line; do
         local SET_VAR
-        SET_VAR=${line/=*/}
+        SET_VAR=${line%%=*}
         local SET_VAL
-        SET_VAL=${line/*=/}
+        SET_VAL=${line#*=}
         if grep -q "^${SET_VAR}=" "${SCRIPTPATH}/compose/.env"; then
             run_script 'env_set' "${SET_VAR}" "${SET_VAL}"
         else

--- a/.scripts/generate_yml.sh
+++ b/.scripts/generate_yml.sh
@@ -18,7 +18,7 @@ generate_yml() {
     info "Checking for enabled apps."
     while IFS= read -r line; do
         local APPNAME
-        APPNAME=${line/_ENABLED=true/}
+        APPNAME=${line%%_ENABLED=true}
         local FILENAME
         FILENAME=${APPNAME,,}
         local APPNETMODE
@@ -68,7 +68,7 @@ generate_yml() {
         else
             error "Failed to find ${SCRIPTPATH}/compose/.apps/${FILENAME}/ directory."
         fi
-    done < <(grep '_ENABLED=true' < "${SCRIPTPATH}/compose/.env")
+    done < <(grep '_ENABLED=true$' < "${SCRIPTPATH}/compose/.env")
     echo "> ${SCRIPTPATH}/compose/docker-compose.yml" >> "${RUNFILE}"
     run_script 'install_yq'
     bash "${RUNFILE}" || fatal "Failed to run generator."

--- a/.scripts/menu_app_select.sh
+++ b/.scripts/menu_app_select.sh
@@ -8,7 +8,7 @@ menu_app_select() {
 
     while IFS= read -r line; do
         local APPNAME
-        APPNAME=${line/_ENABLED=*/}
+        APPNAME=${line%%_ENABLED=*}
         local FILENAME
         FILENAME=${APPNAME,,}
         local APPSUPPORTED
@@ -55,9 +55,9 @@ menu_app_select() {
             info "Disabling all apps."
             while IFS= read -r line; do
                 local APPNAME
-                APPNAME=${line/_ENABLED=true/}
+                APPNAME=${line%%_ENABLED=true}
                 run_script 'env_set' "${APPNAME}_ENABLED" false
-            done < <(grep '_ENABLED=true' < "${SCRIPTPATH}/compose/.env")
+            done < <(grep '_ENABLED=true$' < "${SCRIPTPATH}/compose/.env")
             info "Enabling selected apps."
             while IFS= read -r line; do
                 local APPNAME

--- a/.scripts/menu_app_vars.sh
+++ b/.scripts/menu_app_vars.sh
@@ -22,7 +22,7 @@ menu_app_vars() {
     set -e
     if [[ ${ANSWER} != 0 ]]; then
         while IFS= read -r line; do
-            SET_VAR=${line/=*/}
+            SET_VAR=${line%%=*}
             run_script 'menu_value_prompt' "${SET_VAR}" || return 1
         done < <(echo "${APPVARS}")
     fi

--- a/.tests/run_generate_full.sh
+++ b/.tests/run_generate_full.sh
@@ -6,9 +6,9 @@ run_generate_full() {
     run_script 'env_update'
     while IFS= read -r line; do
         local APPNAME
-        APPNAME=${line/_ENABLED=*/}
+        APPNAME=${line%%_ENABLED=*}
         info "Testing ${APPNAME}."
-        sed -i 's/_ENABLED=true/_ENABLED=false/' "${SCRIPTPATH}/compose/.env"
+        sed -i 's/_ENABLED=true$/_ENABLED=false/' "${SCRIPTPATH}/compose/.env"
         run_script 'env_set' "${APPNAME}_ENABLED" true
         run_test 'run_generate_slim'
     done < <(grep '_ENABLED=' < "${SCRIPTPATH}/compose/.env")


### PR DESCRIPTION
## Purpose

.env vars could not include `=` due to the way we were handling updating the .env file.

## Approach

Use parameter expansion prefix and suffix instead of search and replace when updating the .env file. Also use similar changes in various other files to improve overall safety and quality.

## Requirements

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
