### PR TITLE
Simplify code for script information

### DIFF
--- a/.scripts/install_yq.sh
+++ b/.scripts/install_yq.sh
@@ -38,6 +38,6 @@ install_yq() {
 }
 
 test_install_yq() {
-    run_script 'install_yq' FORCE
+    run_script 'install_yq'
     yq --version || fatal "Failed to determine yq version."
 }

--- a/.scripts/install_yq.sh
+++ b/.scripts/install_yq.sh
@@ -38,6 +38,6 @@ install_yq() {
 }
 
 test_install_yq() {
-    run_script 'install_yq'
+    run_script 'install_yq' FORCE
     yq --version || fatal "Failed to determine yq version."
 }

--- a/main.sh
+++ b/main.sh
@@ -51,7 +51,7 @@ fi
 # Script Information
 declare PATHCMD
 { command -v realpath > /dev/null && PATHCMD='realpath -ePq'; } || { command -v readlink > /dev/null && PATHCMD='readlink -esq'; }
-SCRIPTNAME=$($PATHCMD "${BASH_SOURCE[0]:-$0}")
+SCRIPTNAME=$(eval "${PATHCMD}" "${BASH_SOURCE[0]:-$0}")
 SCRIPTPATH=$(dirname "${SCRIPTNAME}")
 readonly SCRIPTNAME SCRIPTPATH
 unset PATHCMD

--- a/main.sh
+++ b/main.sh
@@ -49,9 +49,12 @@ if [[ ${CI:-} == true ]] && [[ ${TRAVIS:-} == true ]] && [[ ${TRAVIS_SECURE_ENV_
 fi
 
 # Script Information
-SCRIPTNAME=$(realpath -ePq "${BASH_SOURCE[0]:-$0}")
+declare PATHCMD
+{ command -v realpath > /dev/null && PATHCMD='realpath -ePq'; } || { command -v readlink > /dev/null && PATHCMD='readlink -esq'; }
+SCRIPTNAME=$($PATHCMD "${BASH_SOURCE[0]:-$0}")
 SCRIPTPATH=$(dirname "${SCRIPTNAME}")
 readonly SCRIPTNAME SCRIPTPATH
+unset PATHCMD
 
 # User/Group Information
 readonly DETECTED_PUID=${SUDO_UID:-$UID}

--- a/main.sh
+++ b/main.sh
@@ -49,19 +49,9 @@ if [[ ${CI:-} == true ]] && [[ ${TRAVIS:-} == true ]] && [[ ${TRAVIS_SECURE_ENV_
 fi
 
 # Script Information
-# https://stackoverflow.com/questions/59895/get-the-source-directory-of-a-bash-script-from-within-the-script-itself/246128#246128
-get_scriptname() {
-    local SOURCE="${BASH_SOURCE[0]:-$0}" # https://stackoverflow.com/questions/35006457/choosing-between-0-and-bash-source/35006505#35006505
-    while [[ -L ${SOURCE} ]]; do # resolve ${SOURCE} until the file is no longer a symlink
-        local DIR
-        DIR="$(cd -P "$(dirname "${SOURCE}")" > /dev/null 2>&1 && pwd)"
-        SOURCE="$(readlink "${SOURCE}")"
-        [[ ${SOURCE} != /* ]] && SOURCE="${DIR}/${SOURCE}" # if ${SOURCE} was a relative symlink, we need to resolve it relative to the path where the symlink file was located
-    done
-    echo "${SOURCE}"
-}
-readonly SCRIPTPATH="$(cd -P "$(dirname "$(get_scriptname)")" > /dev/null 2>&1 && pwd)"
-readonly SCRIPTNAME="${SCRIPTPATH}/$(basename "$(get_scriptname)")"
+SCRIPTNAME=$(realpath -ePq "${BASH_SOURCE[0]:-$0}")
+SCRIPTPATH=$(dirname "${SCRIPTNAME}")
+readonly SCRIPTNAME SCRIPTPATH
 
 # User/Group Information
 readonly DETECTED_PUID=${SUDO_UID:-$UID}


### PR DESCRIPTION
## Purpose

This commit removes the need for `get_scriptname`

## Approach

`realpath(1)` will resolve the absolute path of a file even if it is behind multiple symlinks. This removes the need of the while-loop in `get_scriptname` and therefor also the entire function. 
`dirname(1)` will strip the last component of a file so while `realpath` will give us the absolute path of the script, `dirname` will give us the path of the folder the script is in.

#### Open Questions and Pre-Merge TODOs

- [x] Test that `realpath` is working as expected

#### Learning

Personal knowledge. For more information see the aforementioned man pages.

## Requirements

- [X] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [X] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
