### PR TITLE
Switch qbittorrent to LSIO pipeline

### DIFF
--- a/compose/.apps/qbittorrent/qbittorrent.aarch64.yml
+++ b/compose/.apps/qbittorrent/qbittorrent.aarch64.yml
@@ -1,3 +1,3 @@
 services:
   qbittorrent:
-    image: lsioarmhf/qbittorrent-aarch64
+    image: linuxserver/qbittorrent

--- a/compose/.apps/qbittorrent/qbittorrent.armv7l.yml
+++ b/compose/.apps/qbittorrent/qbittorrent.armv7l.yml
@@ -1,3 +1,3 @@
 services:
   qbittorrent:
-    image: lsioarmhf/qbittorrent
+    image: linuxserver/qbittorrent


### PR DESCRIPTION
## Purpose

Switch to new LSIO pipeline images for ARMHF and AARCH64

#### Open Questions and Pre-Merge TODOs

- [x] Verify new pipeline images are being offered for this app

#### Learning

https://hub.docker.com/r/linuxserver/qbittorrent

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
