### PR TITLE
Remove use of PROMPT and INTERFACE variable wherever possible

### DIFF
--- a/.scripts/cmdline.sh
+++ b/.scripts/cmdline.sh
@@ -54,22 +54,22 @@ cmdline() {
             c)
                 case ${OPTARG} in
                     down)
-                        run_script 'run_compose' "${INTERFACE:-false}" down
+                        run_script 'run_compose' down
                         ;;
                     generate)
                         run_script 'generate_yml'
                         ;;
                     pull)
                         run_script 'generate_yml'
-                        run_script 'run_compose' "${INTERFACE:-false}" pull
+                        run_script 'run_compose' pull
                         ;;
                     restart)
                         run_script 'generate_yml'
-                        run_script 'run_compose' "${INTERFACE:-false}" restart
+                        run_script 'run_compose' restart
                         ;;
                     up)
                         run_script 'generate_yml'
-                        run_script 'run_compose' "${INTERFACE:-false}" up
+                        run_script 'run_compose' up
                         ;;
                     *)
                         fatal "Invalid compose option."
@@ -90,7 +90,7 @@ cmdline() {
                 exit
                 ;;
             p)
-                run_script 'prune_docker' "${INTERFACE:-false}"
+                run_script 'prune_docker'
                 exit
                 ;;
             t)
@@ -98,7 +98,7 @@ cmdline() {
                 exit
                 ;;
             u)
-                run_script 'update_self' "${INTERFACE:-false}" "${OPTARG}"
+                run_script 'update_self' "${OPTARG}"
                 exit
                 ;;
             v)
@@ -112,10 +112,10 @@ cmdline() {
                 case ${OPTARG} in
                     c)
                         run_script 'generate_yml'
-                        run_script 'run_compose' "${INTERFACE:-false}"
+                        run_script 'run_compose'
                         ;;
                     u)
-                        run_script 'update_self' "${INTERFACE:-false}"
+                        run_script 'update_self'
                         ;;
                     *)
                         fatal "${OPTARG} requires an option."

--- a/.scripts/config_global.sh
+++ b/.scripts/config_global.sh
@@ -3,8 +3,6 @@ set -euo pipefail
 IFS=$'\n\t'
 
 config_global() {
-    local PROMPT
-    PROMPT=${1:-false}
     local APPNAME
     APPNAME="Global"
     local VARNAMES
@@ -12,7 +10,7 @@ config_global() {
     local APPVARS
     APPVARS=$(for v in "${VARNAMES[@]}"; do echo "${v}=$(run_script 'env_get' "${v}")"; done)
 
-    if run_script 'question_prompt' "${PROMPT}" N "Would you like to keep these settings for ${APPNAME}?\\n\\n${APPVARS}"; then
+    if run_script 'question_prompt' N "Would you like to keep these settings for ${APPNAME}?\\n\\n${APPVARS}"; then
         info "Keeping ${APPNAME} .env variables."
     else
         info "Configuring ${APPNAME} .env variables."

--- a/.scripts/config_vpn.sh
+++ b/.scripts/config_vpn.sh
@@ -3,8 +3,6 @@ set -euo pipefail
 IFS=$'\n\t'
 
 config_vpn() {
-    local PROMPT
-    PROMPT=${1:-false}
     local APPNAME
     APPNAME="VPN"
     local VARNAMES
@@ -22,7 +20,7 @@ config_vpn() {
         MESSAGE="Would you like to keep these settings for ${APPNAME}?\\n You do not have apps enabled that will use these variables.\\n\\n${APPVARS}"
     fi
 
-    if run_script 'question_prompt' "${PROMPT}" "${DEFAULT}" "${MESSAGE}"; then
+    if run_script 'question_prompt' "${DEFAULT}" "${MESSAGE}"; then
         info "Keeping ${APPNAME} .env variables."
     else
         info "Configuring ${APPNAME} .env variables."

--- a/.scripts/menu_app_vars.sh
+++ b/.scripts/menu_app_vars.sh
@@ -16,7 +16,7 @@ menu_app_vars() {
         return
     fi
 
-    if run_script 'question_prompt' GUI Y "Would you like to keep these settings for ${APPNAME}?\\n\\n${APPVARS}"; then
+    if run_script 'question_prompt' Y "Would you like to keep these settings for ${APPNAME}?\\n\\n${APPVARS}"; then
         info "Keeping ${APPNAME} .env variables."
     else
         info "Configuring ${APPNAME} .env variables."

--- a/.scripts/menu_config.sh
+++ b/.scripts/menu_config.sh
@@ -23,34 +23,34 @@ menu_config() {
             run_script 'env_update'
             run_script 'menu_app_select'
             run_script 'config_apps'
-            run_script 'config_vpn' "${INTERFACE:-false}"
-            run_script 'config_global' "${INTERFACE:-false}"
+            run_script 'config_vpn'
+            run_script 'config_global'
             run_script 'generate_yml'
-            run_script 'run_compose' "${INTERFACE:-false}"
+            run_script 'run_compose'
             ;;
         "Select Apps ")
             run_script 'env_update'
             run_script 'menu_app_select'
             run_script 'generate_yml'
-            run_script 'run_compose' "${INTERFACE:-false}"
+            run_script 'run_compose'
             ;;
         "Set App Variables ")
             run_script 'env_update'
             run_script 'config_apps'
             run_script 'generate_yml'
-            run_script 'run_compose' "${INTERFACE:-false}"
+            run_script 'run_compose'
             ;;
         "Set VPN Variables ")
             run_script 'env_update'
-            run_script 'config_vpn' "${INTERFACE:-false}"
+            run_script 'config_vpn'
             run_script 'generate_yml'
-            run_script 'run_compose' "${INTERFACE:-false}"
+            run_script 'run_compose'
             ;;
         "Set Global Variables ")
             run_script 'env_update'
-            run_script 'config_global' "${INTERFACE:-false}"
+            run_script 'config_global'
             run_script 'generate_yml'
-            run_script 'run_compose' "${INTERFACE:-false}"
+            run_script 'run_compose'
             ;;
         "Cancel")
             info "Returning to Main Menu."

--- a/.scripts/menu_main.sh
+++ b/.scripts/menu_main.sh
@@ -26,13 +26,13 @@ menu_main() {
             run_script 'run_install' || run_script 'menu_main'
             ;;
         "Update DockSTARTer ")
-            run_script 'update_self' "${INTERFACE:-false}" || run_script 'menu_main'
+            run_script 'update_self' || run_script 'menu_main'
             ;;
         "Backup Configs ")
             run_script 'menu_backup' || run_script 'menu_main'
             ;;
         "Prune Docker System ")
-            run_script 'prune_docker' "${INTERFACE:-false}" || run_script 'menu_main'
+            run_script 'prune_docker' || run_script 'menu_main'
             ;;
         "Cancel")
             info "Exiting DockSTARTer."

--- a/.scripts/menu_value_prompt.sh
+++ b/.scripts/menu_value_prompt.sh
@@ -221,7 +221,7 @@ menu_value_prompt() {
                 elif [[ ${INPUT} == ~* ]]; then
                     local CORRECTED_DIR
                     CORRECTED_DIR="${DETECTED_HOMEDIR}${INPUT#*~}"
-                    if run_script 'question_prompt' GUI Y "Cannot use the ~ shortcut in ${SET_VAR}. Would you like to use ${CORRECTED_DIR} instead?"; then
+                    if run_script 'question_prompt' Y "Cannot use the ~ shortcut in ${SET_VAR}. Would you like to use ${CORRECTED_DIR} instead?"; then
                         run_script 'env_set' "${SET_VAR}" "${CORRECTED_DIR}"
                         whiptail --fb --clear --title "DockSTARTer" --msgbox "Returning to the previous menu to confirm selection." 0 0
                     else
@@ -230,11 +230,11 @@ menu_value_prompt() {
                     menu_value_prompt "${SET_VAR}"
                 elif [[ -d ${INPUT} ]]; then
                     run_script 'env_set' "${SET_VAR}" "${INPUT}"
-                    if run_script 'question_prompt' GUI Y "Would you like to set permissions on ${INPUT} ?"; then
+                    if run_script 'question_prompt' Y "Would you like to set permissions on ${INPUT} ?"; then
                         run_script 'set_permissions' "${INPUT}" "${PUID}" "${PGID}"
                     fi
                 else
-                    if run_script 'question_prompt' GUI Y "${INPUT} is not a valid path. Would you like to attempt to create it?"; then
+                    if run_script 'question_prompt' Y "${INPUT} is not a valid path. Would you like to attempt to create it?"; then
                         mkdir -p "${INPUT}" || fatal "${INPUT} folder could not be created."
                         run_script 'set_permissions' "${INPUT}" "${PUID}" "${PGID}"
                         run_script 'env_set' "${SET_VAR}" "${INPUT}"
@@ -247,7 +247,7 @@ menu_value_prompt() {
                 ;;
             P[GU]ID)
                 if [[ ${INPUT} == "0" ]]; then
-                    if run_script 'question_prompt' GUI Y "Running as root is not recommended. Would you like to select a different ID?"; then
+                    if run_script 'question_prompt' Y "Running as root is not recommended. Would you like to select a different ID?"; then
                         menu_value_prompt "${SET_VAR}"
                     else
                         run_script 'env_set' "${SET_VAR}" "${INPUT}"

--- a/.scripts/prune_docker.sh
+++ b/.scripts/prune_docker.sh
@@ -3,9 +3,7 @@ set -euo pipefail
 IFS=$'\n\t'
 
 prune_docker() {
-    local PROMPT
-    PROMPT=${1:-false}
-    if run_script 'question_prompt' "${PROMPT}" Y "Would you like to remove all unused containers, networks, volumes, images and build cache?"; then
+    if run_script 'question_prompt' Y "Would you like to remove all unused containers, networks, volumes, images and build cache?"; then
         info "Removing unused docker resources."
     else
         info "Nothing will be removed."

--- a/.scripts/question_prompt.sh
+++ b/.scripts/question_prompt.sh
@@ -3,18 +3,16 @@ set -euo pipefail
 IFS=$'\n\t'
 
 question_prompt() {
-    local PROMPT
-    PROMPT=${1:-false}
     local DEFAULT
-    DEFAULT=${2:-Y}
+    DEFAULT=${1:-Y}
     local QUESTION
-    QUESTION=${3:-}
+    QUESTION=${2:-}
     local YN
     while true; do
-        if [[ ${PROMPT} == "CLI" ]]; then
+        if [[ ${PROMPT:-} == "CLI" ]]; then
             info "${QUESTION}"
             read -rp "[Yn]" YN
-        elif [[ ${PROMPT} == "GUI" ]]; then
+        elif [[ ${PROMPT:-} == "GUI" ]]; then
             local WHIPTAIL_DEFAULT
             if [[ ${DEFAULT} == "N" ]]; then
                 WHIPTAIL_DEFAULT=" --defaultno "

--- a/.scripts/run_compose.sh
+++ b/.scripts/run_compose.sh
@@ -3,10 +3,8 @@ set -euo pipefail
 IFS=$'\n\t'
 
 run_compose() {
-    local PROMPT
-    PROMPT=${1:-false}
     local COMMAND
-    COMMAND=${2:-}
+    COMMAND=${1:-}
     local COMPOSECOMMAND
     local COMMANDINFO
     case ${COMMAND} in
@@ -31,7 +29,7 @@ run_compose() {
             COMMANDINFO="Creating containers for all enabled services."
             ;;
     esac
-    if run_script 'question_prompt' "${PROMPT}" Y "Would you like to run compose now?"; then
+    if run_script 'question_prompt' Y "Would you like to run compose now?"; then
         info "${COMMANDINFO}"
     else
         info "Compose will not be run."

--- a/.scripts/update_self.sh
+++ b/.scripts/update_self.sh
@@ -3,11 +3,9 @@ set -euo pipefail
 IFS=$'\n\t'
 
 update_self() {
-    local PROMPT
-    PROMPT=${1:-false}
     local BRANCH
-    BRANCH=${2:-origin/master}
-    if run_script 'question_prompt' "${PROMPT}" Y "Would you like to update DockSTARTer to ${BRANCH} now?"; then
+    BRANCH=${1:-origin/master}
+    if run_script 'question_prompt' Y "Would you like to update DockSTARTer to ${BRANCH} now?"; then
         info "Updating DockSTARTer to ${BRANCH}."
     else
         info "DockSTARTer will not be updated to ${BRANCH}."

--- a/main.sh
+++ b/main.sh
@@ -176,7 +176,7 @@ main() {
     # shellcheck source=/dev/null
     source "${SCRIPTPATH}/.scripts/cmdline.sh"
     cmdline "${ARGS[@]:-}"
-    readonly INTERFACE="GUI"
+    readonly PROMPT="GUI"
     run_script 'menu_main'
 }
 main


### PR DESCRIPTION
## Purpose

Follow up to #577 
I don't exactly know why I added these back in other than it seemed easy and useful, but they serve no purpose and the `readonly PROMPT="GUI"` line in main.sh can be adjusted in the future if we ever need to make use of something like `readonly PROMPT="CLI"` which is accommodated for in `question_prompt`.

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
