### PR TITLE
Remove unneeded tpc port specification`

### DIFF
--- a/compose/.apps/openvpnas/openvpnas.ports.yml
+++ b/compose/.apps/openvpnas/openvpnas.ports.yml
@@ -2,5 +2,5 @@ services:
   openvpnas:
     ports:
       - "${OPENVPNAS_PORT_1194}:1194/udp"
-      - "${OPENVPNAS_PORT_943}:943/tcp"
-      - "${OPENVPNAS_PORT_9443}:9443/tcp"
+      - "${OPENVPNAS_PORT_943}:943"
+      - "${OPENVPNAS_PORT_9443}:9443"

--- a/compose/.apps/pihole/pihole.ports.yml
+++ b/compose/.apps/pihole/pihole.ports.yml
@@ -2,7 +2,7 @@ services:
   pihole:
     ports:
       - "${PIHOLE_PORT_443}:443"
-      - "${PIHOLE_PORT_53}:53/tcp"
+      - "${PIHOLE_PORT_53}:53"
       - "${PIHOLE_PORT_53}:53/udp"
       - "${PIHOLE_PORT_67}:67/udp"
       - "${PIHOLE_PORT_80}:80"

--- a/compose/.apps/plex/plex.ports.yml
+++ b/compose/.apps/plex/plex.ports.yml
@@ -2,13 +2,13 @@ services:
   plex:
     ports:
       - "${PLEX_PORT_1900}:1900/udp"
-      - "${PLEX_PORT_3005}:3005/tcp"
-      - "${PLEX_PORT_32400}:32400/tcp"
+      - "${PLEX_PORT_3005}:3005"
+      - "${PLEX_PORT_32400}:32400"
       - "${PLEX_PORT_32410}:32410/udp"
       - "${PLEX_PORT_32412}:32412/udp"
       - "${PLEX_PORT_32413}:32413/udp"
       - "${PLEX_PORT_32414}:32414/udp"
-      - "${PLEX_PORT_32469}:32469/tcp"
+      - "${PLEX_PORT_32469}:32469"
       - "${PLEX_PORT_33400}:33400"
       - "${PLEX_PORT_5353}:5353/udp"
-      - "${PLEX_PORT_8324}:8324/tcp"
+      - "${PLEX_PORT_8324}:8324"

--- a/compose/.apps/telegraf/telegraf.ports.yml
+++ b/compose/.apps/telegraf/telegraf.ports.yml
@@ -2,5 +2,5 @@ services:
   telegraf:
     ports:
       - "${TELEGRAF_PORT_8092}:8092/udp"
-      - "${TELEGRAF_PORT_8094}:8094/tcp"
+      - "${TELEGRAF_PORT_8094}:8094"
       - "${TELEGRAF_PORT_8125}:8125"


### PR DESCRIPTION
## Purpose

Specifying `/tcp` is not necessary for port definitions.

## Approach

Stop specifying `/tcp`

#### Learning

https://docs.docker.com/compose/compose-file/#ports

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
