### PR TITLE
Adjust snap docker removal

### DIFF
--- a/.scripts/install_docker.sh
+++ b/.scripts/install_docker.sh
@@ -4,6 +4,7 @@ IFS=$'\n\t'
 
 install_docker() {
     local MINIMUM_DOCKER="17.09.0"
+    run_script 'remove_snap_docker'
     local INSTALLED_DOCKER
     INSTALLED_DOCKER=$( (docker --version 2> /dev/null || echo "0") | sed -E 's/.* version ([^,]*)(, build .*)?/\1/')
     # Find minimum compatible version at https://docs.docker.com/engine/release-notes/
@@ -20,10 +21,6 @@ install_docker() {
         fi
         if vergt "${AVAILABLE_DOCKER}" "${INSTALLED_DOCKER}"; then
             run_script 'package_manager_run' remove_docker
-            if [[ -n "$(command -v snap)" ]]; then
-                info "Removing snap Docker package."
-                snap remove docker > /dev/null 2>&1 || true
-            fi
             # https://github.com/docker/docker-install
             info "Installing latest docker. Please be patient, this can take a while."
             local GET_DOCKER

--- a/.scripts/remove_snap_docker.sh
+++ b/.scripts/remove_snap_docker.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+remove_snap_docker() {
+    if [[ -n "$(command -v snap)" ]]; then
+        if snap services docker > /dev/null 2>&1; then
+            info "Removing snap Docker package."
+            snap remove docker > /dev/null 2>&1 || true
+        fi
+    fi
+}
+
+test_remove_snap_docker() {
+    run_script 'remove_snap_docker'
+}


### PR DESCRIPTION
## Purpose

This closes #748 

## Approach

Move snap docker removal code to a separate script. Use `snap services docker` to confirm snap docker is installed (and not run the removal unnecessarily). Move the call in the script above where it detects it docker is installed.

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
