### PR TITLE
Add advanced install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ You may choose to rely on DockSTARTer for various changes to your Docker system,
 
 ![Value Prompt](https://i.imgur.com/k1bdAoQ.png)
 
+![Command Line Interface](https://i.imgur.com/Y8F3uT2.png)
+
 ## Getting Started
 
 ### One Time Setup (required)
@@ -45,6 +47,25 @@ sudo yum install curl git
 bash -c "$(curl -fsSL https://get.dockstarter.com)"
 sudo reboot
 ```
+
+<details>
+  <summary>Advanced install (any system)</summary>
+
+The standard install above downloads the initial script using a method with some known risks. For those concerned with the security of the above method here is an alternative:
+
+```bash
+# NOTE: Run the appropriate command for your distro
+sudo apt-get install curl git
+sudo dnf install curl git
+sudo yum install curl git
+
+# NOTE: Do not sudo the next line.
+git clone https://github.com/GhostWriters/DockSTARTer "/home/${USER}/.docker"
+sudo bash /home/${USER}/.docker/main.sh -i
+sudo reboot
+```
+
+</details>
 
 ### Running DockSTARTer
 


### PR DESCRIPTION
## Purpose

Piping curl to shell is not perfect by any stretch and is considered bad practice (see the links below). I have already done the research before ever adding this method to the readme and done everything possible to minimize the potential negatives of offering this method while still using it for the sake of having a very minimal set of install instructions. Two things that have been done (prior to this commit, just noting for documentation) are using DNSSEC on the domain which should negate most intercept attempts and using curl with silent failures into a variable meaning if the script is not downloaded in its entirety the variable will be blank and nothing will run. This does not negate the possibility that the script downloaded could potentially not be the intended script as there are still ways for this to happen, but it does greatly reduce the changes. All that being said we will still provide advanced install instructions for those who recognize the risks and are not willing to take them to use the shorthand installation method.

## Approach

Adding a collapsible section to the readme that can be easily skipped by those who do not wish to bother. These instructions function effectively the same as the shorthand instructions.

#### Learning

https://www.reddit.com/r/selfhosted/comments/asgr3w/dockstarter_an_easy_install_script_for_self/egu88us/
https://www.idontplaydarts.com/2016/04/detecting-curl-pipe-bash-server-side/

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
