### PR TITLE
Adjust default branch handling

### DIFF
--- a/.scripts/cmdline.sh
+++ b/.scripts/cmdline.sh
@@ -115,7 +115,7 @@ cmdline() {
                         run_script 'run_compose'
                         ;;
                     u)
-                        run_script 'update_self' "origin/master"
+                        run_script 'update_self'
                         ;;
                     *)
                         fatal "${OPTARG} requires an option."

--- a/.scripts/update_self.sh
+++ b/.scripts/update_self.sh
@@ -4,7 +4,7 @@ IFS=$'\n\t'
 
 update_self() {
     local BRANCH
-    BRANCH=${1:-}
+    BRANCH=${1:-origin/master}
     local QUESTION
     QUESTION="Would you like to update DockSTARTer to ${BRANCH} now?"
     info "${QUESTION}"


### PR DESCRIPTION
## Purpose

Define the default branch to be used when no branch is set from inside the `update_self` function. Other places in the code were calling this function without providing the branch and this is a safer long term plan to prevent issues. Prior to this commit some attempts to update would run with no branch specified.

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
