### PR TITLE
Add OpenCollective bot config

### DIFF
--- a/.github/opencollective.yml
+++ b/.github/opencollective.yml
@@ -1,0 +1,1 @@
+collective: DockSTARTer


### PR DESCRIPTION
## Purpose

Add the config file for the OpenCollective bot which will add comments to issues opened on the repo. If this becomes intrusive we will remove it.

## Approach

Add the config file per the documentation. We will allow the bot to use it's default settings for now and if needed we can adjust them more specifically in the future.

#### Learning

https://github.com/opencollective/opencollective-bot

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
