### PR TITLE
Use basename with Travis get_scriptname

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -60,7 +60,7 @@ get_scriptname() {
         [[ ${SOURCE} != /* ]] && SOURCE="${DIR}/${SOURCE}" # if ${SOURCE} was a relative symlink, we need to resolve it relative to the path where the symlink file was located
     done
     if [[ ${CI:-} == true ]] && [[ ${TRAVIS:-} == true ]]; then
-        echo "${TRAVIS_BUILD_DIR:-}/main.sh"
+        echo "${TRAVIS_BUILD_DIR:-}/$(basename "${SOURCE}")"
         return
     fi
     echo "${SOURCE}"


### PR DESCRIPTION
## Purpose

Follow up to #589 
Don't hard code `main.sh`

## Approach

Use `basename` on `${SOURCE}` which contains `./main.sh`

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
