### PR TITLE
Sanitizer improvements

### DIFF
--- a/.scripts/detect_lan_network.sh
+++ b/.scripts/detect_lan_network.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+detect_lan_network() {
+    # https://github.com/tom472/mediabox/commit/d6a3317c9513ac9907715c76fb4459cba426da18
+    # https://stackoverflow.com/questions/13322485/how-to-get-the-primary-ip-address-of-the-local-machine-on-linux-and-os-x#comment89955893_25851186
+    local DETECTED_LAN_NETWORK
+    DETECTED_LAN_NETWORK=$(ip a | grep -Po "$(ip route get 1 | sed -n 's/^.*src \([0-9.]*\) .*$/\1/p')\/\d+" | sed 's/[0-9]*\//0\//')
+    echo "${DETECTED_LAN_NETWORK}"
+}
+
+test_detect_lan_network() {
+    run_script 'detect_lan_network'
+}

--- a/.scripts/env_sanitize.sh
+++ b/.scripts/env_sanitize.sh
@@ -8,6 +8,14 @@ env_sanitize() {
         sed -i -E "s/^(\w+DIR)=~\//\1=$(sed 's/[&/\]/\\&/g' <<< "${DETECTED_HOMEDIR}")\//g" "${SCRIPTPATH}/compose/.env" | warning "Please verify that ~ is not used in ${SCRIPTPATH}/compose/.env file."
     fi
 
+    local LAN_NETWORK
+    LAN_NETWORK=$(run_script 'env_get' LAN_NETWORK)
+    if echo "${LAN_NETWORK}" | grep -q 'x'; then
+        local DETECTED_LAN_NETWORK
+        DETECTED_LAN_NETWORK=$(run_script 'detect_lan_network')
+        run_script 'env_set' LAN_NETWORK "${DETECTED_LAN_NETWORK}"
+    fi
+
     local OUROBOROS_ENABLED
     OUROBOROS_ENABLED=$(run_script 'env_get' OUROBOROS_ENABLED)
     local WATCHTOWER_ENABLED

--- a/.scripts/env_sanitize.sh
+++ b/.scripts/env_sanitize.sh
@@ -3,9 +3,9 @@ set -euo pipefail
 IFS=$'\n\t'
 
 env_sanitize() {
-    if grep -q '=~' "${SCRIPTPATH}/compose/.env"; then
+    if grep -q -E '^\w+DIR=~/' "${SCRIPTPATH}/compose/.env"; then
         info "Replacing ~ with ${DETECTED_HOMEDIR} in ${SCRIPTPATH}/compose/.env file."
-        sed -i "s/=~/=$(sed 's/[&/\]/\\&/g' <<< "${DETECTED_HOMEDIR}")/g" "${SCRIPTPATH}/compose/.env" | warning "Please verify that ~ is not used in ${SCRIPTPATH}/compose/.env file."
+        sed -i -E "s/^(\w+DIR)=~\//\1=$(sed 's/[&/\]/\\&/g' <<< "${DETECTED_HOMEDIR}")\//g" "${SCRIPTPATH}/compose/.env" | warning "Please verify that ~ is not used in ${SCRIPTPATH}/compose/.env file."
     fi
 
     local OUROBOROS_ENABLED

--- a/.scripts/menu_value_prompt.sh
+++ b/.scripts/menu_value_prompt.sh
@@ -47,9 +47,7 @@ menu_value_prompt() {
             VALUEOPTIONS+=("Use System " "${SYSTEM_VAL}")
             ;;
         LAN_NETWORK)
-            # https://github.com/tom472/mediabox/commit/d6a3317c9513ac9907715c76fb4459cba426da18
-            # https://stackoverflow.com/questions/13322485/how-to-get-the-primary-ip-address-of-the-local-machine-on-linux-and-os-x#comment89955893_25851186
-            SYSTEM_VAL=$(ip a | grep -Po "$(ip route get 1 | sed -n 's/^.*src \([0-9.]*\) .*$/\1/p')\/\d+" | sed 's/[0-9]*\//0\//')
+            SYSTEM_VAL=$(run_script 'detect_lan_network')
             VALUEOPTIONS+=("Use System " "${SYSTEM_VAL}")
             ;;
         MEDIADIR_BOOKS)


### PR DESCRIPTION
## Purpose

Adjust tilde sanitizer so that it only looks for variables that end in DIR. This way if `=~` were used somewhere in the value of another variable (for example a complex password) it is not replaced.

Move LAN_NETWORK detection to a separate script so that it can be reused in multiple places.


Set LAN_NETWORK for the user if it contains an x …
x will be present in the default value, and is not valid in a CIDR
Many users asking for support overlook this
This should also prevent overwriting values that users have manually set themselves (if they set them correctly and did not include an x)

#### Open Questions and Pre-Merge TODOs

- [x] Testing `ds -u origin/lan-network`
- - [x] Confirm LAN_NETWORK menu still works
- - [x] Confirm tilde directories are still replaced
- - [x] Confirm LAN_NETWORK is correctly set whenever it contains an `x` (the default value from .env.example should be replaced)

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
