### PR TITLE
Sed fixes

### DIFF
--- a/.scripts/env_sanitize.sh
+++ b/.scripts/env_sanitize.sh
@@ -5,7 +5,7 @@ IFS=$'\n\t'
 env_sanitize() {
     if grep -q '=~' "${SCRIPTPATH}/compose/.env"; then
         info "Replacing ~ with ${DETECTED_HOMEDIR} in ${SCRIPTPATH}/compose/.env file."
-        sed -i "s/=~/=$(echo "${DETECTED_HOMEDIR}" | sed -e 's/[\/&]/\\&/g')/g" "${SCRIPTPATH}/compose/.env" | warning "Please verify that ~ is not used in ${SCRIPTPATH}/compose/.env file."
+        sed -i "s/=~/=$(sed_replace "${DETECTED_HOMEDIR}")/g" "${SCRIPTPATH}/compose/.env" | warning "Please verify that ~ is not used in ${SCRIPTPATH}/compose/.env file."
     fi
 
     local OUROBOROS_ENABLED

--- a/.scripts/env_set.sh
+++ b/.scripts/env_set.sh
@@ -8,10 +8,6 @@ env_set() {
     local NEW_VAL
     NEW_VAL=${2:-}
     local VAR_VAL
-    VAR_VAL=$(grep "^${SET_VAR}=" "${SCRIPTPATH}/compose/.env" | xargs || fatal "Failed to find ${SET_VAR} in ${SCRIPTPATH}/compose/.env")
-    local SED_FIND
-    SED_FIND=$(echo "${VAR_VAL}" | sed -e 's/[\/&]/\\&/g')
-    local SED_REPLACE
-    SED_REPLACE=$(echo "${SET_VAR}=${NEW_VAL}" | sed -e 's/[\/&]/\\&/g')
-    sed -i "s/^${SED_FIND}$/${SED_REPLACE}/" "${SCRIPTPATH}/compose/.env" || fatal "Failed to set ${SED_REPLACE}"
+    VAR_VAL=$(grep "^${SET_VAR}=" "${SCRIPTPATH}/compose/.env" | xargs) || fatal "Failed to find ${SET_VAR} in ${SCRIPTPATH}/compose/.env"
+    sed -i "s/^$(sed_find "${VAR_VAL}")$/$(sed_replace "${SET_VAR}=${NEW_VAL}")/" "${SCRIPTPATH}/compose/.env" || fatal "Failed to set ${SED_REPLACE}"
 }

--- a/main.sh
+++ b/main.sh
@@ -90,6 +90,15 @@ fatal() {
     exit 1
 }
 
+# Sed Functions
+# https://stackoverflow.com/a/29613573/1384186
+sed_find() {
+    sed 's/[^^]/[&]/g; s/\^/\\^/g' <<< "${1:-}"
+}
+sed_replace() {
+    sed 's/[&/\]/\\&/g' <<< "${1:-}"
+}
+
 # Script Runner Function
 run_script() {
     local SCRIPTSNAME="${1:-}"


### PR DESCRIPTION
## Purpose

Fix sed find and replace. This was causing values to reset to default from `.env.example` during updates.

## Approach

Add two new sed helper functions so that we are not repeating the code in multiple places. Use a separate function for find and replace. See link in comments.

#### Learning

https://stackoverflow.com/a/29613573/1384186

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
