### PR TITLE
Use terminal capability instead of ANSI color codes

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -71,13 +71,26 @@ readonly DETECTED_PGID=$(id -g "${DETECTED_PUID}" 2> /dev/null || true)
 readonly DETECTED_UGROUP=$(id -gn "${DETECTED_PUID}" 2> /dev/null || true)
 readonly DETECTED_HOMEDIR=$(eval echo "~${DETECTED_UNAME}" 2> /dev/null || true)
 
-# Colors
-# https://misc.flogisoft.com/bash/tip_colors_and_formatting
-readonly BLU='\e[34m'
-readonly GRN='\e[32m'
-readonly RED='\e[31m'
-readonly YLW='\e[33m'
-readonly NC='\e[0m'
+# Terminal Check
+if [[ -t 1 ]]; then
+    # Colors
+    #- Reference for colornumbers used by most terminals can be found here: https://jonasjacek.github.io/colors/
+    #- The actual color depends on the color scheme set by the current terminal-emulator
+    #- For capabilities, see terminfo(5)
+    if [[ $(tput colors) -ge 8 ]]; then
+        tput initc # Initialize colors to ensure we have colors
+        BLU="$(tput setaf 4)"
+        GRN="$(tput setaf 2)"
+        RED="$(tput setaf 1)"
+        YLW="$(tput setaf 3)"
+        NC="$(tput sgr0)"
+    fi
+fi
+readonly BLU="${BLU:-}"
+readonly GRN="${GRN:-}"
+readonly RED="${RED:-}"
+readonly YLW="${YLW:-}"
+readonly NC="${NC:-}"
 
 # Log Functions
 readonly LOG_FILE="/tmp/dockstarter.log"
@@ -163,7 +176,7 @@ main() {
         fatal "Unsupported architecture."
     fi
     # Terminal Check
-    if [[ -n ${PS1:-} ]] || [[ ${-} == *"i"* ]]; then
+    if [[ -t 1 ]]; then
         root_check
     fi
     local PROMPT


### PR DESCRIPTION
## Purpose

Fixes #649 and fixing terminal check not handled properly, see https://github.com/GhostWriters/DockSTARTer/issues/649#issuecomment-484918965

## Approach

Use of `tput` to handle the color escape-sequences automatically for a large numbers of terminals.

#### Open Questions and Pre-Merge TODOs

- [ ] 1. Terminals should trigger root check and output color from log functions
- [ ] 2. If it is not a terminal, such as cron, it should not output any color from log functions and root check should not trigger

Terminals in this context is not the program you use to run bash rather the terminal your program emulates.

Task no.1 can be tested by running the script normally and by setting `TERM` to different values.
```console
$ export TERM="screen"
$ sudo ds
```
will emulate screen for example. 
Testing that root check triggers can be done by this **dangerous** command
```console
$ sudo su root -l; ds; exit
```
**N.B. Changing user to root is very dangerous as you will have access to anything on your system and if you are not cautious with what you are doing you can end up with a broken system**
That is why I put it as a one-line command which will exit the root user once ds has been run.

Task no.2 can be tested by checking the log file and verify it does not contain any escape-sequences.

#### Learning

Personal knowledge. For people who wants to learn more about terminal capabilites and the test for terminals, check out these relevant pages from [`tput(1)`](http://man7.org/linux/man-pages/man1/tput.1.html), [`terminfo(5)`](http://man7.org/linux/man-pages/man5/terminfo.5.html) and [`bash(1)`](https://www.gnu.org/software/bash/manual/bash.html#Bash-Conditional-Expressions)

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
