### PR TITLE
Use --all and --prune with git fetch

### DIFF
--- a/.scripts/update_self.sh
+++ b/.scripts/update_self.sh
@@ -12,7 +12,7 @@ update_self() {
         return 1
     fi
     cd "${SCRIPTPATH}" || fatal "Failed to change to ${SCRIPTPATH} directory."
-    git fetch > /dev/null 2>&1 || fatal "Failed to fetch recent changes from git."
+    git fetch --all --prune > /dev/null 2>&1 || fatal "Failed to fetch recent changes from git."
     git reset --hard "${BRANCH}" > /dev/null 2>&1 || fatal "Failed to reset to ${BRANCH}."
     git pull > /dev/null 2>&1 || fatal "Failed to pull recent changes from git."
     git for-each-ref --format '%(refname:short)' refs/heads | grep -v master | xargs git branch -D > /dev/null 2>&1 || true


### PR DESCRIPTION
## Purpose

Fetch all remotes and prune unused/merged.

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
