### PR TITLE
Create all appvars

### DIFF
--- a/.scripts/appvars_create.sh
+++ b/.scripts/appvars_create.sh
@@ -24,6 +24,7 @@ appvars_create() {
         fi
 
     done < <(run_script 'yml_get' "${APPNAME}" "services.${FILENAME}.labels" || error "Unable to find labels for ${APPNAME}")
+    run_script 'env_set' "${APPNAME}_ENABLED" true
 }
 
 test_appvars_create() {

--- a/.scripts/appvars_create.sh
+++ b/.scripts/appvars_create.sh
@@ -28,6 +28,7 @@ appvars_create() {
 }
 
 test_appvars_create() {
+    run_script 'env_update'
     run_script 'appvars_create' PORTAINER
     cat "${SCRIPTPATH}/compose/.env"
 }

--- a/.scripts/appvars_create_all.sh
+++ b/.scripts/appvars_create_all.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+appvars_create_all() {
+    if grep -q '_ENABLED=true$' "${SCRIPTPATH}/compose/.env"; then
+        while IFS= read -r line; do
+            local APPNAME=${line%%_ENABLED=true}
+            run_script 'appvars_create' "${APPNAME}"
+        done < <(grep '_ENABLED=true$' < "${SCRIPTPATH}/compose/.env")
+    else
+        info "${SCRIPTPATH}/compose/.env does not contain any disabled apps."
+    fi
+}
+
+test_appvars_create_all() {
+    run_script 'appvars_create_all'
+    cat "${SCRIPTPATH}/compose/.env"
+}

--- a/.scripts/appvars_create_all.sh
+++ b/.scripts/appvars_create_all.sh
@@ -14,6 +14,7 @@ appvars_create_all() {
 }
 
 test_appvars_create_all() {
+    run_script 'env_update'
     run_script 'appvars_create_all'
     cat "${SCRIPTPATH}/compose/.env"
 }

--- a/.scripts/appvars_purge.sh
+++ b/.scripts/appvars_purge.sh
@@ -30,6 +30,7 @@ appvars_purge() {
 }
 
 test_appvars_purge() {
+    run_script 'env_update'
     run_script 'appvars_purge' PORTAINER
     cat "${SCRIPTPATH}/compose/.env"
 }

--- a/.scripts/appvars_purge_all.sh
+++ b/.scripts/appvars_purge_all.sh
@@ -22,6 +22,7 @@ appvars_purge_all() {
 }
 
 test_appvars_purge_all() {
+    run_script 'env_update'
     run_script 'appvars_purge_all'
     cat "${SCRIPTPATH}/compose/.env"
 }

--- a/.scripts/cmdline.sh
+++ b/.scripts/cmdline.sh
@@ -86,6 +86,7 @@ cmdline() {
                 ;;
             e)
                 run_script 'env_update'
+                run_script 'appvars_create_all'
                 exit
                 ;;
             h)

--- a/.scripts/config_apps.sh
+++ b/.scripts/config_apps.sh
@@ -4,6 +4,7 @@ IFS=$'\n\t'
 
 config_apps() {
     info "Configuring .env variables for enabled apps."
+    run_script 'appvars_create_all'
     while IFS= read -r line; do
         local APPNAME=${line%%_ENABLED=true}
         run_script 'menu_app_vars' "${APPNAME}" || return 1

--- a/.scripts/generate_yml.sh
+++ b/.scripts/generate_yml.sh
@@ -4,6 +4,7 @@ IFS=$'\n\t'
 
 generate_yml() {
     run_script 'env_update'
+    run_script 'appvars_create_all'
     info "Generating docker-compose.yml file."
     local RUNFILE
     RUNFILE=$(mktemp) || fatal "Failed to create temporary storage for yml generator."

--- a/.scripts/menu_app_vars.sh
+++ b/.scripts/menu_app_vars.sh
@@ -4,6 +4,7 @@ IFS=$'\n\t'
 
 menu_app_vars() {
     local APPNAME=${1:-}
+    run_script 'appvars_create' "${APPNAME}"
     local APPVARS
     APPVARS=$(grep -v "^${APPNAME}_ENABLED=" "${SCRIPTPATH}/compose/.env" | grep "^${APPNAME}_")
     if [[ -z ${APPVARS} ]]; then

--- a/.scripts/update_self.sh
+++ b/.scripts/update_self.sh
@@ -19,6 +19,7 @@ update_self() {
         chown -R "${DETECTED_PUID}":"${DETECTED_PGID}" "${line}" > /dev/null 2>&1 || true
     done < <(git ls-tree -r HEAD | awk '{print $4}')
     run_script 'env_update'
+    run_script 'appvars_create_all'
 }
 
 test_update_self() {


### PR DESCRIPTION
## Purpose

Ensure all appvars are created before they are needed. Ex: before prompting the user to edit them, or before trying to run containers that would use them.

Scenario: User who has `plexinc/pms-docker` prior to DS switching to `linuxserver/plex` would have incorrect variables after upgrading DS and not get the new variables automatically.

## Approach

Create `appvars_create_all` and run it in specific places. Also run `appvars_create` for specific apps when prompting for that app's vars. Also set app's enabled variable to true when adding its vars.

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
