### PR TITLE
Add EMBY_TRANSCODEDIR

### DIFF
--- a/compose/.apps/emby/emby.labels.yml
+++ b/compose/.apps/emby/emby.labels.yml
@@ -8,3 +8,4 @@ services:
       com.dockstarter.appvars.emby_network_mode: ""
       com.dockstarter.appvars.emby_port_8096: "8096"
       com.dockstarter.appvars.emby_port_8920: "8920"
+      com.dockstarter.appvars.emby_transcodedir: "/tmp"


### PR DESCRIPTION
## Purpose

Fix missing `EMBY_TRANSCODEDIR`

## Approach

Add the label so that emby will create the correct variable.

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
