### PR TITLE
Add pages for all missing apps

### DIFF
--- a/docs/apps/airsonic.md
+++ b/docs/apps/airsonic.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/bazarr.md
+++ b/docs/apps/bazarr.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/beets.md
+++ b/docs/apps/beets.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/booksonic.md
+++ b/docs/apps/booksonic.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/calibreweb.md
+++ b/docs/apps/calibreweb.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/cloudcmd.md
+++ b/docs/apps/cloudcmd.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/cloudflareddns.md
+++ b/docs/apps/cloudflareddns.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/couchpotato.md
+++ b/docs/apps/couchpotato.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/deluge.md
+++ b/docs/apps/deluge.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/duckdns.md
+++ b/docs/apps/duckdns.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/emby.md
+++ b/docs/apps/emby.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/freshrss.md
+++ b/docs/apps/freshrss.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/glances.md
+++ b/docs/apps/glances.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/grafana.md
+++ b/docs/apps/grafana.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/guacamole.md
+++ b/docs/apps/guacamole.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/h5ai.md
+++ b/docs/apps/h5ai.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/handbrake.md
+++ b/docs/apps/handbrake.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/headphones.md
+++ b/docs/apps/headphones.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/heimdall.md
+++ b/docs/apps/heimdall.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/htpcmanager.md
+++ b/docs/apps/htpcmanager.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/hydra2.md
+++ b/docs/apps/hydra2.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/influxdb.md
+++ b/docs/apps/influxdb.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/lazylibrarian.md
+++ b/docs/apps/lazylibrarian.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/lidarr.md
+++ b/docs/apps/lidarr.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/logitechmediaserver.md
+++ b/docs/apps/logitechmediaserver.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/makemkv.md
+++ b/docs/apps/makemkv.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/mariadb.md
+++ b/docs/apps/mariadb.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/mcmyadmin2.md
+++ b/docs/apps/mcmyadmin2.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/medusa.md
+++ b/docs/apps/medusa.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/monitorr.md
+++ b/docs/apps/monitorr.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/muximux.md
+++ b/docs/apps/muximux.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/mylar.md
+++ b/docs/apps/mylar.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/nzbget.md
+++ b/docs/apps/nzbget.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/nzbgetvpn.md
+++ b/docs/apps/nzbgetvpn.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/ombi.md
+++ b/docs/apps/ombi.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/organizr.md
+++ b/docs/apps/organizr.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/phpmyadmin.md
+++ b/docs/apps/phpmyadmin.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/plexrequests.md
+++ b/docs/apps/plexrequests.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/portaineragent.md
+++ b/docs/apps/portaineragent.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/pyload.md
+++ b/docs/apps/pyload.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/qbittorrent.md
+++ b/docs/apps/qbittorrent.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/qbittorrentvpn.md
+++ b/docs/apps/qbittorrentvpn.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/radarr.md
+++ b/docs/apps/radarr.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/resiliosync.md
+++ b/docs/apps/resiliosync.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/rtorrentvpn.md
+++ b/docs/apps/rtorrentvpn.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/rutorrent.md
+++ b/docs/apps/rutorrent.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/sabnzbd.md
+++ b/docs/apps/sabnzbd.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/sabnzbdvpn.md
+++ b/docs/apps/sabnzbdvpn.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/sickrage.md
+++ b/docs/apps/sickrage.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/smokeping.md
+++ b/docs/apps/smokeping.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/sonarr.md
+++ b/docs/apps/sonarr.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/syncthing.md
+++ b/docs/apps/syncthing.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/tautulli.md
+++ b/docs/apps/tautulli.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/telegraf.md
+++ b/docs/apps/telegraf.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/thelounge.md
+++ b/docs/apps/thelounge.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/transmission.md
+++ b/docs/apps/transmission.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/transmissionvpn.md
+++ b/docs/apps/transmissionvpn.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/ttrss.md
+++ b/docs/apps/ttrss.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/tvheadend.md
+++ b/docs/apps/tvheadend.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/ubooquity.md
+++ b/docs/apps/ubooquity.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/unifi.md
+++ b/docs/apps/unifi.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/varken.md
+++ b/docs/apps/varken.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/docs/apps/vsftpd.md
+++ b/docs/apps/vsftpd.md
@@ -1,0 +1,1 @@
+Placeholder page

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,22 +36,85 @@ nav:
     - Port Conflicts: basics/port-conflicts.md
   - App Specifics:
     - AirDCpp: apps/airdcpp.md
+    - airsonic: apps/airsonic.md
+    - bazarr: apps/bazarr.md
+    - beets: apps/beets.md
     - BitWarden: apps/bitwarden.md
+    - booksonic: apps/booksonic.md
+    - calibreweb: apps/calibreweb.md
+    - cloudcmd: apps/cloudcmd.md
+    - cloudflareddns: apps/cloudflareddns.md
+    - couchpotato: apps/couchpotato.md
     - ddclient: apps/ddclient.md
+    - deluge: apps/deluge.md
     - DelugeVPN: apps/delugevpn.md
+    - duckdns: apps/duckdns.md
     - Duplicati: apps/duplicati.md
+    - emby: apps/emby.md
+    - freshrss: apps/freshrss.md
+    - glances: apps/glances.md
+    - grafana: apps/grafana.md
+    - guacamole: apps/guacamole.md
+    - h5ai: apps/h5ai.md
+    - handbrake: apps/handbrake.md
+    - headphones: apps/headphones.md
+    - heimdall: apps/heimdall.md
     - Home Assistant: apps/homeassistant.md
+    - htpcmanager: apps/htpcmanager.md
+    - hydra2: apps/hydra2.md
+    - influxdb: apps/influxdb.md
     - Jackett: apps/jackett.md
+    - lazylibrarian: apps/lazylibrarian.md
     - Let's Encrypt (Certbot): apps/letsencrypt.md
+    - lidarr: apps/lidarr.md
     - Logarr: apps/logarr.md
+    - logitechmediaserver: apps/logitechmediaserver.md
+    - makemkv: apps/makemkv.md
+    - mariadb: apps/mariadb.md
+    - mcmyadmin2: apps/mcmyadmin2.md
+    - medusa: apps/medusa.md
+    - monitorr: apps/monitorr.md
+    - muximux: apps/muximux.md
+    - mylar: apps/mylar.md
     - Netdata: apps/netdata.md
     - NextCloud: apps/nextcloud.md
+    - nzbget: apps/nzbget.md
+    - nzbgetvpn: apps/nzbgetvpn.md
+    - ombi: apps/ombi.md
     - OpenVPN-AS: apps/openvpnas.md
+    - organizr: apps/organizr.md
     - Ouroboros: apps/ouroboros.md
+    - phpmyadmin: apps/phpmyadmin.md
     - Pi-hole: apps/pihole.md
     - Plex: apps/plex.md
+    - plexrequests: apps/plexrequests.md
     - Portainer: apps/portainer.md
+    - portaineragent: apps/portaineragent.md
+    - pyload: apps/pyload.md
+    - qbittorrent: apps/qbittorrent.md
+    - qbittorrentvpn: apps/qbittorrentvpn.md
+    - radarr: apps/radarr.md
+    - resiliosync: apps/resiliosync.md
+    - rtorrentvpn: apps/rtorrentvpn.md
+    - rutorrent: apps/rutorrent.md
+    - sabnzbd: apps/sabnzbd.md
+    - sabnzbdvpn: apps/sabnzbdvpn.md
     - Samba: apps/samba.md
+    - sickrage: apps/sickrage.md
+    - smokeping: apps/smokeping.md
+    - sonarr: apps/sonarr.md
+    - syncthing: apps/syncthing.md
+    - tautulli: apps/tautulli.md
+    - telegraf: apps/telegraf.md
+    - thelounge: apps/thelounge.md
+    - transmission: apps/transmission.md
+    - transmissionvpn: apps/transmissionvpn.md
+    - ttrss: apps/ttrss.md
+    - tvheadend: apps/tvheadend.md
+    - ubooquity: apps/ubooquity.md
+    - unifi: apps/unifi.md
+    - varken: apps/varken.md
+    - vsftpd: apps/vsftpd.md
     - Watchtower: apps/watchtower.md
   - Advanced:
     - Advanced Usage: advanced/advanced-usage.md


### PR DESCRIPTION
## Purpose

This begins to address #676 by creating placeholder pages for all apps that didn't already have them. The pages still need actual documentation, but this will at least make it easier since to simply click the edit button on each page.

Admittedly I don't love this solution, but it gets us closer to the goal of better documentation.

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
