### PR TITLE
Use appdata naming for default config locations

### DIFF
--- a/.scripts/menu_value_prompt.sh
+++ b/.scripts/menu_value_prompt.sh
@@ -19,7 +19,7 @@ menu_value_prompt() {
 
     case "${SET_VAR}" in
         DOCKERCONFDIR)
-            HOME_VAL="${DETECTED_HOMEDIR}/.config/docker"
+            HOME_VAL="${DETECTED_HOMEDIR}/.config/appdata"
             VALUEOPTIONS+=("Use Home " "${HOME_VAL}")
             ;;
         DOCKERGID)
@@ -31,7 +31,7 @@ menu_value_prompt() {
             VALUEOPTIONS+=("Use System " "${SYSTEM_VAL}")
             ;;
         DOCKERSHAREDDIR)
-            HOME_VAL="${DETECTED_HOMEDIR}/.config/docker/shared"
+            HOME_VAL="${DETECTED_HOMEDIR}/.config/appdata/shared"
             VALUEOPTIONS+=("Use Home " "${HOME_VAL}")
             ;;
         DOWNLOADSDIR)

--- a/compose/.env.example
+++ b/compose/.env.example
@@ -1,11 +1,11 @@
 # Universal Settings
 COMPOSE_HTTP_TIMEOUT=60
-DOCKERCONFDIR=~/.docker/config
+DOCKERCONFDIR=~/.config/appdata
 DOCKERGID=999
 DOCKERHOSTNAME=DockSTARTer
 DOCKERLOGGING_MAXFILE=10
 DOCKERLOGGING_MAXSIZE=200k
-DOCKERSHAREDDIR=~/.docker/config/shared
+DOCKERSHAREDDIR=~/.config/appdata/shared
 DOWNLOADSDIR=/mnt/downloads
 MEDIADIR_AUDIOBOOKS=/mnt/medialibrary/audiobooks
 MEDIADIR_BOOKS=/mnt/medialibrary/books
@@ -154,8 +154,8 @@ DUPLICATI_ENABLED=false
 DUPLICATI_BACKUP_CONFIG=true
 DUPLICATI_NETWORK_MODE=
 DUPLICATI_PORT_8200=8200
-DUPLICATI_BACKUPSDIR=~/.docker/config/backups
-DUPLICATI_SOURCEDIR=~/.docker/config
+DUPLICATI_BACKUPSDIR=~/.config/appdata/backups
+DUPLICATI_SOURCEDIR=~/.config/appdata
 
 ### EMBY
 EMBY_ENABLED=false


### PR DESCRIPTION
## Purpose

`appdata` is a fairly consistent term among the community to refer to where apps store their data. I believe this originated with UnRaid, but since it's common enough even outside of UnRaid users I believe it is a good move to make this the default for DS. Existing users will be unaffected.

## Approach

Change all references from `~/.config/docker` and `~/.docker/config` to `~/.config/appdata`. Our `env_sanitize` will still replace `~` with the absolute path of the home folder for the user and this will remain consistent with expected behaviour in the rest of DS.

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
