### PR TITLE
Silence branch cleanup

### DIFF
--- a/.scripts/update_self.sh
+++ b/.scripts/update_self.sh
@@ -36,7 +36,7 @@ update_self() {
                 git fetch > /dev/null 2>&1 || fatal "Failed to fetch recent changes from git."
                 git reset --hard "${BRANCH}" > /dev/null 2>&1 || fatal "Failed to reset to ${BRANCH}."
                 git pull > /dev/null 2>&1 || fatal "Failed to pull recent changes from git."
-                git for-each-ref --format '%(refname:short)' refs/heads | grep -v master | xargs git branch -D || true
+                git for-each-ref --format '%(refname:short)' refs/heads | grep -v master | xargs git branch -D > /dev/null 2>&1 || true
                 chmod +x "${SCRIPTNAME}" > /dev/null 2>&1 || fatal "ds must be executable."
                 run_script 'env_update'
                 break


### PR DESCRIPTION
## Purpose

If only the `master` branch exists during DS's update process an `fatal: branch name required` message is shown because there are no branch names being passed to the command that deletes the extra branches. The command does not fail because we already had an `|| true` in place, but the error was not silenced. The error is not an important one and is expected behavior but does not need to be shown to the end users.

## Approach

Redirect output to null.

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
