### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: minimal
 
-before_deploy:
+script:
   - "docker run --rm -v ${PWD}/site:/site -v ${PWD}:/docs squidfunk/mkdocs-material build --verbose --clean --strict" # Build a local version of the docs
+
+before_deploy:
   - "sudo cp ${PWD}/CNAME ${PWD}/site/"
 
 deploy:


### PR DESCRIPTION
## Purpose

Have mkdocs run for all builds even if a deploy isn't happening (ex: pull requests).

## Approach

Move the mkdocs command to the `script` section of the Travis file.

#### Learning

https://docs.travis-ci.com/user/job-lifecycle

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
