### PR TITLE
Add System Requirements info

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,18 +22,21 @@ You may choose to rely on DockSTARTer for various changes to your Docker system,
 
 ## Getting Started
 
+### System Requirements
+
+You must be running a [Supported platform](https://docs.docker.com/install/#supported-platforms) or an operating system based on one of the supported platforms listed. Each platform named below will be linked to documentation listing specific compatible versions.
+
 ### One Time Setup (required)
 
-- APT Systems (Debian/Ubuntu/Raspbian/etc)
+- APT Systems ([Debian](https://docs.docker.com/install/linux/docker-ce/debian/#os-requirements)/[Ubuntu](https://docs.docker.com/install/linux/docker-ce/ubuntu/#os-requirements)/Raspbian/etc)
 
 ```bash
-## NOTE: Ubuntu 18.10 is known to have issues with the installation process, 18.04 is recommended
 sudo apt-get install curl git
 bash -c "$(curl -fsSL https://get.dockstarter.com)"
 sudo reboot
 ```
 
-- DNF Systems (Fedora)
+- DNF Systems ([Fedora](https://docs.docker.com/install/linux/docker-ce/fedora/#os-requirements))
 
 ```bash
 sudo dnf install curl git
@@ -41,7 +44,7 @@ bash -c "$(curl -fsSL https://get.dockstarter.com)"
 sudo reboot
 ```
 
-- YUM Systems (CentOS)
+- YUM Systems ([CentOS](https://docs.docker.com/install/linux/docker-ce/centos/#os-requirements))
 
 ```bash
 sudo yum install curl git


### PR DESCRIPTION
## Purpose

Remove outdated information about Ubuntu 18.10. Include information linking to which systems and versions are supported. Note that as of writing 18.10 is supported and 19.04 is waiting for a release in https://download.docker.com/linux/ubuntu/dists/disco/pool/stable/amd64/

#### Learning

https://docs.docker.com/install/#supported-platforms
https://docs.docker.com/install/linux/docker-ce/debian/#os-requirements
https://docs.docker.com/install/linux/docker-ce/ubuntu/#os-requirements
https://docs.docker.com/install/linux/docker-ce/fedora/#os-requirements
https://docs.docker.com/install/linux/docker-ce/centos/#os-requirements

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
