### PR TITLE
Add standard/common directories where missing

### DIFF
--- a/compose/.apps/airdcpp/airdcpp.yml
+++ b/compose/.apps/airdcpp/airdcpp.yml
@@ -25,3 +25,4 @@ services:
       - ${DOCKERCONFDIR}/airdcpp:/.airdcpp
       - ${DOCKERSHAREDDIR}:/shared
       - ${DOWNLOADSDIR}:/Downloads
+      - ${DOWNLOADSDIR}:/downloads

--- a/compose/.apps/delugevpn/delugevpn.yml
+++ b/compose/.apps/delugevpn/delugevpn.yml
@@ -27,5 +27,6 @@ services:
       - ${DOCKERCONFDIR}/delugevpn:/config
       - ${DOCKERSHAREDDIR}:/shared
       - ${DOWNLOADSDIR}:/data
+      - ${DOWNLOADSDIR}:/downloads
     cap_add:
       - NET_ADMIN

--- a/compose/.apps/emby/emby.yml
+++ b/compose/.apps/emby/emby.yml
@@ -20,5 +20,8 @@ services:
       - ${DOCKERCONFDIR}/emby:/config
       - ${DOCKERSHAREDDIR}:/shared
       - ${MEDIADIR_MOVIES}:/data/movies
+      - ${MEDIADIR_MOVIES}:/movies
       - ${MEDIADIR_MUSIC}:/data/music
+      - ${MEDIADIR_MUSIC}:/music
       - ${MEDIADIR_TV}:/data/tv
+      - ${MEDIADIR_TV}:/tv

--- a/compose/.apps/nzbgetvpn/nzbgetvpn.yml
+++ b/compose/.apps/nzbgetvpn/nzbgetvpn.yml
@@ -26,5 +26,6 @@ services:
       - /etc/localtime:/etc/localtime:ro
       - ${DOCKERCONFDIR}/nzbgetvpn:/config
       - ${DOWNLOADSDIR}:/data
+      - ${DOWNLOADSDIR}:/downloads
     cap_add:
       - NET_ADMIN

--- a/compose/.apps/nzbgetvpn/nzbgetvpn.yml
+++ b/compose/.apps/nzbgetvpn/nzbgetvpn.yml
@@ -25,6 +25,7 @@ services:
     volumes:
       - /etc/localtime:/etc/localtime:ro
       - ${DOCKERCONFDIR}/nzbgetvpn:/config
+      - ${DOCKERSHAREDDIR}:/shared
       - ${DOWNLOADSDIR}:/data
       - ${DOWNLOADSDIR}:/downloads
     cap_add:

--- a/compose/.apps/pyload/pyload.yml
+++ b/compose/.apps/pyload/pyload.yml
@@ -19,3 +19,4 @@ services:
       - ${DOCKERCONFDIR}/pyload:/opt/pyload/pyload-config
       - ${DOCKERSHAREDDIR}:/shared
       - ${DOWNLOADSDIR}:/opt/pyload/Downloads
+      - ${DOWNLOADSDIR}:/downloads

--- a/compose/.apps/qbittorrentvpn/qbittorrentvpn.yml
+++ b/compose/.apps/qbittorrentvpn/qbittorrentvpn.yml
@@ -28,4 +28,5 @@ services:
       - ${DOCKERCONFDIR}/qbittorrentvpn:/config
       - ${DOCKERSHAREDDIR}:/shared
       - ${DOWNLOADSDIR}:/data
+      - ${DOWNLOADSDIR}:/downloads
     privileged: true

--- a/compose/.apps/rtorrentvpn/rtorrentvpn.yml
+++ b/compose/.apps/rtorrentvpn/rtorrentvpn.yml
@@ -29,5 +29,6 @@ services:
       - /etc/localtime:/etc/localtime:ro
       - ${DOCKERCONFDIR}/rtorrentvpn:/config
       - ${DOWNLOADSDIR}:/data
+      - ${DOWNLOADSDIR}:/downloads
     cap_add:
       - NET_ADMIN

--- a/compose/.apps/rtorrentvpn/rtorrentvpn.yml
+++ b/compose/.apps/rtorrentvpn/rtorrentvpn.yml
@@ -28,6 +28,7 @@ services:
     volumes:
       - /etc/localtime:/etc/localtime:ro
       - ${DOCKERCONFDIR}/rtorrentvpn:/config
+      - ${DOCKERSHAREDDIR}:/shared
       - ${DOWNLOADSDIR}:/data
       - ${DOWNLOADSDIR}:/downloads
     cap_add:

--- a/compose/.apps/sabnzbdvpn/sabnzbdvpn.yml
+++ b/compose/.apps/sabnzbdvpn/sabnzbdvpn.yml
@@ -26,5 +26,6 @@ services:
       - /etc/localtime:/etc/localtime:ro
       - ${DOCKERCONFDIR}/sabnzbdvpn:/config
       - ${DOWNLOADSDIR}:/data
+      - ${DOWNLOADSDIR}:/downloads
     cap_add:
       - NET_ADMIN

--- a/compose/.apps/sabnzbdvpn/sabnzbdvpn.yml
+++ b/compose/.apps/sabnzbdvpn/sabnzbdvpn.yml
@@ -25,6 +25,7 @@ services:
     volumes:
       - /etc/localtime:/etc/localtime:ro
       - ${DOCKERCONFDIR}/sabnzbdvpn:/config
+      - ${DOCKERSHAREDDIR}:/shared
       - ${DOWNLOADSDIR}:/data
       - ${DOWNLOADSDIR}:/downloads
     cap_add:

--- a/compose/.apps/samba/samba.yml
+++ b/compose/.apps/samba/samba.yml
@@ -26,6 +26,7 @@ services:
     volumes:
       - /etc/localtime:/etc/localtime:ro
       - ${DOCKERCONFDIR}:/data/docker/config
+      - ${DOCKERSHAREDDIR}:/shared
       - ${DOWNLOADSDIR}:/data/downloads
       - ${DOWNLOADSDIR}:/downloads
       - ${MEDIADIR_BOOKS}:/books

--- a/compose/.apps/samba/samba.yml
+++ b/compose/.apps/samba/samba.yml
@@ -27,8 +27,14 @@ services:
       - /etc/localtime:/etc/localtime:ro
       - ${DOCKERCONFDIR}:/data/docker/config
       - ${DOWNLOADSDIR}:/data/downloads
-      - ${MEDIADIR_COMICS}:/data/comics
+      - ${DOWNLOADSDIR}:/downloads
+      - ${MEDIADIR_BOOKS}:/books
       - ${MEDIADIR_BOOKS}:/data/books
+      - ${MEDIADIR_COMICS}:/comics
+      - ${MEDIADIR_COMICS}:/data/comics
       - ${MEDIADIR_MOVIES}:/data/movies
+      - ${MEDIADIR_MOVIES}:/movies
       - ${MEDIADIR_MUSIC}:/data/music
+      - ${MEDIADIR_MUSIC}:/music
       - ${MEDIADIR_TV}:/data/tv
+      - ${MEDIADIR_TV}:/tv


### PR DESCRIPTION
## Purpose

Some containers were missing common directories such as `/shared` while others had non standard mapping for things like `/movies`.

## Approach

Keep existing mappings but add the standard mappings in addition wherever a non standard mapping is used. Add all missing common directories.

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
