### PR TITLE
Location

### DIFF
--- a/.scripts/menu_value_prompt.sh
+++ b/.scripts/menu_value_prompt.sh
@@ -20,8 +20,8 @@ menu_value_prompt() {
 
     case "${SET_VAR}" in
         DOCKERCONFDIR)
-            SYSTEM_VAL="${DETECTED_HOMEDIR}/.docker/config"
-            VALUEOPTIONS+=("Use System " "${SYSTEM_VAL}")
+            HOME_VAL="${DETECTED_HOMEDIR}/.config/docker"
+            VALUEOPTIONS+=("Use Home " "${HOME_VAL}")
             ;;
         DOCKERGID)
             SYSTEM_VAL=$(cut -d: -f3 < <(getent group docker))
@@ -32,8 +32,8 @@ menu_value_prompt() {
             VALUEOPTIONS+=("Use System " "${SYSTEM_VAL}")
             ;;
         DOCKERSHAREDDIR)
-            SYSTEM_VAL="${DETECTED_HOMEDIR}/.docker/config/shared"
-            VALUEOPTIONS+=("Use System " "${SYSTEM_VAL}")
+            HOME_VAL="${DETECTED_HOMEDIR}/.config/docker/shared"
+            VALUEOPTIONS+=("Use Home " "${HOME_VAL}")
             ;;
         DOWNLOADSDIR)
             SYSTEM_VAL="${DETECTED_HOMEDIR}/Downloads"

--- a/.scripts/symlink_ds.sh
+++ b/.scripts/symlink_ds.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 IFS=$'\n\t'
 
 symlink_ds() {
+    run_script 'set_permissions' "${SCRIPTNAME}"
+
     # /usr/bin/ds
     if [[ -L "/usr/bin/ds" ]] && [[ ${SCRIPTNAME} != "$(readlink -f /usr/bin/ds)" ]]; then
         info "Attempting to remove /usr/bin/ds symlink."


### PR DESCRIPTION
## Purpose

This closes #602 

## Approach

- Docker directories in the menu will show as "Home" instead of "System" and be put in `~/.config/docker`
- Create a `repo_exists` to confirm if the script can locate the `.git` repo folder and `.scripts` folder from the repo
- Remove the forced use of the `.docker` folder and use the `ds` symlink to determine if DS is already installed
- If DS is already installed (via detection above) and the user is running it from another location and the repo exists in the location it's running from then prompt the user if this should be the location `ds` runs (if not then clone the repo to the default `.docker` folder as usual).

#### Open Questions and Pre-Merge TODOs

- [x] Testing: Basic installs ([see below](https://github.com/GhostWriters/DockSTARTer/pull/646#issuecomment-484208458))
- [x] Testing: Advanced installs to standard location ([see below](https://github.com/GhostWriters/DockSTARTer/pull/646#issuecomment-484208458))
- [x] Testing: Advanced installs to non-standard location ([see below](https://github.com/GhostWriters/DockSTARTer/pull/646#issuecomment-484208458))
- [x] Testing: Rename the install folder and then run `main.sh` from its new location
- [x] Testing: cron for backups

~~All of these may require https://github.com/GhostWriters/DockSTARTer/commit/59b1f02d27a884fbda6337e8f4fbcd11f0d9f1ad to be in place. For the purpose of not accidentally merging that to master it has been reverted, but during testing it may need to be re-implemented, or this branch may need to be cloned and have that commit reinstated on the separate branch.~~ ([see below](https://github.com/GhostWriters/DockSTARTer/pull/646#issuecomment-484208458))

#### Learning

Massive thanks to @phenonymous for requesting #602 and basically pionerring this solution through multiple iterations and various discussions with me via GitHub comments and on Discord.

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
