### PR TITLE
Add PGID to Grafana

### DIFF
--- a/compose/.apps/grafana/grafana.yml
+++ b/compose/.apps/grafana/grafana.yml
@@ -17,4 +17,4 @@ services:
       - /etc/localtime:/etc/localtime:ro
       - ${DOCKERCONFDIR}/grafana:/var/lib/grafana
       - ${DOCKERSHAREDDIR}:/shared
-    user: ${PUID}
+    user: ${PUID}:${PGID}


### PR DESCRIPTION
## Purpose

Include the PGID with Grafana. This is more so that I don't lose track of how this works after looking up the proper syntax. I have previously mistakenly suggested someone use `group: ${PGID}` which was incorrect.

## Approach

`user: ${PUID}:${PGID}`

#### Learning

https://docs.docker.com/engine/reference/run/#user
https://docs.docker.com/compose/compose-file/#domainname-hostname-ipc-mac_address-privileged-read_only-shm_size-stdin_open-tty-user-working_dir

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
