### PR TITLE
Update Hydra2, Jackett, and Syncthing to LSIO pipeline images

### DIFF
--- a/compose/.apps/hydra2/hydra2.aarch64.yml
+++ b/compose/.apps/hydra2/hydra2.aarch64.yml
@@ -1,3 +1,3 @@
 services:
   hydra2:
-    image: lsioarmhf/hydra2-aarch64
+    image: linuxserver/hydra2

--- a/compose/.apps/hydra2/hydra2.armv7l.yml
+++ b/compose/.apps/hydra2/hydra2.armv7l.yml
@@ -1,3 +1,3 @@
 services:
   hydra2:
-    image: lsioarmhf/hydra2
+    image: linuxserver/hydra2

--- a/compose/.apps/jackett/jackett.aarch64.yml
+++ b/compose/.apps/jackett/jackett.aarch64.yml
@@ -1,3 +1,3 @@
 services:
   jackett:
-    image: lsioarmhf/jackett-aarch64
+    image: linuxserver/jackett

--- a/compose/.apps/jackett/jackett.armv7l.yml
+++ b/compose/.apps/jackett/jackett.armv7l.yml
@@ -1,3 +1,3 @@
 services:
   jackett:
-    image: lsioarmhf/jackett
+    image: linuxserver/jackett

--- a/compose/.apps/syncthing/syncthing.aarch64.yml
+++ b/compose/.apps/syncthing/syncthing.aarch64.yml
@@ -1,3 +1,3 @@
 services:
   syncthing:
-    image: lsioarmhf/syncthing-aarch64
+    image: linuxserver/syncthing

--- a/compose/.apps/syncthing/syncthing.armv7l.yml
+++ b/compose/.apps/syncthing/syncthing.armv7l.yml
@@ -1,3 +1,3 @@
 services:
   syncthing:
-    image: lsioarmhf/syncthing
+    image: linuxserver/syncthing


### PR DESCRIPTION
## Purpose

Update a handful of ARM images to LSIO's new builds.

#### Learning

https://hub.docker.com/r/linuxserver/hydra2/
https://hub.docker.com/r/linuxserver/jackett/
https://hub.docker.com/r/linuxserver/syncthing/

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
