### PR TITLE
Use multiarch Netdata images for ARM CPUs

### DIFF
--- a/compose/.apps/netdata/netdata.aarch64.yml
+++ b/compose/.apps/netdata/netdata.aarch64.yml
@@ -1,3 +1,3 @@
 services:
   netdata:
-    image: netdata/netdata:aarch64
+    image: netdata/netdata

--- a/compose/.apps/netdata/netdata.armv7l.yml
+++ b/compose/.apps/netdata/netdata.armv7l.yml
@@ -1,3 +1,3 @@
 services:
   netdata:
-    image: netdata/netdata:armhf
+    image: netdata/netdata


### PR DESCRIPTION
## Purpose

This closes #593 

## Approach

Switch to new multiarch images provided by netdata.

#### Learning

https://hub.docker.com/r/netdata/netdata/

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
