### PR TITLE
Replace privileged with net_admin on openvpnas

### DIFF
--- a/compose/.apps/openvpnas/openvpnas.yml
+++ b/compose/.apps/openvpnas/openvpnas.yml
@@ -18,4 +18,5 @@ services:
       - /etc/localtime:/etc/localtime:ro
       - ${DOCKERCONFDIR}/openvpnas:/config
       - ${DOCKERSHAREDDIR}:/shared
-    privileged: true
+    cap_add:
+      - NET_ADMIN


### PR DESCRIPTION
## Purpose

Privileged mode seems to no longer be required and has been replaced with net_admin in the official documentation. The other changes in the PR linked below were already addressed in DS.

#### Learning

https://github.com/linuxserver/docker-openvpnas/pull/49

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
