### PR TITLE
Fix portaineragent

### DIFF
--- a/compose/.apps/portaineragent/portaineragent.hostname.yml
+++ b/compose/.apps/portaineragent/portaineragent.hostname.yml
@@ -1,3 +1,4 @@
 services:
   portaineragent:
-    hostname: ${DOCKERHOSTNAME}
+    #hostname: ${DOCKERHOSTNAME}
+    # This causes issues, leave it commented out

--- a/compose/.apps/portaineragent/portaineragent.yml
+++ b/compose/.apps/portaineragent/portaineragent.yml
@@ -2,6 +2,7 @@ services:
   portaineragent:
     container_name: portaineragent
     environment:
+      - CAP_HOST_MANAGEMENT=1
       - TZ=${TZ}
     logging:
       driver: json-file
@@ -10,6 +11,7 @@ services:
         max-size: ${DOCKERLOGGING_MAXSIZE}
     restart: unless-stopped
     volumes:
+      - /:/host
       - /etc/localtime:/etc/localtime:ro
       - /var/run/docker.sock:/var/run/docker.sock
       - /var/lib/docker/volumes:/var/lib/docker/volumes


### PR DESCRIPTION
## Purpose

Setting the hostname to match the docker host breaks this container. Also there are some additional capabilities added using an extra volume and environment variable.

## Approach

Comment out the hostname directive, but keep it so we have a reminder of why it was commented out.

#### Learning

https://portainer.readthedocs.io/en/stable/agent.html

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
