### PR TITLE
Use better version checking

### DIFF
--- a/.scripts/install_compose.sh
+++ b/.scripts/install_compose.sh
@@ -7,10 +7,10 @@ install_compose() {
     local AVAILABLE_COMPOSE
     AVAILABLE_COMPOSE=$(curl -H "${GH_HEADER:-}" -s "https://api.github.com/repos/docker/compose/releases/latest" | grep -Po '"tag_name": "[Vv]?\K.*?(?=")') || fatal "Failed to check latest available docker-compose version."
     local INSTALLED_COMPOSE
-    INSTALLED_COMPOSE=$( (docker-compose --version 2> /dev/null || true) | sed -E 's/.* version ([^,]*)(, build .*)?/\1/')
+    INSTALLED_COMPOSE=$( (docker-compose --version 2> /dev/null || echo "0") | sed -E 's/.* version ([^,]*)(, build .*)?/\1/')
     local FORCE
     FORCE=${1:-}
-    if [[ ${AVAILABLE_COMPOSE} != "${INSTALLED_COMPOSE}" ]] || [[ -n ${FORCE} ]]; then
+    if vergt "${AVAILABLE_COMPOSE}" "${INSTALLED_COMPOSE}" || [[ -n ${FORCE} ]]; then
         info "Removing old docker-compose."
         rm /usr/local/bin/docker-compose > /dev/null 2>&1 || true
         rm /usr/bin/docker-compose > /dev/null 2>&1 || true
@@ -22,8 +22,8 @@ install_compose() {
         pip install -IUq docker-compose > /dev/null 2>&1 || fatal "Failed to install docker-compose from pip."
 
         local UPDATED_COMPOSE
-        UPDATED_COMPOSE=$( (docker-compose --version 2> /dev/null || true) | sed -E 's/.* version ([^,]*)(, build .*)?/\1/')
-        if [[ ${AVAILABLE_COMPOSE} != "${UPDATED_COMPOSE}" ]]; then
+        UPDATED_COMPOSE=$( (docker-compose --version 2> /dev/null || echo "0") | sed -E 's/.* version ([^,]*)(, build .*)?/\1/')
+        if vergt "${AVAILABLE_COMPOSE}" "${UPDATED_COMPOSE}"; then
             fatal "Failed to install the latest docker-compose."
         fi
     fi

--- a/.scripts/install_docker.sh
+++ b/.scripts/install_docker.sh
@@ -7,10 +7,10 @@ install_docker() {
     local AVAILABLE_DOCKER
     AVAILABLE_DOCKER=$(curl -H "${GH_HEADER:-}" -s "https://api.github.com/repos/docker/docker-ce/releases/latest" | grep -Po '"tag_name": "[Vv]?\K.*?(?=")') || fatal "Failed to check latest available docker version."
     local INSTALLED_DOCKER
-    INSTALLED_DOCKER=$( (docker --version 2> /dev/null || true) | sed -E 's/.* version ([^,]*)(, build .*)?/\1/')
+    INSTALLED_DOCKER=$( (docker --version 2> /dev/null || echo "0") | sed -E 's/.* version ([^,]*)(, build .*)?/\1/')
     local FORCE
     FORCE=${1:-}
-    if [[ ${AVAILABLE_DOCKER} != "${INSTALLED_DOCKER}" ]] || [[ -n ${FORCE} ]]; then
+    if vergt "${AVAILABLE_DOCKER}" "${INSTALLED_DOCKER}" || [[ -n ${FORCE} ]]; then
         if [[ -n "$(command -v snap)" ]]; then
             info "Removing snap Docker package."
             snap remove docker > /dev/null 2>&1 || true
@@ -18,8 +18,8 @@ install_docker() {
         info "Installing latest docker. Please be patient, this can take a while."
         curl -fsSL get.docker.com | sh > /dev/null 2>&1 || fatal "Failed to install docker."
         local UPDATED_DOCKER
-        UPDATED_DOCKER=$( (docker --version 2> /dev/null || true) | sed -E 's/.* version ([^,]*)(, build .*)?/\1/')
-        if [[ ${AVAILABLE_DOCKER} != "${UPDATED_DOCKER}" ]]; then
+        UPDATED_DOCKER=$( (docker --version 2> /dev/null || echo "0") | sed -E 's/.* version ([^,]*)(, build .*)?/\1/')
+        if vergt "${AVAILABLE_DOCKER}" "${UPDATED_DOCKER}"; then
             #TODO: Better detection of most recently available version is required before this can be used.
             echo # placeholder
             #fatal "Failed to install the latest docker."

--- a/.scripts/install_yq.sh
+++ b/.scripts/install_yq.sh
@@ -7,10 +7,10 @@ install_yq() {
     local AVAILABLE_YQ
     AVAILABLE_YQ=$(curl -H "${GH_HEADER:-}" -s "https://api.github.com/repos/mikefarah/yq/releases/latest" | grep -Po '"tag_name": "[Vv]?\K.*?(?=")') || fatal "Failed to check latest available yq version."
     local INSTALLED_YQ
-    INSTALLED_YQ=$( (yq --version 2> /dev/null || true) | sed -E 's/.* version ([^,]*)(, build .*)?/\1/')
+    INSTALLED_YQ=$( (yq --version 2> /dev/null || echo "0") | sed -E 's/.* version ([^,]*)(, build .*)?/\1/')
     local FORCE
     FORCE=${1:-}
-    if [[ ${AVAILABLE_YQ} != "${INSTALLED_YQ}" ]] || [[ -n ${FORCE} ]]; then
+    if vergt "${AVAILABLE_YQ}" "${INSTALLED_YQ}" || [[ -n ${FORCE} ]]; then
         info "Installing latest yq."
         if [[ ${ARCH} == "aarch64" ]] || [[ ${ARCH} == "armv7l" ]]; then
             curl -H "${GH_HEADER:-}" -L "https://github.com/mikefarah/yq/releases/download/${AVAILABLE_YQ}/yq_linux_arm" -o /usr/local/bin/yq > /dev/null 2>&1 || fatal "Failed to install yq."
@@ -23,8 +23,8 @@ install_yq() {
         fi
         chmod +x /usr/local/bin/yq > /dev/null 2>&1 || true
         local UPDATED_YQ
-        UPDATED_YQ=$( (yq --version 2> /dev/null || true) | sed -E 's/.* version ([^,]*)(, build .*)?/\1/')
-        if [[ ${AVAILABLE_YQ} != "${UPDATED_YQ}" ]]; then
+        UPDATED_YQ=$( (yq --version 2> /dev/null || echo "0") | sed -E 's/.* version ([^,]*)(, build .*)?/\1/')
+        if vergt "${AVAILABLE_YQ}" "${UPDATED_YQ}"; then
             fatal "Failed to install the latest yq."
         fi
     fi

--- a/main.sh
+++ b/main.sh
@@ -90,6 +90,13 @@ fatal() {
     exit 1
 }
 
+# Root Check
+root_check() {
+    if [[ ${DETECTED_PUID} == "0" ]] || [[ ${DETECTED_HOMEDIR} == "/root" ]]; then
+        fatal "Running as root is not supported. Please run as a standard user with sudo."
+    fi
+}
+
 # Script Runner Function
 run_script() {
     local SCRIPTSNAME="${1:-}"
@@ -116,12 +123,12 @@ run_test() {
     fi
 }
 
-# Root Check
-root_check() {
-    if [[ ${DETECTED_PUID} == "0" ]] || [[ ${DETECTED_HOMEDIR} == "/root" ]]; then
-        fatal "Running as root is not supported. Please run as a standard user with sudo."
-    fi
-}
+# Version functions
+# https://stackoverflow.com/questions/4023830/how-to-compare-two-strings-in-dot-separated-version-format-in-bash#comment92693604_4024263
+vergte() { printf '%s\n%s' "${2}" "${1}" | sort -C -V; }
+vergt() { ! verlte "${1}" "${2}"; }
+verlte() { printf '%s\n%s' "${1}" "${2}" | sort -C -V; }
+verlt() { ! verlte "${2}" "${1}"; }
 
 # Cleanup Function
 cleanup() {


### PR DESCRIPTION
## Purpose

This closes #575 

## Approach

Add version comparing functions to the main script since there are multiple of them and using `run_script` doesn't make sense (would require multiple files). Only perform installs/upgrades if the available version is greater than the installed version (or forced install/upgrade)

#### Learning

https://stackoverflow.com/questions/4023830/how-to-compare-two-strings-in-dot-separated-version-format-in-bash#comment92693604_4024263

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
