### PR TITLE
Use single quotes to match other conventions

### DIFF
--- a/.scripts/cmdline.sh
+++ b/.scripts/cmdline.sh
@@ -37,13 +37,13 @@ cmdline() {
             b)
                 case ${OPTARG} in
                     min)
-                        run_script "backup_min"
+                        run_script 'backup_min'
                         ;;
                     med)
-                        run_script "backup_med"
+                        run_script 'backup_med'
                         ;;
                     max)
-                        run_script "backup_max"
+                        run_script 'backup_max'
                         ;;
                     *)
                         fatal "Invalid backup option."


### PR DESCRIPTION
## Purpose

Just keeping with the conventions of the repo.

## Approach

run_script is always followed by the name of the function in single quotes unless a variable is used in which case double quotes are used.

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
