### PR TITLE
Hostnames

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -21,19 +21,20 @@ More important than being beautiful is being functional. This repository is prim
 - Should be formatted with [https://prettier.io/](https://prettier.io/)
 - Are separated into multiple files:
   - `<appname>.yml` is the main YAML template for an app and should have elements in the following order:
-    - `# APPNICENAME` comment on line 1, must match <appname> exactly but can have mixed case. Ex: Portainer vs PORTAINER
+    - `# APPNICENAME` comment on line 1, must match `<appname>` exactly but can have mixed case. Ex: Portainer vs PORTAINER
     - `# APPDESCRIPTION` comment on line 2, will show the description in the menus
     - `container_name` should match `<appname>`
     - `restart` should be `unless-stopped` or should include a comment about why another option is used
-    - `logging` should and the items beneath it should be included exactly as shown in other apps
+    - `logging` and the items beneath it should be included exactly as shown in other apps
     - `environment` should contain an alphabetically sorted list of environment variables used by the app
       - `- TZ=${TZ}` is always included even if not needed unless some other form of timezone variable is used
     - `volumes` should contain an alphabetically sorted list of volumes used by the app
       - `- /etc/localtime:/etc/localtime:ro` is always included
       - `- ${DOCKERSHAREDDIR}:/shared` is always included
       - `${DOCKERCONFDIR}/<appname>` should be used to define the primary config directory for the app
-  - `<appname>.netmode.yml` contains the `<APPNAME>_NETWORK_MODE` variable.
-  - `<appname>.ports.yml` contains the ports used by the app. If no ports are required by an app then a [placeholder](https://github.com/GhostWriters/DockSTARTer/blob/master/compose/.reqs/v1.yml) file should be used.
+  - `<appname>.hostname.yml` sets the hostname to use the `${DOCKERHOSTNAME}` variable
+  - `<appname>.netmode.yml` contains the `<APPNAME>_NETWORK_MODE` variable
+  - `<appname>.ports.yml` contains the ports used by the app or a [placeholder](https://github.com/GhostWriters/DockSTARTer/blob/master/compose/.reqs/v1.yml) file if no ports are required
   - At least one of the following files must be included:
     - `<appname>.aarch64.yml` defines the aarch64 or arm64 image
     - `<appname>.armv7l.yml` defines the armv7l or armhf image

--- a/compose/.apps/airdcpp/airdcpp.hostname.yml
+++ b/compose/.apps/airdcpp/airdcpp.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  airdcpp:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/airdcpp/airdcpp.yml
+++ b/compose/.apps/airdcpp/airdcpp.yml
@@ -3,7 +3,6 @@
 services:
   airdcpp:
     container_name: airdcpp
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/airsonic/airsonic.hostname.yml
+++ b/compose/.apps/airsonic/airsonic.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  airsonic:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/airsonic/airsonic.yml
+++ b/compose/.apps/airsonic/airsonic.yml
@@ -3,7 +3,6 @@
 services:
   airsonic:
     container_name: airsonic
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/bazarr/bazarr.hostname.yml
+++ b/compose/.apps/bazarr/bazarr.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  bazarr:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/bazarr/bazarr.yml
+++ b/compose/.apps/bazarr/bazarr.yml
@@ -3,7 +3,6 @@
 services:
   bazarr:
     container_name: bazarr
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/beets/beets.hostname.yml
+++ b/compose/.apps/beets/beets.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  beets:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/beets/beets.yml
+++ b/compose/.apps/beets/beets.yml
@@ -3,7 +3,6 @@
 services:
   beets:
     container_name: beets
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/bitwarden/bitwarden.hostname.yml
+++ b/compose/.apps/bitwarden/bitwarden.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  bitwarden:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/bitwarden/bitwarden.yml
+++ b/compose/.apps/bitwarden/bitwarden.yml
@@ -3,7 +3,6 @@
 services:
   bitwarden:
     container_name: bitwarden
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/booksonic/booksonic.hostname.yml
+++ b/compose/.apps/booksonic/booksonic.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  booksonic:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/booksonic/booksonic.yml
+++ b/compose/.apps/booksonic/booksonic.yml
@@ -3,7 +3,6 @@
 services:
   booksonic:
     container_name: booksonic
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/calibreweb/calibreweb.hostname.yml
+++ b/compose/.apps/calibreweb/calibreweb.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  calibreweb:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/calibreweb/calibreweb.yml
+++ b/compose/.apps/calibreweb/calibreweb.yml
@@ -3,7 +3,6 @@
 services:
   calibreweb:
     container_name: calibreweb
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/cloudcmd/cloudcmd.hostname.yml
+++ b/compose/.apps/cloudcmd/cloudcmd.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  cloudcmd:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/cloudcmd/cloudcmd.yml
+++ b/compose/.apps/cloudcmd/cloudcmd.yml
@@ -3,7 +3,6 @@
 services:
   cloudcmd:
     container_name: cloudcmd
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/cloudflareddns/cloudflareddns.hostname.yml
+++ b/compose/.apps/cloudflareddns/cloudflareddns.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  cloudflareddns:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/cloudflareddns/cloudflareddns.yml
+++ b/compose/.apps/cloudflareddns/cloudflareddns.yml
@@ -3,7 +3,6 @@
 services:
   cloudflareddns:
     container_name: cloudflareddns
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/couchpotato/couchpotato.hostname.yml
+++ b/compose/.apps/couchpotato/couchpotato.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  couchpotato:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/couchpotato/couchpotato.yml
+++ b/compose/.apps/couchpotato/couchpotato.yml
@@ -3,7 +3,6 @@
 services:
   couchpotato:
     container_name: couchpotato
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/ddclient/ddclient.hostname.yml
+++ b/compose/.apps/ddclient/ddclient.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  ddclient:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/ddclient/ddclient.yml
+++ b/compose/.apps/ddclient/ddclient.yml
@@ -3,7 +3,6 @@
 services:
   ddclient:
     container_name: ddclient
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/deluge/deluge.hostname.yml
+++ b/compose/.apps/deluge/deluge.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  deluge:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/deluge/deluge.yml
+++ b/compose/.apps/deluge/deluge.yml
@@ -3,7 +3,6 @@
 services:
   deluge:
     container_name: deluge
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/delugevpn/delugevpn.hostname.yml
+++ b/compose/.apps/delugevpn/delugevpn.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  delugevpn:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/delugevpn/delugevpn.yml
+++ b/compose/.apps/delugevpn/delugevpn.yml
@@ -3,7 +3,6 @@
 services:
   delugevpn:
     container_name: delugevpn
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/duckdns/duckdns.hostname.yml
+++ b/compose/.apps/duckdns/duckdns.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  duckdns:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/duckdns/duckdns.yml
+++ b/compose/.apps/duckdns/duckdns.yml
@@ -3,7 +3,6 @@
 services:
   duckdns:
     container_name: duckdns
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/duplicati/duplicati.hostname.yml
+++ b/compose/.apps/duplicati/duplicati.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  duplicati:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/duplicati/duplicati.yml
+++ b/compose/.apps/duplicati/duplicati.yml
@@ -3,7 +3,6 @@
 services:
   duplicati:
     container_name: duplicati
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/emby/emby.hostname.yml
+++ b/compose/.apps/emby/emby.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  emby:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/emby/emby.yml
+++ b/compose/.apps/emby/emby.yml
@@ -3,7 +3,6 @@
 services:
   emby:
     container_name: emby
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/freshrss/freshrss.hostname.yml
+++ b/compose/.apps/freshrss/freshrss.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  freshrss:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/freshrss/freshrss.yml
+++ b/compose/.apps/freshrss/freshrss.yml
@@ -3,7 +3,6 @@
 services:
   freshrss:
     container_name: freshrss
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/glances/glances.hostname.yml
+++ b/compose/.apps/glances/glances.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  glances:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/glances/glances.yml
+++ b/compose/.apps/glances/glances.yml
@@ -3,7 +3,6 @@
 services:
   glances:
     container_name: glances
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/grafana/grafana.hostname.yml
+++ b/compose/.apps/grafana/grafana.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  grafana:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/grafana/grafana.yml
+++ b/compose/.apps/grafana/grafana.yml
@@ -3,7 +3,6 @@
 services:
   grafana:
     container_name: grafana
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/guacamole/guacamole.hostname.yml
+++ b/compose/.apps/guacamole/guacamole.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  guacamole:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/guacamole/guacamole.yml
+++ b/compose/.apps/guacamole/guacamole.yml
@@ -3,7 +3,6 @@
 services:
   guacamole:
     container_name: guacamole
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/h5ai/h5ai.hostname.yml
+++ b/compose/.apps/h5ai/h5ai.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  h5ai:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/h5ai/h5ai.yml
+++ b/compose/.apps/h5ai/h5ai.yml
@@ -3,7 +3,6 @@
 services:
   h5ai:
     container_name: h5ai
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/handbrake/handbrake.hostname.yml
+++ b/compose/.apps/handbrake/handbrake.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  handbrake:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/handbrake/handbrake.yml
+++ b/compose/.apps/handbrake/handbrake.yml
@@ -3,7 +3,6 @@
 services:
   handbrake:
     container_name: handbrake
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/headphones/headphones.hostname.yml
+++ b/compose/.apps/headphones/headphones.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  headphones:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/headphones/headphones.yml
+++ b/compose/.apps/headphones/headphones.yml
@@ -3,7 +3,6 @@
 services:
   headphones:
     container_name: headphones
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/heimdall/heimdall.hostname.yml
+++ b/compose/.apps/heimdall/heimdall.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  heimdall:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/heimdall/heimdall.yml
+++ b/compose/.apps/heimdall/heimdall.yml
@@ -3,7 +3,6 @@
 services:
   heimdall:
     container_name: heimdall
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/homeassistant/homeassistant.hostname.yml
+++ b/compose/.apps/homeassistant/homeassistant.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  homeassistant:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/homeassistant/homeassistant.yml
+++ b/compose/.apps/homeassistant/homeassistant.yml
@@ -3,7 +3,6 @@
 services:
   homeassistant:
     container_name: homeassistant
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/htpcmanager/htpcmanager.hostname.yml
+++ b/compose/.apps/htpcmanager/htpcmanager.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  htpcmanager:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/htpcmanager/htpcmanager.yml
+++ b/compose/.apps/htpcmanager/htpcmanager.yml
@@ -3,7 +3,6 @@
 services:
   htpcmanager:
     container_name: htpcmanager
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/hydra2/hydra2.hostname.yml
+++ b/compose/.apps/hydra2/hydra2.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  hydra2:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/hydra2/hydra2.yml
+++ b/compose/.apps/hydra2/hydra2.yml
@@ -3,7 +3,6 @@
 services:
   hydra2:
     container_name: hydra2
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/influxdb/influxdb.hostname.yml
+++ b/compose/.apps/influxdb/influxdb.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  influxdb:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/influxdb/influxdb.yml
+++ b/compose/.apps/influxdb/influxdb.yml
@@ -3,7 +3,6 @@
 services:
   influxdb:
     container_name: influxdb
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/jackett/jackett.hostname.yml
+++ b/compose/.apps/jackett/jackett.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  jackett:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/jackett/jackett.yml
+++ b/compose/.apps/jackett/jackett.yml
@@ -3,7 +3,6 @@
 services:
   jackett:
     container_name: jackett
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/lazylibrarian/lazylibrarian.hostname.yml
+++ b/compose/.apps/lazylibrarian/lazylibrarian.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  lazylibrarian:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/lazylibrarian/lazylibrarian.yml
+++ b/compose/.apps/lazylibrarian/lazylibrarian.yml
@@ -3,7 +3,6 @@
 services:
   lazylibrarian:
     container_name: lazylibrarian
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/letsencrypt/letsencrypt.hostname.yml
+++ b/compose/.apps/letsencrypt/letsencrypt.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  letsencrypt:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/letsencrypt/letsencrypt.yml
+++ b/compose/.apps/letsencrypt/letsencrypt.yml
@@ -3,7 +3,6 @@
 services:
   letsencrypt:
     container_name: letsencrypt
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/lidarr/lidarr.hostname.yml
+++ b/compose/.apps/lidarr/lidarr.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  lidarr:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/lidarr/lidarr.yml
+++ b/compose/.apps/lidarr/lidarr.yml
@@ -3,7 +3,6 @@
 services:
   lidarr:
     container_name: lidarr
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/logarr/logarr.hostname.yml
+++ b/compose/.apps/logarr/logarr.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  logarr:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/logarr/logarr.yml
+++ b/compose/.apps/logarr/logarr.yml
@@ -3,7 +3,6 @@
 services:
   logarr:
     container_name: logarr
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/logitechmediaserver/logitechmediaserver.hostname.yml
+++ b/compose/.apps/logitechmediaserver/logitechmediaserver.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  logitechmediaserver:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/logitechmediaserver/logitechmediaserver.yml
+++ b/compose/.apps/logitechmediaserver/logitechmediaserver.yml
@@ -3,7 +3,6 @@
 services:
   logitechmediaserver:
     container_name: logitechmediaserver
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/makemkv/makemkv.hostname.yml
+++ b/compose/.apps/makemkv/makemkv.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  makemkv:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/makemkv/makemkv.yml
+++ b/compose/.apps/makemkv/makemkv.yml
@@ -3,7 +3,6 @@
 services:
   makemkv:
     container_name: makemkv
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/mariadb/mariadb.hostname.yml
+++ b/compose/.apps/mariadb/mariadb.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  mariadb:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/mariadb/mariadb.yml
+++ b/compose/.apps/mariadb/mariadb.yml
@@ -3,7 +3,6 @@
 services:
   mariadb:
     container_name: mariadb
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/mcmyadmin2/mcmyadmin2.hostname.yml
+++ b/compose/.apps/mcmyadmin2/mcmyadmin2.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  mcmyadmin2:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/mcmyadmin2/mcmyadmin2.yml
+++ b/compose/.apps/mcmyadmin2/mcmyadmin2.yml
@@ -3,7 +3,6 @@
 services:
   mcmyadmin2:
     container_name: mcmyadmin2
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/medusa/medusa.hostname.yml
+++ b/compose/.apps/medusa/medusa.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  medusa:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/medusa/medusa.yml
+++ b/compose/.apps/medusa/medusa.yml
@@ -3,7 +3,6 @@
 services:
   medusa:
     container_name: medusa
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/monitorr/monitorr.hostname.yml
+++ b/compose/.apps/monitorr/monitorr.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  monitorr:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/monitorr/monitorr.yml
+++ b/compose/.apps/monitorr/monitorr.yml
@@ -3,7 +3,6 @@
 services:
   monitorr:
     container_name: monitorr
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/muximux/muximux.hostname.yml
+++ b/compose/.apps/muximux/muximux.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  muximux:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/muximux/muximux.yml
+++ b/compose/.apps/muximux/muximux.yml
@@ -3,7 +3,6 @@
 services:
   muximux:
     container_name: muximux
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/mylar/mylar.hostname.yml
+++ b/compose/.apps/mylar/mylar.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  mylar:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/mylar/mylar.yml
+++ b/compose/.apps/mylar/mylar.yml
@@ -3,7 +3,6 @@
 services:
   mylar:
     container_name: mylar
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/netdata/netdata.hostname.yml
+++ b/compose/.apps/netdata/netdata.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  netdata:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/netdata/netdata.yml
+++ b/compose/.apps/netdata/netdata.yml
@@ -3,7 +3,6 @@
 services:
   netdata:
     container_name: netdata
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/nextcloud/nextcloud.hostname.yml
+++ b/compose/.apps/nextcloud/nextcloud.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  nextcloud:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/nextcloud/nextcloud.yml
+++ b/compose/.apps/nextcloud/nextcloud.yml
@@ -3,7 +3,6 @@
 services:
   nextcloud:
     container_name: nextcloud
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/nzbget/nzbget.hostname.yml
+++ b/compose/.apps/nzbget/nzbget.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  nzbget:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/nzbget/nzbget.yml
+++ b/compose/.apps/nzbget/nzbget.yml
@@ -3,7 +3,6 @@
 services:
   nzbget:
     container_name: nzbget
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/nzbgetvpn/nzbgetvpn.hostname.yml
+++ b/compose/.apps/nzbgetvpn/nzbgetvpn.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  nzbgetvpn:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/nzbgetvpn/nzbgetvpn.yml
+++ b/compose/.apps/nzbgetvpn/nzbgetvpn.yml
@@ -3,7 +3,6 @@
 services:
   nzbgetvpn:
     container_name: nzbgetvpn
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/ombi/ombi.hostname.yml
+++ b/compose/.apps/ombi/ombi.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  ombi:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/ombi/ombi.yml
+++ b/compose/.apps/ombi/ombi.yml
@@ -3,7 +3,6 @@
 services:
   ombi:
     container_name: ombi
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/openvpnas/openvpnas.hostname.yml
+++ b/compose/.apps/openvpnas/openvpnas.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  openvpnas:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/openvpnas/openvpnas.yml
+++ b/compose/.apps/openvpnas/openvpnas.yml
@@ -3,7 +3,6 @@
 services:
   openvpnas:
     container_name: openvpnas
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/organizr/organizr.hostname.yml
+++ b/compose/.apps/organizr/organizr.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  organizr:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/organizr/organizr.yml
+++ b/compose/.apps/organizr/organizr.yml
@@ -3,7 +3,6 @@
 services:
   organizr:
     container_name: organizr
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/ouroboros/ouroboros.hostname.yml
+++ b/compose/.apps/ouroboros/ouroboros.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  ouroboros:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/ouroboros/ouroboros.yml
+++ b/compose/.apps/ouroboros/ouroboros.yml
@@ -3,7 +3,6 @@
 services:
   ouroboros:
     container_name: ouroboros
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/phpmyadmin/phpmyadmin.hostname.yml
+++ b/compose/.apps/phpmyadmin/phpmyadmin.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  phpmyadmin:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/phpmyadmin/phpmyadmin.yml
+++ b/compose/.apps/phpmyadmin/phpmyadmin.yml
@@ -3,7 +3,6 @@
 services:
   phpmyadmin:
     container_name: phpmyadmin
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/pihole/pihole.hostname.yml
+++ b/compose/.apps/pihole/pihole.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  pihole:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/pihole/pihole.yml
+++ b/compose/.apps/pihole/pihole.yml
@@ -3,7 +3,6 @@
 services:
   pihole:
     container_name: pihole
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/plex/plex.hostname.yml
+++ b/compose/.apps/plex/plex.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  plex:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/plex/plex.yml
+++ b/compose/.apps/plex/plex.yml
@@ -3,7 +3,6 @@
 services:
   plex:
     container_name: plex
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/plexrequests/plexrequests.hostname.yml
+++ b/compose/.apps/plexrequests/plexrequests.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  plexrequests:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/plexrequests/plexrequests.yml
+++ b/compose/.apps/plexrequests/plexrequests.yml
@@ -3,7 +3,6 @@
 services:
   plexrequests:
     container_name: plexrequests
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/portainer/portainer.hostname.yml
+++ b/compose/.apps/portainer/portainer.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  portainer:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/portainer/portainer.yml
+++ b/compose/.apps/portainer/portainer.yml
@@ -3,7 +3,6 @@
 services:
   portainer:
     container_name: portainer
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/portaineragent/portaineragent.hostname.yml
+++ b/compose/.apps/portaineragent/portaineragent.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  portaineragent:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/portaineragent/portaineragent.yml
+++ b/compose/.apps/portaineragent/portaineragent.yml
@@ -3,7 +3,6 @@
 services:
   portaineragent:
     container_name: portaineragent
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/pyload/pyload.hostname.yml
+++ b/compose/.apps/pyload/pyload.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  pyload:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/pyload/pyload.yml
+++ b/compose/.apps/pyload/pyload.yml
@@ -3,7 +3,6 @@
 services:
   pyload:
     container_name: pyload
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/qbittorrent/qbittorrent.hostname.yml
+++ b/compose/.apps/qbittorrent/qbittorrent.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  qbittorrent:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/qbittorrent/qbittorrent.yml
+++ b/compose/.apps/qbittorrent/qbittorrent.yml
@@ -3,7 +3,6 @@
 services:
   qbittorrent:
     container_name: qbittorrent
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/qbittorrentvpn/qbittorrentvpn.hostname.yml
+++ b/compose/.apps/qbittorrentvpn/qbittorrentvpn.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  qbittorrentvpn:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/qbittorrentvpn/qbittorrentvpn.yml
+++ b/compose/.apps/qbittorrentvpn/qbittorrentvpn.yml
@@ -3,7 +3,6 @@
 services:
   qbittorrentvpn:
     container_name: qbittorrentvpn
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/radarr/radarr.hostname.yml
+++ b/compose/.apps/radarr/radarr.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  radarr:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/radarr/radarr.yml
+++ b/compose/.apps/radarr/radarr.yml
@@ -3,7 +3,6 @@
 services:
   radarr:
     container_name: radarr
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/resiliosync/resiliosync.hostname.yml
+++ b/compose/.apps/resiliosync/resiliosync.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  resiliosync:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/resiliosync/resiliosync.yml
+++ b/compose/.apps/resiliosync/resiliosync.yml
@@ -3,7 +3,6 @@
 services:
   resiliosync:
     container_name: resiliosync
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/rtorrentvpn/rtorrentvpn.hostname.yml
+++ b/compose/.apps/rtorrentvpn/rtorrentvpn.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  rtorrentvpn:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/rtorrentvpn/rtorrentvpn.yml
+++ b/compose/.apps/rtorrentvpn/rtorrentvpn.yml
@@ -3,7 +3,6 @@
 services:
   rtorrentvpn:
     container_name: rtorrentvpn
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/rutorrent/rutorrent.hostname.yml
+++ b/compose/.apps/rutorrent/rutorrent.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  rutorrent:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/rutorrent/rutorrent.yml
+++ b/compose/.apps/rutorrent/rutorrent.yml
@@ -3,7 +3,6 @@
 services:
   rutorrent:
     container_name: rutorrent
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/sabnzbd/sabnzbd.hostname.yml
+++ b/compose/.apps/sabnzbd/sabnzbd.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  sabnzbd:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/sabnzbd/sabnzbd.yml
+++ b/compose/.apps/sabnzbd/sabnzbd.yml
@@ -3,7 +3,6 @@
 services:
   sabnzbd:
     container_name: sabnzbd
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/sabnzbdvpn/sabnzbdvpn.hostname.yml
+++ b/compose/.apps/sabnzbdvpn/sabnzbdvpn.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  sabnzbdvpn:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/sabnzbdvpn/sabnzbdvpn.yml
+++ b/compose/.apps/sabnzbdvpn/sabnzbdvpn.yml
@@ -3,7 +3,6 @@
 services:
   sabnzbdvpn:
     container_name: sabnzbdvpn
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/samba/samba.hostname.yml
+++ b/compose/.apps/samba/samba.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  samba:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/samba/samba.yml
+++ b/compose/.apps/samba/samba.yml
@@ -12,7 +12,6 @@ services:
         -s "Movies;/data/movies;yes;no;no;${SAMBA_USERNAME}" \
         -s "Music;/data/music;yes;no;no;${SAMBA_USERNAME}" \
         -s "TV;/data/tv;yes;no;no;${SAMBA_USERNAME}"
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/sickrage/sickrage.hostname.yml
+++ b/compose/.apps/sickrage/sickrage.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  sickrage:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/sickrage/sickrage.yml
+++ b/compose/.apps/sickrage/sickrage.yml
@@ -3,7 +3,6 @@
 services:
   sickrage:
     container_name: sickrage
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/smokeping/smokeping.hostname.yml
+++ b/compose/.apps/smokeping/smokeping.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  smokeping:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/smokeping/smokeping.yml
+++ b/compose/.apps/smokeping/smokeping.yml
@@ -3,7 +3,6 @@
 services:
   smokeping:
     container_name: smokeping
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/sonarr/sonarr.hostname.yml
+++ b/compose/.apps/sonarr/sonarr.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  sonarr:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/sonarr/sonarr.yml
+++ b/compose/.apps/sonarr/sonarr.yml
@@ -3,7 +3,6 @@
 services:
   sonarr:
     container_name: sonarr
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/syncthing/syncthing.hostname.yml
+++ b/compose/.apps/syncthing/syncthing.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  syncthing:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/syncthing/syncthing.yml
+++ b/compose/.apps/syncthing/syncthing.yml
@@ -3,7 +3,6 @@
 services:
   syncthing:
     container_name: syncthing
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/tautulli/tautulli.hostname.yml
+++ b/compose/.apps/tautulli/tautulli.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  tautulli:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/tautulli/tautulli.yml
+++ b/compose/.apps/tautulli/tautulli.yml
@@ -3,7 +3,6 @@
 services:
   tautulli:
     container_name: tautulli
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/telegraf/telegraf.hostname.yml
+++ b/compose/.apps/telegraf/telegraf.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  telegraf:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/telegraf/telegraf.yml
+++ b/compose/.apps/telegraf/telegraf.yml
@@ -3,7 +3,6 @@
 services:
   telegraf:
     container_name: telegraf
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/thelounge/thelounge.hostname.yml
+++ b/compose/.apps/thelounge/thelounge.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  thelounge:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/thelounge/thelounge.yml
+++ b/compose/.apps/thelounge/thelounge.yml
@@ -3,7 +3,6 @@
 services:
   thelounge:
     container_name: thelounge
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/transmission/transmission.hostname.yml
+++ b/compose/.apps/transmission/transmission.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  transmission:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/transmission/transmission.yml
+++ b/compose/.apps/transmission/transmission.yml
@@ -3,7 +3,6 @@
 services:
   transmission:
     container_name: transmission
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/transmissionvpn/transmissionvpn.hostname.yml
+++ b/compose/.apps/transmissionvpn/transmissionvpn.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  transmissionvpn:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/transmissionvpn/transmissionvpn.yml
+++ b/compose/.apps/transmissionvpn/transmissionvpn.yml
@@ -3,7 +3,6 @@
 services:
   transmissionvpn:
     container_name: transmissionvpn
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/ttrss/ttrss.hostname.yml
+++ b/compose/.apps/ttrss/ttrss.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  ttrss:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/ttrss/ttrss.yml
+++ b/compose/.apps/ttrss/ttrss.yml
@@ -3,7 +3,6 @@
 services:
   ttrss:
     container_name: ttrss
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/tvheadend/tvheadend.hostname.yml
+++ b/compose/.apps/tvheadend/tvheadend.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  tvheadend:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/tvheadend/tvheadend.yml
+++ b/compose/.apps/tvheadend/tvheadend.yml
@@ -3,7 +3,6 @@
 services:
   tvheadend:
     container_name: tvheadend
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/ubooquity/ubooquity.hostname.yml
+++ b/compose/.apps/ubooquity/ubooquity.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  ubooquity:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/ubooquity/ubooquity.yml
+++ b/compose/.apps/ubooquity/ubooquity.yml
@@ -3,7 +3,6 @@
 services:
   ubooquity:
     container_name: ubooquity
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/unifi/unifi.hostname.yml
+++ b/compose/.apps/unifi/unifi.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  unifi:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/unifi/unifi.yml
+++ b/compose/.apps/unifi/unifi.yml
@@ -3,7 +3,6 @@
 services:
   unifi:
     container_name: unifi
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/varken/varken.hostname.yml
+++ b/compose/.apps/varken/varken.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  varken:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/varken/varken.yml
+++ b/compose/.apps/varken/varken.yml
@@ -3,7 +3,6 @@
 services:
   varken:
     container_name: varken
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/vsftpd/vsftpd.hostname.yml
+++ b/compose/.apps/vsftpd/vsftpd.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  vsftpd:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/vsftpd/vsftpd.yml
+++ b/compose/.apps/vsftpd/vsftpd.yml
@@ -3,7 +3,6 @@
 services:
   vsftpd:
     container_name: vsftpd
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose/.apps/watchtower/watchtower.hostname.yml
+++ b/compose/.apps/watchtower/watchtower.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  watchtower:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/watchtower/watchtower.yml
+++ b/compose/.apps/watchtower/watchtower.yml
@@ -3,7 +3,6 @@
 services:
   watchtower:
     container_name: watchtower
-    hostname: ${DOCKERHOSTNAME}
     restart: unless-stopped
     logging:
       driver: "json-file"


### PR DESCRIPTION
## Purpose

This closes #708

## Approach

Reduce some of the output from `generate_yml` and split the `hostname` directive out from the main yml file for each app and into their own file that can be included as needed. For now it is included anytime the ports file is included. This is not combined with the ports file in case it could be included with other network modes in the future.

#### Open Questions and Pre-Merge TODOs

- [x] Testing
- [ ] After this merges, tag any other open PR involving adding new apps in the comments below requesting updates to reflect the new changes
- [x] Update contributing guideline

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
