### PR TITLE
Declare locals inline

### DIFF
--- a/.scripts/backup_max.sh
+++ b/.scripts/backup_max.sh
@@ -11,10 +11,8 @@ backup_max() {
     local DOCKERCONFDIR
     DOCKERCONFDIR=$(run_script 'env_get' DOCKERCONFDIR)
     while IFS= read -r line; do
-        local APPNAME
-        APPNAME=${line}
-        local FILENAME
-        FILENAME=${APPNAME,,}
+        local APPNAME=${line}
+        local FILENAME=${APPNAME,,}
         local BACKUP_CONFIG
         BACKUP_CONFIG=$(run_script 'env_get' "${APPNAME}_BACKUP_CONFIG")
         if [[ ${BACKUP_CONFIG} != false ]]; then

--- a/.scripts/backup_med.sh
+++ b/.scripts/backup_med.sh
@@ -10,10 +10,8 @@ backup_med() {
     run_script 'env_update'
     run_script 'backup_create' ".compose.backups"
     while IFS= read -r line; do
-        local APPNAME
-        APPNAME=${line%%_ENABLED=true}
-        local FILENAME
-        FILENAME=${APPNAME,,}
+        local APPNAME=${line%%_ENABLED=true}
+        local FILENAME=${APPNAME,,}
         local BACKUP_CONFIG
         BACKUP_CONFIG=$(run_script 'env_get' "${APPNAME}_BACKUP_CONFIG")
         if [[ ${BACKUP_CONFIG} != false ]]; then

--- a/.scripts/config_apps.sh
+++ b/.scripts/config_apps.sh
@@ -5,8 +5,7 @@ IFS=$'\n\t'
 config_apps() {
     info "Configuring .env variables for enabled apps."
     while IFS= read -r line; do
-        local APPNAME
-        APPNAME=${line%%_ENABLED=true}
+        local APPNAME=${line%%_ENABLED=true}
         run_script 'menu_app_vars' "${APPNAME}" || return 1
     done < <(grep '_ENABLED=true$' < "${SCRIPTPATH}/compose/.env")
 }

--- a/.scripts/config_global.sh
+++ b/.scripts/config_global.sh
@@ -3,10 +3,8 @@ set -euo pipefail
 IFS=$'\n\t'
 
 config_global() {
-    local APPNAME
-    APPNAME="Global"
-    local VARNAMES
-    VARNAMES=(TZ DOCKERHOSTNAME PUID PGID DOCKERCONFDIR DOWNLOADSDIR MEDIADIR_AUDIOBOOKS MEDIADIR_BOOKS MEDIADIR_COMICS MEDIADIR_MOVIES MEDIADIR_MUSIC MEDIADIR_TV DOCKERSHAREDDIR)
+    local APPNAME="Global"
+    local VARNAMES=(TZ DOCKERHOSTNAME PUID PGID DOCKERCONFDIR DOWNLOADSDIR MEDIADIR_AUDIOBOOKS MEDIADIR_BOOKS MEDIADIR_COMICS MEDIADIR_MOVIES MEDIADIR_MUSIC MEDIADIR_TV DOCKERSHAREDDIR)
     local APPVARS
     APPVARS=$(for v in "${VARNAMES[@]}"; do echo "${v}=$(run_script 'env_get' "${v}")"; done)
 
@@ -15,7 +13,7 @@ config_global() {
     else
         info "Configuring ${APPNAME} .env variables."
         while IFS= read -r line; do
-            SET_VAR=${line%%=*}
+            local SET_VAR=${line%%=*}
             run_script 'menu_value_prompt' "${SET_VAR}" || return 1
         done < <(echo "${APPVARS}")
     fi

--- a/.scripts/config_vpn.sh
+++ b/.scripts/config_vpn.sh
@@ -3,10 +3,8 @@ set -euo pipefail
 IFS=$'\n\t'
 
 config_vpn() {
-    local APPNAME
-    APPNAME="VPN"
-    local VARNAMES
-    VARNAMES=(LAN_NETWORK NS1 NS2 VPN_ENABLE VPN_USER VPN_PASS VPN_PROV VPN_OPTIONS)
+    local APPNAME="VPN"
+    local VARNAMES=(LAN_NETWORK NS1 NS2 VPN_ENABLE VPN_USER VPN_PASS VPN_PROV VPN_OPTIONS)
     local APPVARS
     APPVARS=$(for v in "${VARNAMES[@]}"; do echo "${v}=$(run_script 'env_get' "${v}")"; done)
 
@@ -25,7 +23,7 @@ config_vpn() {
     else
         info "Configuring ${APPNAME} .env variables."
         while IFS= read -r line; do
-            SET_VAR=${line%%=*}
+            local SET_VAR=${line%%=*}
             run_script 'menu_value_prompt' "${SET_VAR}" || return 1
         done < <(echo "${APPVARS}")
     fi

--- a/.scripts/env_get.sh
+++ b/.scripts/env_get.sh
@@ -3,8 +3,7 @@ set -euo pipefail
 IFS=$'\n\t'
 
 env_get() {
-    local GET_VAR
-    GET_VAR=${1:-}
+    local GET_VAR=${1:-}
     grep --color=never -Po "^${GET_VAR}=\K.*" "${SCRIPTPATH}/compose/.env" || true
 }
 

--- a/.scripts/env_set.sh
+++ b/.scripts/env_set.sh
@@ -3,10 +3,8 @@ set -euo pipefail
 IFS=$'\n\t'
 
 env_set() {
-    local SET_VAR
-    SET_VAR=${1:-}
-    local NEW_VAL
-    NEW_VAL=${2:-}
+    local SET_VAR=${1:-}
+    local NEW_VAL=${2:-}
     local VAR_VAL
     VAR_VAL=$(grep --color=never "^${SET_VAR}=" "${SCRIPTPATH}/compose/.env") || fatal "Failed to find ${SET_VAR} in ${SCRIPTPATH}/compose/.env"
     # https://stackoverflow.com/questions/29613304/is-it-possible-to-escape-regex-metacharacters-reliably-with-sed/29613573#29613573

--- a/.scripts/env_update.sh
+++ b/.scripts/env_update.sh
@@ -14,10 +14,8 @@ env_update() {
     run_script 'set_permissions' "${SCRIPTPATH}/compose/.env"
     info "Merging previous values into new .env file."
     while IFS= read -r line; do
-        local SET_VAR
-        SET_VAR=${line%%=*}
-        local SET_VAL
-        SET_VAL=${line#*=}
+        local SET_VAR=${line%%=*}
+        local SET_VAL=${line#*=}
         if grep -q "^${SET_VAR}=" "${SCRIPTPATH}/compose/.env"; then
             run_script 'env_set' "${SET_VAR}" "${SET_VAL}"
         else

--- a/.scripts/generate_yml.sh
+++ b/.scripts/generate_yml.sh
@@ -16,10 +16,8 @@ generate_yml() {
     info "Required files included."
     info "Checking for enabled apps."
     while IFS= read -r line; do
-        local APPNAME
-        APPNAME=${line%%_ENABLED=true}
-        local FILENAME
-        FILENAME=${APPNAME,,}
+        local APPNAME=${line%%_ENABLED=true}
+        local FILENAME=${APPNAME,,}
         if [[ -d ${SCRIPTPATH}/compose/.apps/${FILENAME}/ ]]; then
             if [[ -f ${SCRIPTPATH}/compose/.apps/${FILENAME}/${FILENAME}.yml ]]; then
                 if [[ -f ${SCRIPTPATH}/compose/.apps/${FILENAME}/${FILENAME}.${ARCH}.yml ]]; then

--- a/.scripts/install_compose.sh
+++ b/.scripts/install_compose.sh
@@ -8,8 +8,7 @@ install_compose() {
     AVAILABLE_COMPOSE=$( (curl -H "${GH_HEADER:-}" -fsL "https://api.github.com/repos/docker/compose/releases/latest" | grep -Po '"tag_name": "[Vv]?\K.*?(?=")') || echo "0")
     local INSTALLED_COMPOSE
     INSTALLED_COMPOSE=$( (docker-compose --version 2> /dev/null || echo "0") | sed -E 's/.* version ([^,]*)(, build .*)?/\1/')
-    local FORCE
-    FORCE=${1:-}
+    local FORCE=${1:-}
     if [[ ${AVAILABLE_COMPOSE} == "0" ]]; then
         if [[ ${INSTALLED_COMPOSE} == "0" ]] || [[ -n ${FORCE} ]]; then
             fatal "The latest available version of docker-compose could not be confirmed. This is usually caused by exhausting the rate limit on GitHub's API. Please check https://api.github.com/rate_limit"

--- a/.scripts/install_docker.sh
+++ b/.scripts/install_docker.sh
@@ -8,8 +8,7 @@ install_docker() {
     AVAILABLE_DOCKER=$( (curl -H "${GH_HEADER:-}" -fsL "https://api.github.com/repos/docker/docker-ce/releases/latest" | grep -Po '"tag_name": "[Vv]?\K.*?(?=")') || echo "0")
     local INSTALLED_DOCKER
     INSTALLED_DOCKER=$( (docker --version 2> /dev/null || echo "0") | sed -E 's/.* version ([^,]*)(, build .*)?/\1/')
-    local FORCE
-    FORCE=${1:-}
+    local FORCE=${1:-}
     if [[ ${AVAILABLE_DOCKER} == "0" ]]; then
         if [[ ${INSTALLED_DOCKER} == "0" ]] || [[ -n ${FORCE} ]]; then
             fatal "The latest available version of docker could not be confirmed. This is usually caused by exhausting the rate limit on GitHub's API. Please check https://api.github.com/rate_limit"

--- a/.scripts/install_yq.sh
+++ b/.scripts/install_yq.sh
@@ -8,8 +8,7 @@ install_yq() {
     AVAILABLE_YQ=$( (curl -H "${GH_HEADER:-}" -fsL "https://api.github.com/repos/mikefarah/yq/releases/latest" | grep -Po '"tag_name": "[Vv]?\K.*?(?=")') || echo "0")
     local INSTALLED_YQ
     INSTALLED_YQ=$( (yq --version 2> /dev/null || echo "0") | sed -E 's/.* version ([^,]*)(, build .*)?/\1/')
-    local FORCE
-    FORCE=${1:-}
+    local FORCE=${1:-}
     if [[ ${AVAILABLE_YQ} == "0" ]]; then
         if [[ ${INSTALLED_YQ} == "0" ]] || [[ -n ${FORCE} ]]; then
             fatal "The latest available version of yq could not be confirmed. This is usually caused by exhausting the rate limit on GitHub's API. Please check https://api.github.com/rate_limit"

--- a/.scripts/menu_app_select.sh
+++ b/.scripts/menu_app_select.sh
@@ -3,14 +3,11 @@ set -euo pipefail
 IFS=$'\n\t'
 
 menu_app_select() {
-    local APPLIST
-    APPLIST=()
+    local APPLIST=()
 
     while IFS= read -r line; do
-        local APPNAME
-        APPNAME=${line%%_ENABLED=*}
-        local FILENAME
-        FILENAME=${APPNAME,,}
+        local APPNAME=${line%%_ENABLED=*}
+        local FILENAME=${APPNAME,,}
         if [[ -d ${SCRIPTPATH}/compose/.apps/${FILENAME}/ ]]; then
             if [[ -f ${SCRIPTPATH}/compose/.apps/${FILENAME}/${FILENAME}.yml ]]; then
                 if [[ -f ${SCRIPTPATH}/compose/.apps/${FILENAME}/${FILENAME}.${ARCH}.yml ]]; then
@@ -41,14 +38,12 @@ menu_app_select() {
     else
         info "Disabling all apps."
         while IFS= read -r line; do
-            local APPNAME
-            APPNAME=${line%%_ENABLED=true}
+            local APPNAME=${line%%_ENABLED=true}
             run_script 'env_set' "${APPNAME}_ENABLED" false
         done < <(grep '_ENABLED=true$' < "${SCRIPTPATH}/compose/.env")
         info "Enabling selected apps."
         while IFS= read -r line; do
-            local APPNAME
-            APPNAME=${line^^}
+            local APPNAME=${line^^}
             run_script 'env_set' "${APPNAME}_ENABLED" true
         done < <(echo "${SELECTEDAPPS}")
     fi

--- a/.scripts/menu_app_vars.sh
+++ b/.scripts/menu_app_vars.sh
@@ -3,8 +3,7 @@ set -euo pipefail
 IFS=$'\n\t'
 
 menu_app_vars() {
-    local APPNAME
-    APPNAME=${1:-}
+    local APPNAME=${1:-}
     local APPVARS
     APPVARS=$(grep -v "^${APPNAME}_ENABLED=" "${SCRIPTPATH}/compose/.env" | grep "^${APPNAME}_")
     if [[ -z ${APPVARS} ]]; then
@@ -21,7 +20,7 @@ menu_app_vars() {
     else
         info "Configuring ${APPNAME} .env variables."
         while IFS= read -r line; do
-            SET_VAR=${line%%=*}
+            local SET_VAR=${line%%=*}
             run_script 'menu_value_prompt' "${SET_VAR}" || return 1
         done < <(echo "${APPVARS}")
     fi

--- a/.scripts/menu_backup.sh
+++ b/.scripts/menu_backup.sh
@@ -3,8 +3,7 @@ set -euo pipefail
 IFS=$'\n\t'
 
 menu_backup() {
-    local BACKUPOPTS
-    BACKUPOPTS=()
+    local BACKUPOPTS=()
     BACKUPOPTS+=("Settings " "Configure backup settings")
     BACKUPOPTS+=("MIN " "Backup your .env")
     BACKUPOPTS+=("MED " "Backup configs for enabled apps")

--- a/.scripts/menu_config.sh
+++ b/.scripts/menu_config.sh
@@ -3,8 +3,7 @@ set -euo pipefail
 IFS=$'\n\t'
 
 menu_config() {
-    local CONFIGOPTS
-    CONFIGOPTS=()
+    local CONFIGOPTS=()
     CONFIGOPTS+=("Full Setup " "")
     CONFIGOPTS+=("Select Apps " "")
     CONFIGOPTS+=("Set App Variables " "")

--- a/.scripts/menu_main.sh
+++ b/.scripts/menu_main.sh
@@ -3,8 +3,7 @@ set -euo pipefail
 IFS=$'\n\t'
 
 menu_main() {
-    local MAINOPTS
-    MAINOPTS=()
+    local MAINOPTS=()
     MAINOPTS+=("Configuration " "Setup and start applications")
     MAINOPTS+=("Install Dependencies " "Latest version of Docker and Docker-Compose")
     MAINOPTS+=("Update DockSTARTer " "Get the latest version of DockSTARTer")

--- a/.scripts/menu_value_prompt.sh
+++ b/.scripts/menu_value_prompt.sh
@@ -3,8 +3,7 @@ set -euo pipefail
 IFS=$'\n\t'
 
 menu_value_prompt() {
-    local SET_VAR
-    SET_VAR=${1:-}
+    local SET_VAR=${1:-}
 
     local CURRENT_VAL
     CURRENT_VAL=$(run_script 'env_get' "${SET_VAR}")
@@ -12,10 +11,10 @@ menu_value_prompt() {
     local DEFAULT_VAL
     DEFAULT_VAL=$(grep --color=never -Po "^${SET_VAR}=\K.*" "${SCRIPTPATH}/compose/.env.example" || true)
 
+    local HOME_VAL
     local SYSTEM_VAL
     local VALUEDESCRIPTION
-    local VALUEOPTIONS
-    VALUEOPTIONS=()
+    local VALUEOPTIONS=()
     VALUEOPTIONS+=("Keep Current " "${CURRENT_VAL}")
 
     case "${SET_VAR}" in
@@ -214,8 +213,7 @@ menu_value_prompt() {
                     whiptail --fb --clear --title "DockSTARTer" --msgbox "Cannot use / for ${SET_VAR}. Please select another folder." 0 0
                     menu_value_prompt "${SET_VAR}"
                 elif [[ ${INPUT} == ~* ]]; then
-                    local CORRECTED_DIR
-                    CORRECTED_DIR="${DETECTED_HOMEDIR}${INPUT#*~}"
+                    local CORRECTED_DIR="${DETECTED_HOMEDIR}${INPUT#*~}"
                     if run_script 'question_prompt' Y "Cannot use the ~ shortcut in ${SET_VAR}. Would you like to use ${CORRECTED_DIR} instead?"; then
                         run_script 'env_set' "${SET_VAR}" "${CORRECTED_DIR}"
                         whiptail --fb --clear --title "DockSTARTer" --msgbox "Returning to the previous menu to confirm selection." 0 0

--- a/.scripts/question_prompt.sh
+++ b/.scripts/question_prompt.sh
@@ -3,10 +3,8 @@ set -euo pipefail
 IFS=$'\n\t'
 
 question_prompt() {
-    local DEFAULT
-    DEFAULT=${1:-Y}
-    local QUESTION
-    QUESTION=${2:-}
+    local DEFAULT=${1:-Y}
+    local QUESTION=${2:-}
     local YN
     while true; do
         if [[ ${PROMPT:-} == "CLI" ]]; then

--- a/.scripts/run_compose.sh
+++ b/.scripts/run_compose.sh
@@ -3,8 +3,7 @@ set -euo pipefail
 IFS=$'\n\t'
 
 run_compose() {
-    local COMMAND
-    COMMAND=${1:-}
+    local COMMAND=${1:-}
     local COMPOSECOMMAND
     local COMMANDINFO
     case ${COMMAND} in

--- a/.scripts/set_permissions.sh
+++ b/.scripts/set_permissions.sh
@@ -3,8 +3,7 @@ set -euo pipefail
 IFS=$'\n\t'
 
 set_permissions() {
-    local CH_PATH
-    CH_PATH=${1:-$SCRIPTPATH}
+    local CH_PATH=${1:-$SCRIPTPATH}
     case "${CH_PATH}" in
         # https://en.wikipedia.org/wiki/Unix_filesystem
         # Split into two in order to keep the lines shorter
@@ -24,10 +23,8 @@ set_permissions() {
             warning "Setting permissions for ${CH_PATH} outside of ${DETECTED_HOMEDIR} may be unsafe."
             ;;
     esac
-    local CH_PUID
-    CH_PUID=${2:-$DETECTED_PUID}
-    local CH_PGID
-    CH_PGID=${3:-$DETECTED_PGID}
+    local CH_PUID=${2:-$DETECTED_PUID}
+    local CH_PGID=${3:-$DETECTED_PGID}
     if [[ ${CI:-} == true ]] && [[ ${TRAVIS:-} == true ]]; then
         info "Overriding PUID and PGID for Travis."
         CH_PUID=${DETECTED_UNAME}

--- a/.scripts/update_self.sh
+++ b/.scripts/update_self.sh
@@ -3,8 +3,7 @@ set -euo pipefail
 IFS=$'\n\t'
 
 update_self() {
-    local BRANCH
-    BRANCH=${1:-origin/master}
+    local BRANCH=${1:-origin/master}
     if run_script 'question_prompt' Y "Would you like to update DockSTARTer to ${BRANCH} now?"; then
         info "Updating DockSTARTer to ${BRANCH}."
     else

--- a/main.sh
+++ b/main.sh
@@ -51,10 +51,9 @@ fi
 # Script Information
 # https://stackoverflow.com/questions/59895/get-the-source-directory-of-a-bash-script-from-within-the-script-itself/246128#246128
 get_scriptname() {
-    local SOURCE
-    local DIR
-    SOURCE="${BASH_SOURCE[0]:-$0}" # https://stackoverflow.com/questions/35006457/choosing-between-0-and-bash-source/35006505#35006505
+    local SOURCE="${BASH_SOURCE[0]:-$0}" # https://stackoverflow.com/questions/35006457/choosing-between-0-and-bash-source/35006505#35006505
     while [[ -L ${SOURCE} ]]; do # resolve ${SOURCE} until the file is no longer a symlink
+        local DIR
         DIR="$(cd -P "$(dirname "${SOURCE}")" > /dev/null 2>&1 && pwd)"
         SOURCE="$(readlink "${SOURCE}")"
         [[ ${SOURCE} != /* ]] && SOURCE="${DIR}/${SOURCE}" # if ${SOURCE} was a relative symlink, we need to resolve it relative to the path where the symlink file was located


### PR DESCRIPTION
## Purpose

This closes #650 
I had previously made efforts to always declare and set separately because I misunderstood the rule SC2155.

## Approach

Set the value of local variables when declaring them local unless the value is being set via a command which is prohibited by shellcheck.

Also add the `local` declaration to a few places that were previously missed and we're accidentally setting at a global scope.

Also adjust the backup script to properly declare locals inside loops based on the scope actually needed (I thought I had it right, but this worked out to be a good time to review it).

#### Learning

[SC2155](https://github.com/koalaman/shellcheck/wiki/SC2155)

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
