### PR TITLE
Run python

### DIFF
--- a/.scripts/install_compose.sh
+++ b/.scripts/install_compose.sh
@@ -12,17 +12,17 @@ install_compose() {
     FORCE=${1:-}
     if vergt "${AVAILABLE_COMPOSE}" "${INSTALLED_COMPOSE}" || [[ -n ${FORCE} ]]; then
         info "Installing latest python pip."
-        python3 -m pip install -IUq pip > /dev/null 2>&1 || warning "Failed to install pip from pip. This can be ignored for now."
+        run_script 'run_python' -m pip install -IUq pip > /dev/null 2>&1 || warning "Failed to install pip from pip. This can be ignored for now."
 
         info "Removing old docker-compose."
         rm /usr/local/bin/docker-compose > /dev/null 2>&1 || true
         rm /usr/bin/docker-compose > /dev/null 2>&1 || true
-        python3 -m pip uninstall docker-py > /dev/null 2>&1 || true
+        run_script 'run_python' -m pip uninstall docker-py > /dev/null 2>&1 || true
 
         info "Installing latest docker-compose."
-        python3 -m pip install -IUq setuptools > /dev/null 2>&1 || warning "Failed to install setuptools from pip. This can be ignored for now."
-        python3 -m pip install -IUq "urllib3[secure]" > /dev/null 2>&1 || warning "Failed to install urllib3[secure] from pip. This can be ignored for now."
-        python3 -m pip install -IUq docker-compose > /dev/null 2>&1 || warning "Failed to install docker-compose from pip. This can be ignored for now."
+        run_script 'run_python' -m pip install -IUq setuptools > /dev/null 2>&1 || warning "Failed to install setuptools from pip. This can be ignored for now."
+        run_script 'run_python' -m pip install -IUq "urllib3[secure]" > /dev/null 2>&1 || warning "Failed to install urllib3[secure] from pip. This can be ignored for now."
+        run_script 'run_python' -m pip install -IUq docker-compose > /dev/null 2>&1 || warning "Failed to install docker-compose from pip. This can be ignored for now."
 
         local UPDATED_COMPOSE
         UPDATED_COMPOSE=$( (docker-compose --version 2> /dev/null || echo "0") | sed -E 's/.* version ([^,]*)(, build .*)?/\1/')

--- a/.scripts/install_compose.sh
+++ b/.scripts/install_compose.sh
@@ -12,17 +12,17 @@ install_compose() {
     FORCE=${1:-}
     if vergt "${AVAILABLE_COMPOSE}" "${INSTALLED_COMPOSE}" || [[ -n ${FORCE} ]]; then
         info "Installing latest python pip."
-        run_script 'run_python' -m pip install -IUq pip > /dev/null 2>&1 || warning "Failed to install pip from pip. This can be ignored for now."
+        run_script 'run_python' -m pip install -IUq pip || warning "Failed to install pip from pip. This can be ignored for now."
 
         info "Removing old docker-compose."
         rm /usr/local/bin/docker-compose > /dev/null 2>&1 || true
         rm /usr/bin/docker-compose > /dev/null 2>&1 || true
-        run_script 'run_python' -m pip uninstall docker-py > /dev/null 2>&1 || true
+        run_script 'run_python' -m pip uninstall docker-py || true
 
         info "Installing latest docker-compose."
-        run_script 'run_python' -m pip install -IUq setuptools > /dev/null 2>&1 || warning "Failed to install setuptools from pip. This can be ignored for now."
-        run_script 'run_python' -m pip install -IUq "urllib3[secure]" > /dev/null 2>&1 || warning "Failed to install urllib3[secure] from pip. This can be ignored for now."
-        run_script 'run_python' -m pip install -IUq docker-compose > /dev/null 2>&1 || warning "Failed to install docker-compose from pip. This can be ignored for now."
+        run_script 'run_python' -m pip install -IUq setuptools || warning "Failed to install setuptools from pip. This can be ignored for now."
+        run_script 'run_python' -m pip install -IUq "urllib3[secure]" || warning "Failed to install urllib3[secure] from pip. This can be ignored for now."
+        run_script 'run_python' -m pip install -IUq docker-compose || warning "Failed to install docker-compose from pip. This can be ignored for now."
 
         local UPDATED_COMPOSE
         UPDATED_COMPOSE=$( (docker-compose --version 2> /dev/null || echo "0") | sed -E 's/.* version ([^,]*)(, build .*)?/\1/')

--- a/.scripts/install_compose.sh
+++ b/.scripts/install_compose.sh
@@ -12,17 +12,17 @@ install_compose() {
     FORCE=${1:-}
     if vergt "${AVAILABLE_COMPOSE}" "${INSTALLED_COMPOSE}" || [[ -n ${FORCE} ]]; then
         info "Installing latest python pip."
-        run_script 'run_python' -m pip install -IUq pip || warning "Failed to install pip from pip. This can be ignored for now."
+        run_script 'run_python' -m pip install -IUq pip > /dev/null 2>&1 || warning "Failed to install pip from pip. This can be ignored for now."
 
         info "Removing old docker-compose."
         rm /usr/local/bin/docker-compose > /dev/null 2>&1 || true
         rm /usr/bin/docker-compose > /dev/null 2>&1 || true
-        run_script 'run_python' -m pip uninstall docker-py || true
+        run_script 'run_python' -m pip uninstall docker-py > /dev/null 2>&1 || true
 
         info "Installing latest docker-compose."
-        run_script 'run_python' -m pip install -IUq setuptools || warning "Failed to install setuptools from pip. This can be ignored for now."
-        run_script 'run_python' -m pip install -IUq "urllib3[secure]" || warning "Failed to install urllib3[secure] from pip. This can be ignored for now."
-        run_script 'run_python' -m pip install -IUq docker-compose || warning "Failed to install docker-compose from pip. This can be ignored for now."
+        run_script 'run_python' -m pip install -IUq setuptools > /dev/null 2>&1 || warning "Failed to install setuptools from pip. This can be ignored for now."
+        run_script 'run_python' -m pip install -IUq "urllib3[secure]" > /dev/null 2>&1 || warning "Failed to install urllib3[secure] from pip. This can be ignored for now."
+        run_script 'run_python' -m pip install -IUq docker-compose > /dev/null 2>&1 || warning "Failed to install docker-compose from pip. This can be ignored for now."
 
         local UPDATED_COMPOSE
         UPDATED_COMPOSE=$( (docker-compose --version 2> /dev/null || echo "0") | sed -E 's/.* version ([^,]*)(, build .*)?/\1/')

--- a/.scripts/install_docker.sh
+++ b/.scripts/install_docker.sh
@@ -18,8 +18,6 @@ install_docker() {
             return
         fi
     fi
-    local FORCE
-    FORCE=${1:-}
     if vergt "${AVAILABLE_DOCKER}" "${INSTALLED_DOCKER}" || [[ -n ${FORCE} ]]; then
         if [[ -n "$(command -v snap)" ]]; then
             info "Removing snap Docker package."

--- a/.scripts/run_python.sh
+++ b/.scripts/run_python.sh
@@ -25,5 +25,6 @@ run_python() {
 
 test_run_python() {
     run_script 'run_python' --version
+    run_script 'run_python' -m pip --version
     warning "Travis does not test run_python."
 }

--- a/.scripts/run_python.sh
+++ b/.scripts/run_python.sh
@@ -3,21 +3,24 @@ set -euo pipefail
 IFS=$'\n\t'
 
 run_python() {
+    # https://devguide.python.org/#status-of-python-branches
+    local PYTHON_CMD
     if [[ -n "$(command -v python3.7)" ]]; then
-        eval python3.7 "$@"
+        PYTHON_CMD="python3.7"
+        # EOL: 2023-06-27
     elif [[ -n "$(command -v python3.6)" ]]; then
-        eval python3.6 "$@"
+        PYTHON_CMD="python3.6"
+        # EOL: 2021-12-23
     elif [[ -n "$(command -v python3.5)" ]]; then
-        eval python3.5 "$@"
-    elif [[ -n "$(command -v python3.4)" ]]; then
-        eval python3.4 "$@"
-    elif [[ -n "$(command -v python3.3)" ]]; then
-        eval python3.3 "$@"
+        PYTHON_CMD="python3.5"
+        # EOL: 2020-09-13
     elif [[ -n "$(command -v python3)" ]]; then
-        eval python3 "$@"
+        PYTHON_CMD="python3"
     else
         fatal "Python3 manager not detected!"
     fi
+
+    eval "${PYTHON_CMD}" "$@" > /dev/null 2>&1 || return 1
 }
 
 test_run_python() {

--- a/.scripts/run_python.sh
+++ b/.scripts/run_python.sh
@@ -20,7 +20,7 @@ run_python() {
         fatal "Python3 manager not detected!"
     fi
 
-    eval "${PYTHON_CMD}" "$@" > /dev/null 2>&1 || return 1
+    eval "${PYTHON_CMD}" "$@" || return 1
 }
 
 test_run_python() {

--- a/.scripts/run_python.sh
+++ b/.scripts/run_python.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+run_python() {
+    if [[ -n "$(command -v python3.7)" ]]; then
+        eval python3.7 "$@"
+    elif [[ -n "$(command -v python3.6)" ]]; then
+        eval python3.6 "$@"
+    elif [[ -n "$(command -v python3.5)" ]]; then
+        eval python3.5 "$@"
+    elif [[ -n "$(command -v python3.4)" ]]; then
+        eval python3.4 "$@"
+    elif [[ -n "$(command -v python3.3)" ]]; then
+        eval python3.3 "$@"
+    elif [[ -n "$(command -v python3)" ]]; then
+        eval python3 "$@"
+    else
+        fatal "Python3 manager not detected!"
+    fi
+}
+
+test_run_python() {
+    run_script 'run_python' --version
+    warning "Travis does not test run_python."
+}

--- a/.scripts/run_python.sh
+++ b/.scripts/run_python.sh
@@ -26,5 +26,4 @@ run_python() {
 test_run_python() {
     run_script 'run_python' --version
     run_script 'run_python' -m pip --version
-    warning "Travis does not test run_python."
 }

--- a/.scripts/run_yum.sh
+++ b/.scripts/run_yum.sh
@@ -24,7 +24,7 @@ run_yum() {
         yum -y upgrade > /dev/null 2>&1 || fatal "Failed to upgrade packages from yum."
     fi
     info "Installing dependencies."
-    yum -y install curl git grep newt python3 python3-pip rsync sed > /dev/null 2>&1 || fatal "Failed to install dependencies from yum."
+    yum -y install curl git grep newt python36u python36u-pip rsync sed > /dev/null 2>&1 || fatal "Failed to install dependencies from yum."
     # https://cryptography.io/en/latest/installation/#building-cryptography-on-linux
     yum -y install redhat-rpm-config gcc libffi-devel python3-devel openssl-devel > /dev/null 2>&1 || fatal "Failed to install python cryptography dependencies from yum."
     info "Removing unused packages."


### PR DESCRIPTION
## Purpose

Adjust for different versions of python on different systems. #621 introduced issues with CentOS which does not symlink `python3`.

## Approach

Support all versions of python3 that are not EOL explicitly with their version number (ex: `python3.7`) as well as allowing `python3` itself to be valid as a fallback if it exists regardless of the version it may link to.

#### Open Questions and Pre-Merge TODOs

- [ ] CentOS Testing
- [x] FedoraTesting
- [ ] Raspbian Testing
- [x] Ubuntu Testing

#### Learning

https://devguide.python.org/#status-of-python-branches

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
