### PR TITLE
Don't set permissions as root

### DIFF
--- a/.scripts/set_permissions.sh
+++ b/.scripts/set_permissions.sh
@@ -30,10 +30,12 @@ set_permissions() {
         CH_PUID=${DETECTED_UNAME}
         CH_PGID=${DETECTED_UGROUP}
     fi
-    info "Taking ownership of ${CH_PATH} for user ${CH_PUID} and group ${CH_PGID}"
-    chown -R "${CH_PUID}":"${CH_PGID}" "${CH_PATH}" > /dev/null 2>&1 || true
-    info "Setting file and folder permissions in ${CH_PATH}"
-    chmod -R a=,a+rX,u+w,g+w "${CH_PATH}" > /dev/null 2>&1 || true
+    if [[ ${CH_PUID} -ne 0 ]] && [[ ${CH_PGID} -ne 0 ]]; then
+        info "Taking ownership of ${CH_PATH} for user ${CH_PUID} and group ${CH_PGID}"
+        chown -R "${CH_PUID}":"${CH_PGID}" "${CH_PATH}" > /dev/null 2>&1 || true
+        info "Setting file and folder permissions in ${CH_PATH}"
+        chmod -R a=,a+rX,u+w,g+w "${CH_PATH}" > /dev/null 2>&1 || true
+    fi
     chmod +x "${SCRIPTNAME}" > /dev/null 2>&1 || fatal "ds must be executable."
 }
 


### PR DESCRIPTION
## Purpose

This closes #658 
Not a lot to say here other than what's already in the issue (which is very minimal). The main purpose of this is to keep DS from setting ownership to root when run via cron. Generally speaking there is no reason for root to be given ownership of anything by DS.

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
