### PR TITLE
Switch to LSIO jellyfin

### DIFF
--- a/compose/.apps/jellyfin/jellyfin.aarch64.yml
+++ b/compose/.apps/jellyfin/jellyfin.aarch64.yml
@@ -1,3 +1,3 @@
 services:
   jellyfin:
-    image: jellyfin/jellyfin:master-arm64
+    image: linuxserver/jellyfin

--- a/compose/.apps/jellyfin/jellyfin.armv7l.yml
+++ b/compose/.apps/jellyfin/jellyfin.armv7l.yml
@@ -1,3 +1,3 @@
 services:
   jellyfin:
-    image: jellyfin/jellyfin:master-arm
+    image: linuxserver/jellyfin

--- a/compose/.apps/jellyfin/jellyfin.ports.yml
+++ b/compose/.apps/jellyfin/jellyfin.ports.yml
@@ -2,3 +2,4 @@ services:
   jellyfin:
     ports:
       - ${JELLYFIN_PORT_8096}:8096
+      - ${JELLYFIN_PORT_8920}:8920

--- a/compose/.apps/jellyfin/jellyfin.x86_64.yml
+++ b/compose/.apps/jellyfin/jellyfin.x86_64.yml
@@ -1,3 +1,3 @@
 services:
   jellyfin:
-    image: jellyfin/jellyfin
+    image: linuxserver/jellyfin

--- a/compose/.apps/jellyfin/jellyfin.yml
+++ b/compose/.apps/jellyfin/jellyfin.yml
@@ -2,6 +2,8 @@ services:
   jellyfin:
     container_name: jellyfin
     environment:
+      - PGID=${PGID}
+      - PUID=${PUID}
       - TZ=${TZ}
     labels:
       com.dockstarter.appinfo.description: "Free Software Media Browser"
@@ -12,15 +14,14 @@ services:
         max-file: ${DOCKERLOGGING_MAXFILE}
         max-size: ${DOCKERLOGGING_MAXSIZE}
     restart: unless-stopped
-    user: ${PUID}:${PGID}
     volumes:
       - /etc/localtime:/etc/localtime:ro
       - ${DOCKERCONFDIR}/jellyfin:/config
       - ${DOCKERSHAREDDIR}:/shared
-      - ${JELLYFIN_CACHEDIR}:/cache
-      - ${MEDIADIR_MOVIES}:/media/movies
+      - ${JELLYFIN_TRANSCODEDIR}:/transcode
+      - ${MEDIADIR_MOVIES}:/data/movies
       - ${MEDIADIR_MOVIES}:/movies
-      - ${MEDIADIR_MUSIC}:/media/music
+      - ${MEDIADIR_MUSIC}:/data/music
       - ${MEDIADIR_MUSIC}:/music
-      - ${MEDIADIR_TV}:/media/tv
+      - ${MEDIADIR_TV}:/data/tvshows
       - ${MEDIADIR_TV}:/tv


### PR DESCRIPTION
## Purpose

Use LSIO's new jellyfin image.

## Approach

Adjust variables and add new port.

#### Learning

https://hub.docker.com/r/linuxserver/jellyfin

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
