### PR TITLE
Correcting wording smb-mounting.md

### DIFF
--- a/docs/advanced/smb-mounting.md
+++ b/docs/advanced/smb-mounting.md
@@ -18,7 +18,7 @@ Then once that's done, you should be able to mount your SMB/Windows Share like s
 sudo mount -t cifs //<host>/Downloads /mnt/downloads -o uid=1000,gid=1000,credentials=/home/<your home user>/.credentials,rw,vers=3.0
 ```
 And to make sure that sticks, you're going to put this entry in your `/etc/fstab` file (You'll probably want to put it at the bottom) to match:
-`//<host>/Downloads /mnt/downloads cifs uid=1000,gid=1000,credentials=/home/<your home user>/.mount-creds,rw,vers=3.0`
+`//<host>/Downloads /mnt/downloads cifs uid=1000,gid=1000,credentials=/home/<your home user>/.credentials,rw,vers=3.0`
 
 You should be able to reboot to test the mount, but you should now be able to `ls -al /mnt/Downloads` (in my example) and see the files in your Shared Downloads folder!
 


### PR DESCRIPTION
## Purpose

Updating the wording of smb-mounting.md documentation as it was telling users to create one file and it was instructing them to call for another file

## Approach

This tutorial was telling users to create a file called `.credentials` but on line 18 it was having them use `.mount-creds` instead of `.credentials` which would result in a "file not found error". 

Proposed change will avoid future confusion.

#### Open Questions and Pre-Merge TODOs

- [x] Use github checklists. When solved, check the box and explain the answer.

#### Learning

_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
