### PR TITLE
Resolve issues with Travis get_scriptname

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -59,6 +59,10 @@ get_scriptname() {
         SOURCE="$(readlink "${SOURCE}")"
         [[ ${SOURCE} != /* ]] && SOURCE="${DIR}/${SOURCE}" # if ${SOURCE} was a relative symlink, we need to resolve it relative to the path where the symlink file was located
     done
+    if [[ ${CI:-} == true ]] && [[ ${TRAVIS:-} == true ]]; then
+        echo "${TRAVIS_BUILD_DIR:-}/main.sh"
+        return
+    fi
     echo "${SOURCE}"
 }
 readonly SCRIPTNAME="$(get_scriptname)"


### PR DESCRIPTION
## Purpose

Prevent Travis from constantly redoing the symlink (and likely causing other odd behavior) by ensuring it's using the correct path.

## Approach

Use the `TRAVIS_BUILD_DIR` variable defined by Travis. As of creating this PR the variable should contain `/home/travis/build/GhostWriters/DockSTARTer/`

#### Learning

https://docs.travis-ci.com/user/environment-variables

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
