### PR TITLE
Remove workaround in get_scriptname for Travis

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -59,10 +59,6 @@ get_scriptname() {
         SOURCE="$(readlink "${SOURCE}")"
         [[ ${SOURCE} != /* ]] && SOURCE="${DIR}/${SOURCE}" # if ${SOURCE} was a relative symlink, we need to resolve it relative to the path where the symlink file was located
     done
-    if [[ ${CI:-} == true ]] && [[ ${TRAVIS:-} == true ]]; then
-        echo "${TRAVIS_BUILD_DIR:-}/$(basename "${SOURCE}")"
-        return
-    fi
     echo "${SOURCE}"
 }
 readonly SCRIPTPATH="$(cd -P "$(dirname "$(get_scriptname)")" > /dev/null && pwd)"


### PR DESCRIPTION
## Purpose

Follow up to #600 #589 #590 

The Travis specific code is no longer needed.

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
