### PR TITLE
Switch htpcmanager to LSIO pipeline

### DIFF
--- a/compose/.apps/htpcmanager/htpcmanager.aarch64.yml
+++ b/compose/.apps/htpcmanager/htpcmanager.aarch64.yml
@@ -1,3 +1,3 @@
 services:
   htpcmanager:
-    image: lsioarmhf/htpcmanager-aarch64
+    image: linuxserver/htpcmanager

--- a/compose/.apps/htpcmanager/htpcmanager.armv7l.yml
+++ b/compose/.apps/htpcmanager/htpcmanager.armv7l.yml
@@ -1,3 +1,3 @@
 services:
   htpcmanager:
-    image: lsioarmhf/htpcmanager
+    image: linuxserver/htpcmanager


### PR DESCRIPTION
## Purpose

Switch to new LSIO pipeline images for ARMHF and AARCH64

#### Open Questions and Pre-Merge TODOs

- [ ] Verify new pipeline images are being offered for this app

#### Learning

https://hub.docker.com/r/linuxserver/htpcmanager

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
