### PR TITLE
Properly handle user selecting Use Home

### DIFF
--- a/.scripts/menu_value_prompt.sh
+++ b/.scripts/menu_value_prompt.sh
@@ -150,6 +150,9 @@ menu_value_prompt() {
         "Keep Current ")
             INPUT=${CURRENT_VAL}
             ;;
+        "Use Home ")
+            INPUT=${HOME_VAL}
+            ;;
         "Use Default ")
             INPUT=${DEFAULT_VAL}
             ;;


### PR DESCRIPTION
## Purpose

df77fc8148e235a0cf272315a84334b77d40013c adjusted prompts to `Use Home` for certain items but did not properly handle when a user selected that option.

## Approach

Add handling of `Use Home` option.

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
