### PR TITLE
Exec

### DIFF
--- a/.scripts/cmdline.sh
+++ b/.scripts/cmdline.sh
@@ -129,7 +129,7 @@ cmdline() {
                 ;;
         esac
     done
-    return 0
+    return
 }
 
 test_cmdline() {

--- a/.scripts/menu_main.sh
+++ b/.scripts/menu_main.sh
@@ -36,7 +36,7 @@ menu_main() {
             ;;
         "Cancel")
             info "Exiting DockSTARTer."
-            return 1
+            return
             ;;
         *)
             error "Invalid Option"

--- a/main.sh
+++ b/main.sh
@@ -146,17 +146,20 @@ verlt() { ! verlte "${2}" "${1}"; }
 
 # Cleanup Function
 cleanup() {
-    readonly EXIT_CODE="$?"
+    local -ri EXIT_CODE=$?
+
     if repo_exists; then
         sudo chmod +x "${SCRIPTNAME}" > /dev/null 2>&1 || fatal "ds must be executable."
     fi
     if [[ ${CI:-} == true ]] && [[ ${TRAVIS:-} == true ]] && [[ ${TRAVIS_SECURE_ENV_VARS:-} == false ]]; then
         warning "TRAVIS_SECURE_ENV_VARS is false for Pull Requests from remote branches. Please retry failed builds!"
     fi
-    if [[ ${EXIT_CODE} != "0" ]]; then
+
+    if [[ ${EXIT_CODE} != 0 ]]; then
         error "DockSTARTer did not finish running successfully."
     fi
     exit ${EXIT_CODE}
+    trap - 0 1 2 3 6 14 15
 }
 trap 'cleanup' 0 1 2 3 6 14 15
 

--- a/main.sh
+++ b/main.sh
@@ -155,7 +155,7 @@ cleanup() {
         warning "TRAVIS_SECURE_ENV_VARS is false for Pull Requests from remote branches. Please retry failed builds!"
     fi
 
-    if [[ ${EXIT_CODE} != 0 ]]; then
+    if [[ ${EXIT_CODE} -ne 0 ]]; then
         error "DockSTARTer did not finish running successfully."
     fi
     exit ${EXIT_CODE}
@@ -199,7 +199,7 @@ main() {
         if ! repo_exists; then
             warning "Attempting to clone DockSTARTer repo to ${DETECTED_HOMEDIR}/.docker location."
             # Anti Sudo Check
-            if [[ ${EUID} == "0" ]]; then
+            if [[ ${EUID} -eq 0 ]]; then
                 fatal "Using sudo during cloning on first run is not supported."
             fi
             git clone https://github.com/GhostWriters/DockSTARTer "${DETECTED_HOMEDIR}/.docker" || fatal "Failed to clone DockSTARTer repo to ${DETECTED_HOMEDIR}/.docker location."
@@ -208,7 +208,7 @@ main() {
         fi
     fi
     # Sudo Check
-    if [[ ${EUID} != "0" ]]; then
+    if [[ ${EUID} -ne 0 ]]; then
         exec sudo bash "${SCRIPTNAME}" "${ARGS[@]:-}"
     fi
     run_script 'symlink_ds'


### PR DESCRIPTION
## Purpose

This closes #648 

## Approach

Use `exec` instead of subshell followed by exit. In case of failure DS will now show a generic failure message using our trap cleanup function since we will no longer catch the failure of the subshell (see changes below). Resolve anywhere DS would previously `return 1` or `exit 1` unnecessarily. Also use `-eq`/`-ne` when comparing numbers.

#### Learning

@phenonymous has been a massive help on this!

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
