### PR TITLE
Switch to universal prompt code

### DIFF
--- a/.scripts/cmdline.sh
+++ b/.scripts/cmdline.sh
@@ -54,22 +54,22 @@ cmdline() {
             c)
                 case ${OPTARG} in
                     down)
-                        run_script 'run_compose' down
+                        run_script 'run_compose' "${INTERFACE:-false}" down
                         ;;
                     generate)
                         run_script 'generate_yml'
                         ;;
                     pull)
                         run_script 'generate_yml'
-                        run_script 'run_compose' pull
+                        run_script 'run_compose' "${INTERFACE:-false}" pull
                         ;;
                     restart)
                         run_script 'generate_yml'
-                        run_script 'run_compose' restart
+                        run_script 'run_compose' "${INTERFACE:-false}" restart
                         ;;
                     up)
                         run_script 'generate_yml'
-                        run_script 'run_compose' up
+                        run_script 'run_compose' "${INTERFACE:-false}" up
                         ;;
                     *)
                         fatal "Invalid compose option."
@@ -90,7 +90,7 @@ cmdline() {
                 exit
                 ;;
             p)
-                run_script 'prune_docker'
+                run_script 'prune_docker' "${INTERFACE:-false}"
                 exit
                 ;;
             t)
@@ -98,7 +98,7 @@ cmdline() {
                 exit
                 ;;
             u)
-                run_script 'update_self' "${OPTARG}"
+                run_script 'update_self' "${INTERFACE:-false}" "${OPTARG}"
                 exit
                 ;;
             v)
@@ -112,10 +112,10 @@ cmdline() {
                 case ${OPTARG} in
                     c)
                         run_script 'generate_yml'
-                        run_script 'run_compose'
+                        run_script 'run_compose' "${INTERFACE:-false}"
                         ;;
                     u)
-                        run_script 'update_self'
+                        run_script 'update_self' "${INTERFACE:-false}"
                         ;;
                     *)
                         fatal "${OPTARG} requires an option."

--- a/.scripts/config_global.sh
+++ b/.scripts/config_global.sh
@@ -2,23 +2,20 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-config_globals() {
-    info "Configuring global .env variables."
+config_global() {
+    local PROMPT
+    PROMPT=${1:-false}
     local APPNAME
-    APPNAME="Globals"
+    APPNAME="Global"
     local VARNAMES
     VARNAMES=(TZ DOCKERHOSTNAME PUID PGID DOCKERCONFDIR DOWNLOADSDIR MEDIADIR_BOOKS MEDIADIR_COMICS MEDIADIR_MOVIES MEDIADIR_MUSIC MEDIADIR_TV DOCKERSHAREDDIR)
     local APPVARS
     APPVARS=$(for v in "${VARNAMES[@]}"; do echo "${v}=$(run_script 'env_get' "${v}")"; done)
 
-    local ANSWER
-    set +e
-    ANSWER=$(
-        whiptail --fb --clear --title "DockSTARTer" --defaultno --yesno "Would you like to keep these settings for ${APPNAME}?\\n\\n${APPVARS}" 0 0 3>&1 1>&2 2>&3
-        echo $?
-    )
-    set -e
-    if [[ ${ANSWER} != 0 ]]; then
+    if run_script 'question_prompt' "${PROMPT}" N "Would you like to keep these settings for ${APPNAME}?\\n\\n${APPVARS}"; then
+        info "Keeping ${APPNAME} .env variables."
+    else
+        info "Configuring ${APPNAME} .env variables."
         while IFS= read -r line; do
             SET_VAR=${line%%=*}
             run_script 'menu_value_prompt' "${SET_VAR}" || return 1

--- a/.scripts/config_vpn.sh
+++ b/.scripts/config_vpn.sh
@@ -3,7 +3,8 @@ set -euo pipefail
 IFS=$'\n\t'
 
 config_vpn() {
-    info "Configuring VPN .env variables."
+    local PROMPT
+    PROMPT=${1:-false}
     local APPNAME
     APPNAME="VPN"
     local VARNAMES
@@ -11,23 +12,20 @@ config_vpn() {
     local APPVARS
     APPVARS=$(for v in "${VARNAMES[@]}"; do echo "${v}=$(run_script 'env_get' "${v}")"; done)
 
-    local ANSWER
+    local DEFAULT
+    local MESSAGE
     if grep -q 'VPN_ENABLED=true$' "${SCRIPTPATH}/compose/.env"; then
-        set +e
-        ANSWER=$(
-            whiptail --fb --clear --title "DockSTARTer" --defaultno --yesno "Would you like to keep these settings for ${APPNAME}?\\n You have apps enabled that will use these variables.\\n\\n${APPVARS}" 0 0 3>&1 1>&2 2>&3
-            echo $?
-        )
-        set -e
+        DEFAULT="N"
+        MESSAGE="Would you like to keep these settings for ${APPNAME}?\\n You have apps enabled that will use these variables.\\n\\n${APPVARS}"
     else
-        set +e
-        ANSWER=$(
-            whiptail --fb --clear --title "DockSTARTer" --yesno "Would you like to keep these settings for ${APPNAME}?\\n You do not have apps enabled that will use these variables.\\n\\n${APPVARS}" 0 0 3>&1 1>&2 2>&3
-            echo $?
-        )
-        set -e
+        DEFAULT="Y"
+        MESSAGE="Would you like to keep these settings for ${APPNAME}?\\n You do not have apps enabled that will use these variables.\\n\\n${APPVARS}"
     fi
-    if [[ ${ANSWER} != 0 ]]; then
+
+    if run_script 'question_prompt' "${PROMPT}" "${DEFAULT}" "${MESSAGE}"; then
+        info "Keeping ${APPNAME} .env variables."
+    else
+        info "Configuring ${APPNAME} .env variables."
         while IFS= read -r line; do
             SET_VAR=${line%%=*}
             run_script 'menu_value_prompt' "${SET_VAR}" || return 1

--- a/.scripts/menu_app_select.sh
+++ b/.scripts/menu_app_select.sh
@@ -30,24 +30,26 @@ menu_app_select() {
         fi
     done < <(grep '_ENABLED=' < "${SCRIPTPATH}/compose/.env")
 
-    if [[ ${CI:-} != true ]] && [[ ${TRAVIS:-} != true ]]; then
-        local SELECTEDAPPS
+    local SELECTEDAPPS
+    if [[ ${CI:-} == true ]] && [[ ${TRAVIS:-} == true ]]; then
+        SELECTEDAPPS="Cancel"
+    else
         SELECTEDAPPS=$(whiptail --fb --clear --title "DockSTARTer" --separate-output --checklist 'Choose which apps you would like to install:\n Use [up], [down], and [space] to select apps, and [tab] to switch to the buttons at the bottom.' 0 0 0 "${APPLIST[@]}" 3>&1 1>&2 2>&3 || echo "Cancel")
-        if [[ ${SELECTEDAPPS} == "Cancel" ]]; then
-            return 1
-        else
-            info "Disabling all apps."
-            while IFS= read -r line; do
-                local APPNAME
-                APPNAME=${line%%_ENABLED=true}
-                run_script 'env_set' "${APPNAME}_ENABLED" false
-            done < <(grep '_ENABLED=true$' < "${SCRIPTPATH}/compose/.env")
-            info "Enabling selected apps."
-            while IFS= read -r line; do
-                local APPNAME
-                APPNAME=${line^^}
-                run_script 'env_set' "${APPNAME}_ENABLED" true
-            done < <(echo "${SELECTEDAPPS}")
-        fi
+    fi
+    if [[ ${SELECTEDAPPS} == "Cancel" ]]; then
+        return 1
+    else
+        info "Disabling all apps."
+        while IFS= read -r line; do
+            local APPNAME
+            APPNAME=${line%%_ENABLED=true}
+            run_script 'env_set' "${APPNAME}_ENABLED" false
+        done < <(grep '_ENABLED=true$' < "${SCRIPTPATH}/compose/.env")
+        info "Enabling selected apps."
+        while IFS= read -r line; do
+            local APPNAME
+            APPNAME=${line^^}
+            run_script 'env_set' "${APPNAME}_ENABLED" true
+        done < <(echo "${SELECTEDAPPS}")
     fi
 }

--- a/.scripts/menu_app_vars.sh
+++ b/.scripts/menu_app_vars.sh
@@ -7,20 +7,19 @@ menu_app_vars() {
     APPNAME=${1:-}
     local APPVARS
     APPVARS=$(grep -v "^${APPNAME}_ENABLED=" "${SCRIPTPATH}/compose/.env" | grep "^${APPNAME}_")
-
     if [[ -z ${APPVARS} ]]; then
-        whiptail --fb --clear --title "DockSTARTer" --msgbox "${APPNAME} has no variables to configure." 0 0
+        if [[ ${CI:-} == true ]] && [[ ${TRAVIS:-} == true ]]; then
+            warning "${APPNAME} has no variables to configure."
+        else
+            whiptail --fb --clear --title "DockSTARTer" --msgbox "${APPNAME} has no variables to configure." 0 0
+        fi
         return
     fi
 
-    local ANSWER
-    set +e
-    ANSWER=$(
-        whiptail --fb --clear --title "DockSTARTer" --yesno "Would you like to keep these settings for ${APPNAME}?\\n\\n${APPVARS}" 0 0 3>&1 1>&2 2>&3
-        echo $?
-    )
-    set -e
-    if [[ ${ANSWER} != 0 ]]; then
+    if run_script 'question_prompt' GUI Y "Would you like to keep these settings for ${APPNAME}?\\n\\n${APPVARS}"; then
+        info "Keeping ${APPNAME} .env variables."
+    else
+        info "Configuring ${APPNAME} .env variables."
         while IFS= read -r line; do
             SET_VAR=${line%%=*}
             run_script 'menu_value_prompt' "${SET_VAR}" || return 1

--- a/.scripts/menu_backup.sh
+++ b/.scripts/menu_backup.sh
@@ -3,17 +3,21 @@ set -euo pipefail
 IFS=$'\n\t'
 
 menu_backup() {
-    local CONFIGOPTS
-    CONFIGOPTS=()
-    CONFIGOPTS+=("Settings " "Configure backup settings")
-    CONFIGOPTS+=("MIN " "Backup your .env")
-    CONFIGOPTS+=("MED " "Backup configs for enabled apps")
-    CONFIGOPTS+=("MAX " "Backup all configs, stop/start running apps during backups")
+    local BACKUPOPTS
+    BACKUPOPTS=()
+    BACKUPOPTS+=("Settings " "Configure backup settings")
+    BACKUPOPTS+=("MIN " "Backup your .env")
+    BACKUPOPTS+=("MED " "Backup configs for enabled apps")
+    BACKUPOPTS+=("MAX " "Backup all configs, stop/start running apps during backups")
 
-    local CONFIGCHOICE
-    CONFIGCHOICE=$(whiptail --fb --clear --title "DockSTARTer" --menu "What would you like to do?" 0 0 0 "${CONFIGOPTS[@]}" 3>&1 1>&2 2>&3 || echo "Cancel")
+    local BACKUPCHOICE
+    if [[ ${CI:-} == true ]] && [[ ${TRAVIS:-} == true ]]; then
+        BACKUPCHOICE="Cancel"
+    else
+        BACKUPCHOICE=$(whiptail --fb --clear --title "DockSTARTer" --menu "What would you like to do?" 0 0 0 "${BACKUPOPTS[@]}" 3>&1 1>&2 2>&3 || echo "Cancel")
+    fi
 
-    case "${CONFIGCHOICE}" in
+    case "${BACKUPCHOICE}" in
         "Settings ")
             run_script 'menu_app_vars' BACKUP
             ;;

--- a/.scripts/menu_config.sh
+++ b/.scripts/menu_config.sh
@@ -12,41 +12,45 @@ menu_config() {
     CONFIGOPTS+=("Set Global Variables " "")
 
     local CONFIGCHOICE
-    CONFIGCHOICE=$(whiptail --fb --clear --title "DockSTARTer" --menu "What would you like to do?" 0 0 0 "${CONFIGOPTS[@]}" 3>&1 1>&2 2>&3 || echo "Cancel")
+    if [[ ${CI:-} == true ]] && [[ ${TRAVIS:-} == true ]]; then
+        CONFIGCHOICE="Cancel"
+    else
+        CONFIGCHOICE=$(whiptail --fb --clear --title "DockSTARTer" --menu "What would you like to do?" 0 0 0 "${CONFIGOPTS[@]}" 3>&1 1>&2 2>&3 || echo "Cancel")
+    fi
 
     case "${CONFIGCHOICE}" in
         "Full Setup ")
             run_script 'env_update'
             run_script 'menu_app_select'
             run_script 'config_apps'
-            run_script 'config_vpn'
-            run_script 'config_globals'
+            run_script 'config_vpn' "${INTERFACE:-false}"
+            run_script 'config_global' "${INTERFACE:-false}"
             run_script 'generate_yml'
-            run_script 'run_compose'
+            run_script 'run_compose' "${INTERFACE:-false}"
             ;;
         "Select Apps ")
             run_script 'env_update'
             run_script 'menu_app_select'
             run_script 'generate_yml'
-            run_script 'run_compose'
+            run_script 'run_compose' "${INTERFACE:-false}"
             ;;
         "Set App Variables ")
             run_script 'env_update'
             run_script 'config_apps'
             run_script 'generate_yml'
-            run_script 'run_compose'
+            run_script 'run_compose' "${INTERFACE:-false}"
             ;;
         "Set VPN Variables ")
             run_script 'env_update'
-            run_script 'config_vpn'
+            run_script 'config_vpn' "${INTERFACE:-false}"
             run_script 'generate_yml'
-            run_script 'run_compose'
+            run_script 'run_compose' "${INTERFACE:-false}"
             ;;
         "Set Global Variables ")
             run_script 'env_update'
-            run_script 'config_globals'
+            run_script 'config_global' "${INTERFACE:-false}"
             run_script 'generate_yml'
-            run_script 'run_compose'
+            run_script 'run_compose' "${INTERFACE:-false}"
             ;;
         "Cancel")
             info "Returning to Main Menu."

--- a/.scripts/menu_main.sh
+++ b/.scripts/menu_main.sh
@@ -12,7 +12,11 @@ menu_main() {
     MAINOPTS+=("Prune Docker System " "Remove all unused containers, networks, volumes, images and build cache")
 
     local MAINCHOICE
-    MAINCHOICE=$(whiptail --fb --clear --title "DockSTARTer" --cancel-button "Exit" --menu "What would you like to do?" 0 0 0 "${MAINOPTS[@]}" 3>&1 1>&2 2>&3 || echo "Cancel")
+    if [[ ${CI:-} == true ]] && [[ ${TRAVIS:-} == true ]]; then
+        MAINCHOICE="Cancel"
+    else
+        MAINCHOICE=$(whiptail --fb --clear --title "DockSTARTer" --cancel-button "Exit" --menu "What would you like to do?" 0 0 0 "${MAINOPTS[@]}" 3>&1 1>&2 2>&3 || echo "Cancel")
+    fi
 
     case "${MAINCHOICE}" in
         "Configuration ")
@@ -22,13 +26,13 @@ menu_main() {
             run_script 'run_install' || run_script 'menu_main'
             ;;
         "Update DockSTARTer ")
-            run_script 'update_self' || run_script 'menu_main'
+            run_script 'update_self' "${INTERFACE:-false}" || run_script 'menu_main'
             ;;
         "Backup Configs ")
             run_script 'menu_backup' || run_script 'menu_main'
             ;;
         "Prune Docker System ")
-            run_script 'prune_docker' || run_script 'menu_main'
+            run_script 'prune_docker' "${INTERFACE:-false}" || run_script 'menu_main'
             ;;
         "Cancel")
             info "Exiting DockSTARTer."

--- a/.scripts/menu_value_prompt.sh
+++ b/.scripts/menu_value_prompt.sh
@@ -221,14 +221,7 @@ menu_value_prompt() {
                 elif [[ ${INPUT} == ~* ]]; then
                     local CORRECTED_DIR
                     CORRECTED_DIR="${DETECTED_HOMEDIR}${INPUT#*~}"
-                    local ANSWER
-                    set +e
-                    ANSWER=$(
-                        whiptail --fb --clear --title "DockSTARTer" --yesno "Cannot use the ~ shortcut in ${SET_VAR}. Would you like to use ${CORRECTED_DIR} instead?." 0 0 3>&1 1>&2 2>&3
-                        echo $?
-                    )
-                    set -e
-                    if [[ ${ANSWER} == 0 ]]; then
+                    if run_script 'question_prompt' GUI Y "Cannot use the ~ shortcut in ${SET_VAR}. Would you like to use ${CORRECTED_DIR} instead?"; then
                         run_script 'env_set' "${SET_VAR}" "${CORRECTED_DIR}"
                         whiptail --fb --clear --title "DockSTARTer" --msgbox "Returning to the previous menu to confirm selection." 0 0
                     else
@@ -237,25 +230,11 @@ menu_value_prompt() {
                     menu_value_prompt "${SET_VAR}"
                 elif [[ -d ${INPUT} ]]; then
                     run_script 'env_set' "${SET_VAR}" "${INPUT}"
-                    local ANSWER
-                    set +e
-                    ANSWER=$(
-                        whiptail --fb --clear --title "DockSTARTer" --yesno "Would you like to set permissions on ${INPUT} ?" 0 0 3>&1 1>&2 2>&3
-                        echo $?
-                    )
-                    set -e
-                    if [[ ${ANSWER} == 0 ]]; then
+                    if run_script 'question_prompt' GUI Y "Would you like to set permissions on ${INPUT} ?"; then
                         run_script 'set_permissions' "${INPUT}" "${PUID}" "${PGID}"
                     fi
                 else
-                    local ANSWER
-                    set +e
-                    ANSWER=$(
-                        whiptail --fb --clear --title "DockSTARTer" --yesno "${INPUT} is not a valid path. Would you like to attempt to create it?" 0 0 3>&1 1>&2 2>&3
-                        echo $?
-                    )
-                    set -e
-                    if [[ ${ANSWER} == 0 ]]; then
+                    if run_script 'question_prompt' GUI Y "${INPUT} is not a valid path. Would you like to attempt to create it?"; then
                         mkdir -p "${INPUT}" || fatal "${INPUT} folder could not be created."
                         run_script 'set_permissions' "${INPUT}" "${PUID}" "${PGID}"
                         run_script 'env_set' "${SET_VAR}" "${INPUT}"
@@ -268,14 +247,7 @@ menu_value_prompt() {
                 ;;
             P[GU]ID)
                 if [[ ${INPUT} == "0" ]]; then
-                    local ANSWER
-                    set +e
-                    ANSWER=$(
-                        whiptail --fb --clear --title "DockSTARTer" --yesno "Running as root is not recommended. Would you like to select a different ID?" 0 0 3>&1 1>&2 2>&3
-                        echo $?
-                    )
-                    set -e
-                    if [[ ${ANSWER} == 0 ]]; then
+                    if run_script 'question_prompt' GUI Y "Running as root is not recommended. Would you like to select a different ID?"; then
                         menu_value_prompt "${SET_VAR}"
                     else
                         run_script 'env_set' "${SET_VAR}" "${INPUT}"

--- a/.scripts/prune_docker.sh
+++ b/.scripts/prune_docker.sh
@@ -3,42 +3,13 @@ set -euo pipefail
 IFS=$'\n\t'
 
 prune_docker() {
-    local QUESTION
-    QUESTION="Would you like to remove all unused containers, networks, volumes, images and build cache?"
-    info "${QUESTION}"
-    local YN
-    while true; do
-        if [[ ${CI:-} == true ]] && [[ ${TRAVIS:-} == true ]]; then
-            info "Travis will not run this."
-            return
-        elif [[ ${PROMPT:-} == "menu" ]]; then
-            local ANSWER
-            set +e
-            ANSWER=$(
-                whiptail --fb --clear --title "DockSTARTer" --yesno "${QUESTION}" 0 0 3>&1 1>&2 2>&3
-                echo $?
-            )
-            set -e
-            if [[ ${ANSWER} == 0 ]]; then
-                YN=Y
-            else
-                YN=N
-            fi
-        else
-            read -rp "[Yn]" YN
-        fi
-        case ${YN} in
-            [Yy]*)
-                docker system prune -a --volumes --force || error "Failed to prune unused docker resources."
-                break
-                ;;
-            [Nn]*)
-                info "Nothing will be removed."
-                return 1
-                ;;
-            *)
-                error "Please answer yes or no."
-                ;;
-        esac
-    done
+    local PROMPT
+    PROMPT=${1:-false}
+    if run_script 'question_prompt' "${PROMPT}" Y "Would you like to remove all unused containers, networks, volumes, images and build cache?"; then
+        info "Removing unused docker resources."
+    else
+        info "Nothing will be removed."
+        return 1
+    fi
+    docker system prune -a --volumes --force || error "Failed to remove unused docker resources."
 }

--- a/.scripts/question_prompt.sh
+++ b/.scripts/question_prompt.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+question_prompt() {
+    local PROMPT
+    PROMPT=${1:-false}
+    local DEFAULT
+    DEFAULT=${2:-Y}
+    local QUESTION
+    QUESTION=${3:-}
+    local YN
+    while true; do
+        if [[ ${PROMPT} == "CLI" ]]; then
+            info "${QUESTION}"
+            read -rp "[Yn]" YN
+        elif [[ ${PROMPT} == "GUI" ]]; then
+            local WHIPTAIL_DEFAULT
+            if [[ ${DEFAULT} == "N" ]]; then
+                WHIPTAIL_DEFAULT=" --defaultno "
+            fi
+            local ANSWER
+            set +e
+            ANSWER=$(
+                eval whiptail --fb --clear --title "DockSTARTer" "${WHIPTAIL_DEFAULT:-}" --yesno \""${QUESTION}"\" 0 0 3>&1 1>&2 2>&3
+                echo $?
+            )
+            set -e
+            if [[ ${ANSWER} == 0 ]]; then
+                YN=Y
+            else
+                YN=N
+            fi
+        else
+            YN=${DEFAULT}
+        fi
+        case ${YN} in
+            [Yy]*)
+                break
+                ;;
+            [Nn]*)
+                return 1
+                ;;
+            *)
+                error "Please answer yes or no."
+                ;;
+        esac
+    done
+}

--- a/.scripts/request_reboot.sh
+++ b/.scripts/request_reboot.sh
@@ -3,45 +3,9 @@ set -euo pipefail
 IFS=$'\n\t'
 
 request_reboot() {
-    local QUESTION
-    QUESTION="Your system needs to reboot for changes to take effect. Would you like to reboot now?"
-    info "${QUESTION}"
-    local YN
-    while true; do
-        if [[ ${CI:-} == true ]] && [[ ${TRAVIS:-} == true ]]; then
-            info "Travis will not run this."
-            return
-        elif [[ ${PROMPT:-} == "menu" ]]; then
-            local ANSWER
-            set +e
-            ANSWER=$(
-                whiptail --fb --clear --title "DockSTARTer" --yesno "${QUESTION}" 0 0 3>&1 1>&2 2>&3
-                echo $?
-            )
-            set -e
-            if [[ ${ANSWER} == 0 ]]; then
-                YN=Y
-            else
-                YN=N
-            fi
-        else
-            read -rp "[Yn]" YN
-        fi
-        case ${YN} in
-            [Yy]*)
-                sudo reboot || error "Failed to reboot!"
-                break
-                ;;
-            [Nn]*)
-                info "Your system will not reboot."
-                warning "If this is your first run the installation will fail."
-                warning "Please run the installation again and choose Yes to reboot at the end."
-                info "If this is not your first run you may disregard this message."
-                return 1
-                ;;
-            *)
-                error "Please answer yes or no."
-                ;;
-        esac
-    done
+    info "Your system may need to reboot for changes to take effect."
+    info "Please run ${YLW}sudo reboot${NC} manually."
+    warning "If this is your first run reboot is required."
+    warning "Failure to reboot on first run can cause errors with other operations."
+    info "If this is not your first run you may disregard this message."
 }

--- a/.scripts/run_compose.sh
+++ b/.scripts/run_compose.sh
@@ -3,79 +3,43 @@ set -euo pipefail
 IFS=$'\n\t'
 
 run_compose() {
+    local PROMPT
+    PROMPT=${1:-false}
+    local COMMAND
+    COMMAND=${2:-}
     local COMPOSECOMMAND
-    COMPOSECOMMAND=${1:-}
-    local FORCE
-    local QUESTION
-    case ${COMPOSECOMMAND} in
+    local COMMANDINFO
+    case ${COMMAND} in
         down)
             COMPOSECOMMAND="down --remove-orphans"
-            FORCE=Y
-            QUESTION="Stoping and removing containers, networks, volumes, and images created by DockSTARTer."
+            COMMANDINFO="Stoping and removing containers, networks, volumes, and images created by DockSTARTer."
             ;;
         pull)
             COMPOSECOMMAND="pull --include-deps"
-            FORCE=Y
-            QUESTION="Pulling the latest images for all enabled services."
+            COMMANDINFO="Pulling the latest images for all enabled services."
             ;;
         restart)
             COMPOSECOMMAND="restart"
-            FORCE=Y
-            QUESTION="Restarting all stopped and running services."
+            COMMANDINFO="Restarting all stopped and running services."
             ;;
         up)
             COMPOSECOMMAND="up -d --remove-orphans"
-            FORCE=Y
-            QUESTION="Creating containers for all enabled services."
+            COMMANDINFO="Creating containers for all enabled services."
             ;;
         *)
             COMPOSECOMMAND="up -d --remove-orphans"
-            FORCE=N
-            QUESTION="Would you like to create containers for all enabled services now?"
+            COMMANDINFO="Creating containers for all enabled services."
             ;;
     esac
-    info "${QUESTION}"
-    local YN
-    while true; do
-        if [[ ${FORCE} != "Y" ]]; then
-            if [[ ${CI:-} == true ]] && [[ ${TRAVIS:-} == true ]]; then
-                info "Travis will not run this."
-                return
-            elif [[ ${PROMPT:-} == "menu" ]]; then
-                local ANSWER
-                set +e
-                ANSWER=$(
-                    whiptail --fb --clear --title "DockSTARTer" --yesno "${QUESTION}" 0 0 3>&1 1>&2 2>&3
-                    echo $?
-                )
-                set -e
-                if [[ ${ANSWER} == 0 ]]; then
-                    YN=Y
-                else
-                    YN=N
-                fi
-            else
-                read -rp "[Yn]" YN
-            fi
-        else
-            YN=Y
-        fi
-        case ${YN} in
-            [Yy]*)
-                run_script 'install_docker'
-                run_script 'install_compose'
-                cd "${SCRIPTPATH}/compose/" || fatal "Failed to change directory to ${SCRIPTPATH}/compose/"
-                su "${DETECTED_UNAME}" -c "docker-compose ${COMPOSECOMMAND}" || fatal "Docker Compose failed."
-                cd "${SCRIPTPATH}" || fatal "Failed to change directory to ${SCRIPTPATH}"
-                break
-                ;;
-            [Nn]*)
-                info "Compose will not be run."
-                return 1
-                ;;
-            *)
-                error "Please answer yes or no."
-                ;;
-        esac
-    done
+    if run_script 'question_prompt' "${PROMPT}" Y "Would you like to run compose now?"; then
+        info "${COMMANDINFO}"
+    else
+        info "Compose will not be run."
+        return 1
+    fi
+    run_script 'install_docker'
+    run_script 'install_compose'
+    cd "${SCRIPTPATH}/compose/" || fatal "Failed to change directory to ${SCRIPTPATH}/compose/"
+    su "${DETECTED_UNAME}" -c "docker-compose ${COMPOSECOMMAND}" || fatal "Docker Compose failed."
+    cd "${SCRIPTPATH}" || fatal "Failed to change directory to ${SCRIPTPATH}"
 }

--- a/.scripts/run_install.sh
+++ b/.scripts/run_install.sh
@@ -12,5 +12,5 @@ run_install() {
     run_script 'install_compose_completion'
     run_script 'install_yq' force
     run_script 'set_permissions'
-    run_script 'request_reboot' || return 1
+    run_script 'request_reboot'
 }

--- a/.scripts/update_self.sh
+++ b/.scripts/update_self.sh
@@ -3,51 +3,21 @@ set -euo pipefail
 IFS=$'\n\t'
 
 update_self() {
+    local PROMPT
+    PROMPT=${1:-false}
     local BRANCH
-    BRANCH=${1:-origin/master}
-    local QUESTION
-    QUESTION="Would you like to update DockSTARTer to ${BRANCH} now?"
-    info "${QUESTION}"
-    local YN
-    while true; do
-        if [[ ${CI:-} == true ]] && [[ ${TRAVIS:-} == true ]]; then
-            info "Travis will not run this."
-            return
-        elif [[ ${PROMPT:-} == "menu" ]]; then
-            local ANSWER
-            set +e
-            ANSWER=$(
-                whiptail --fb --clear --title "DockSTARTer" --yesno "${QUESTION}" 0 0 3>&1 1>&2 2>&3
-                echo $?
-            )
-            set -e
-            if [[ ${ANSWER} == 0 ]]; then
-                YN=Y
-            else
-                YN=N
-            fi
-        else
-            read -rp "[Yn]" YN
-        fi
-        case ${YN} in
-            [Yy]*)
-                info "Updating DockSTARTer."
-                cd "${SCRIPTPATH}" || fatal "Failed to change to ${SCRIPTPATH} directory."
-                git fetch > /dev/null 2>&1 || fatal "Failed to fetch recent changes from git."
-                git reset --hard "${BRANCH}" > /dev/null 2>&1 || fatal "Failed to reset to ${BRANCH}."
-                git pull > /dev/null 2>&1 || fatal "Failed to pull recent changes from git."
-                git for-each-ref --format '%(refname:short)' refs/heads | grep -v master | xargs git branch -D > /dev/null 2>&1 || true
-                chmod +x "${SCRIPTNAME}" > /dev/null 2>&1 || fatal "ds must be executable."
-                run_script 'env_update'
-                break
-                ;;
-            [Nn]*)
-                info "DockSTARTer will not be updated."
-                return 1
-                ;;
-            *)
-                error "Please answer yes or no."
-                ;;
-        esac
-    done
+    BRANCH=${2:-origin/master}
+    if run_script 'question_prompt' "${PROMPT}" Y "Would you like to update DockSTARTer to ${BRANCH} now?"; then
+        info "Updating DockSTARTer to ${BRANCH}."
+    else
+        info "DockSTARTer will not be updated to ${BRANCH}."
+        return 1
+    fi
+    cd "${SCRIPTPATH}" || fatal "Failed to change to ${SCRIPTPATH} directory."
+    git fetch > /dev/null 2>&1 || fatal "Failed to fetch recent changes from git."
+    git reset --hard "${BRANCH}" > /dev/null 2>&1 || fatal "Failed to reset to ${BRANCH}."
+    git pull > /dev/null 2>&1 || fatal "Failed to pull recent changes from git."
+    git for-each-ref --format '%(refname:short)' refs/heads | grep -v master | xargs git branch -D > /dev/null 2>&1 || true
+    chmod +x "${SCRIPTNAME}" > /dev/null 2>&1 || fatal "ds must be executable."
+    run_script 'env_update'
 }

--- a/.tests/run_generate_slim.sh
+++ b/.tests/run_generate_slim.sh
@@ -8,8 +8,6 @@ run_generate_slim() {
     bash "${SCRIPTPATH}/main.sh" -c
     cd "${SCRIPTPATH}/compose/" || fatal "Failed to change to ${SCRIPTPATH}/compose/ directory."
     docker-compose config || fatal "Failed to validate ${SCRIPTPATH}/compose/docker-compose.yml file."
-    echo
-    docker-compose up -d --remove-orphans || fatal "Docker Compose failed."
     cd "${SCRIPTPATH}" || fatal "Failed to change to ${SCRIPTPATH} directory."
     info "Generator test complete."
 }

--- a/main.sh
+++ b/main.sh
@@ -44,7 +44,7 @@ usage() {
 readonly ARGS=("$@")
 
 # Github Token for Travis CI
-if [[ ${CI:-} == true ]] && [[ ${TRAVIS:-} == true ]] && [[ ${TRAVIS_SECURE_ENV_VARS} == true ]]; then
+if [[ ${CI:-} == true ]] && [[ ${TRAVIS:-} == true ]] && [[ ${TRAVIS_SECURE_ENV_VARS:-} == true ]]; then
     readonly GH_HEADER="Authorization: token ${GH_TOKEN}"
 fi
 
@@ -135,7 +135,7 @@ cleanup() {
     if [[ ${SCRIPTPATH} == "${DETECTED_HOMEDIR}/.docker" ]]; then
         chmod +x "${SCRIPTNAME}" > /dev/null 2>&1 || fatal "ds must be executable."
     fi
-    if [[ ${CI:-} == true ]] && [[ ${TRAVIS:-} == true ]] && [[ ${TRAVIS_SECURE_ENV_VARS} == false ]]; then
+    if [[ ${CI:-} == true ]] && [[ ${TRAVIS:-} == true ]] && [[ ${TRAVIS_SECURE_ENV_VARS:-} == false ]]; then
         warning "TRAVIS_SECURE_ENV_VARS is false for Pull Requests from remote branches. Please retry failed builds!"
     fi
 }
@@ -176,7 +176,7 @@ main() {
     # shellcheck source=/dev/null
     source "${SCRIPTPATH}/.scripts/cmdline.sh"
     cmdline "${ARGS[@]:-}"
-    readonly PROMPT="menu"
+    readonly INTERFACE="GUI"
     run_script 'menu_main'
 }
 main


### PR DESCRIPTION
## Purpose

This closes #382 
Default to not prompt for most things
Use sane default for opting into prompts as needed
Remove the actual reboot code and instruct the user to manually reboot

## Approach

Create a standard question prompt function since we're reusing that logic a lot. Allow the question prompt function to prompt as CLI or GUI (although we currently do not have any need for CLI prompts, keeping the option for the future). Get rid of the code that performs a reboot and replace it with information requesting that the user perform the reboot manually along with a warning stating the importance of a reboot on first run.

Edit: I've also added a significant rework of any place we used a `yesno` with `whiptail` so that it all uses the same standard code. There's also some minor renaming to ensure that naming conventions are proper (slipped by me in the past). Also Travis runs fine with the built in compose code so we no longer run compose commands separately in the test script (we just allow the test script to run compose through ds).

In the future we may want to look into getting rid of `INTERFACE` and `PROMPT` code and just define it once for the whole script rather than individually for each function. We had done this in the past but undone it with this PR for now just to get this moving. There's no functional reason to have to get rid of it, just a personal preference on my part.

#### Open Questions and Pre-Merge TODOs

- [x] Testing

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
