### PR TITLE
Utilize mktemp for docker install

### DIFF
--- a/.scripts/backup_create.sh
+++ b/.scripts/backup_create.sh
@@ -197,7 +197,8 @@ backup_create() {
 
         i=$(($(tail -100 "${LOG}" | grep 'Total transferred file size:' | cut -d " " -f5 | sed -e 's/\,//g') / 1048576))
         info "${i} MiB needed."
-        rm -rf "${LOG}" "${SNAPSHOT_DST}/${SNAPSHOT_NAME}.test-free-disk-space" || fatal "Failed to remove ${SNAPSHOT_DST}/${SNAPSHOT_NAME}.test-free-disk-space"
+        rm -rf "${SNAPSHOT_DST}/${SNAPSHOT_NAME}.test-free-disk-space" || fatal "Failed to remove ${SNAPSHOT_DST}/${SNAPSHOT_NAME}.test-free-disk-space"
+        rm -rf "${LOG}" || warning "Temporary backup log file could not be removed."
         remove_snapshot $((MIN_MIBSIZE + i)) $((MAX_MIBSIZE - i))
         if [ "${OOVERWRITE_LAST}" == "${OVERWRITE_LAST}" ]; then # no need to retry
             break

--- a/.scripts/generate_yml.sh
+++ b/.scripts/generate_yml.sh
@@ -6,8 +6,7 @@ generate_yml() {
     run_script 'env_update'
     info "Generating docker-compose.yml file."
     local RUNFILE
-    RUNFILE="${SCRIPTPATH}/compose/docker-compose.sh"
-    rm -f "${RUNFILE}" || fatal "Failed to remove ${RUNFILE} file."
+    RUNFILE="$(mktemp)"
     echo "#!/usr/bin/env bash" > "${RUNFILE}"
     {
         echo 'yq m '\\
@@ -57,9 +56,9 @@ generate_yml() {
     done < <(grep '_ENABLED=true$' < "${SCRIPTPATH}/compose/.env")
     echo "> ${SCRIPTPATH}/compose/docker-compose.yml" >> "${RUNFILE}"
     run_script 'install_yq'
-    bash "${RUNFILE}" || fatal "Failed to run generator."
+    bash "${RUNFILE}" > /dev/null 2>&1 || fatal "Failed to run generator."
     info "Merging docker-compose.yml complete."
-    rm -f "${RUNFILE}" || error "Failed to remove ${RUNFILE} file."
+    rm -f "${RUNFILE}" || warning "Temporary yml generator file could not be removed."
 }
 
 test_generate_yml() {

--- a/.scripts/generate_yml.sh
+++ b/.scripts/generate_yml.sh
@@ -57,8 +57,8 @@ generate_yml() {
     echo "> ${SCRIPTPATH}/compose/docker-compose.yml" >> "${RUNFILE}"
     run_script 'install_yq'
     bash "${RUNFILE}" > /dev/null 2>&1 || fatal "Failed to run generator."
-    info "Merging docker-compose.yml complete."
     rm -f "${RUNFILE}" || warning "Temporary yml generator file could not be removed."
+    info "Merging docker-compose.yml complete."
 }
 
 test_generate_yml() {

--- a/.scripts/install_docker.sh
+++ b/.scripts/install_docker.sh
@@ -16,7 +16,11 @@ install_docker() {
             snap remove docker > /dev/null 2>&1 || true
         fi
         info "Installing latest docker. Please be patient, this can take a while."
-        curl -fsSL get.docker.com | sh > /dev/null 2>&1 || fatal "Failed to install docker."
+        local GET_DOCKER
+        GET_DOCKER="$(mktemp)"
+        curl -fsSL get.docker.com -o "${GET_DOCKER}" > /dev/null 2>&1 || fatal "Failed to get docker install script."
+        sh "${GET_DOCKER}" > /dev/null 2>&1 || fatal "Failed to install docker."
+        rm -f "${GET_DOCKER}" || warning "Temporary get.docker.com file could not be removed."
         local UPDATED_DOCKER
         UPDATED_DOCKER=$( (docker --version 2> /dev/null || echo "0") | sed -E 's/.* version ([^,]*)(, build .*)?/\1/')
         if vergt "${AVAILABLE_DOCKER}" "${UPDATED_DOCKER}"; then


### PR DESCRIPTION
## Purpose

Stop piping to shell with docker install. Use mktemp for yml generator instead of fixed file location inside the repo. Minor tweaks for use of mktemp in other places.

## Approach

Setup mktemp files into variables wherever they are used (already being done for some things). Use the variable as the path to the file.

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
