### PR TITLE
Reduce the number of times set_permissions is called

### DIFF
--- a/.scripts/env_update.sh
+++ b/.scripts/env_update.sh
@@ -33,5 +33,7 @@ env_update() {
     run_script 'set_permissions' "${SCRIPTPATH}" "${PUID}" "${PGID}"
     local DOCKERCONFDIR
     DOCKERCONFDIR=$(run_script 'env_get' DOCKERCONFDIR)
-    run_script 'set_permissions' "${DOCKERCONFDIR}" "${PUID}" "${PGID}"
+    if [[ ${DOCKERCONFDIR} != ${SCRIPTPATH}* ]]; then
+        run_script 'set_permissions' "${DOCKERCONFDIR}" "${PUID}" "${PGID}"
+    fi
 }

--- a/.scripts/run_compose.sh
+++ b/.scripts/run_compose.sh
@@ -64,11 +64,6 @@ run_compose() {
             [Yy]*)
                 run_script 'install_docker'
                 run_script 'install_compose'
-                local PUID
-                PUID=$(run_script 'env_get' PUID)
-                local PGID
-                PGID=$(run_script 'env_get' PGID)
-                run_script 'set_permissions' "${SCRIPTPATH}" "${PUID}" "${PGID}"
                 cd "${SCRIPTPATH}/compose/" || fatal "Failed to change directory to ${SCRIPTPATH}/compose/"
                 su "${DETECTED_UNAME}" -c "docker-compose ${COMPOSECOMMAND}" || fatal "Docker Compose failed."
                 cd "${SCRIPTPATH}" || fatal "Failed to change directory to ${SCRIPTPATH}"


### PR DESCRIPTION
## Purpose

This closes #563 

## Approach

Only set permissions on `DOCKERCONFDIR` if it is outside of `SCRIPTPATH` (if it's inside then permissions will be set by the parent being set). Do not run the set permissions sequence when running compose as it would have already been done by now via other parts of the script and thus would be redundant at this point.

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
