### PR TITLE
Rename some functions

### DIFF
--- a/.scripts/cmdline.sh
+++ b/.scripts/cmdline.sh
@@ -61,22 +61,22 @@ cmdline() {
             c)
                 case ${OPTARG} in
                     down)
-                        run_script 'run_compose' down
+                        run_script 'docker_compose' down
                         ;;
                     generate)
-                        run_script 'generate_yml'
+                        run_script 'yml_merge'
                         ;;
                     pull)
-                        run_script 'generate_yml'
-                        run_script 'run_compose' pull
+                        run_script 'yml_merge'
+                        run_script 'docker_compose' pull
                         ;;
                     restart)
-                        run_script 'generate_yml'
-                        run_script 'run_compose' restart
+                        run_script 'yml_merge'
+                        run_script 'docker_compose' restart
                         ;;
                     up)
-                        run_script 'generate_yml'
-                        run_script 'run_compose' up
+                        run_script 'yml_merge'
+                        run_script 'docker_compose' up
                         ;;
                     *)
                         fatal "Invalid compose option."
@@ -98,7 +98,7 @@ cmdline() {
                 exit
                 ;;
             p)
-                run_script 'prune_docker'
+                run_script 'docker_prune'
                 exit
                 ;;
             r)
@@ -124,8 +124,8 @@ cmdline() {
             :)
                 case ${OPTARG} in
                     c)
-                        run_script 'generate_yml'
-                        run_script 'run_compose'
+                        run_script 'yml_merge'
+                        run_script 'docker_compose'
                         exit
                         ;;
                     r)

--- a/.scripts/docker_compose.sh
+++ b/.scripts/docker_compose.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-run_compose() {
+docker_compose() {
     local COMMAND=${1:-}
     local COMPOSECOMMAND
     local COMMANDINFO
@@ -41,11 +41,11 @@ run_compose() {
     cd "${SCRIPTPATH}" || fatal "Failed to change directory to ${SCRIPTPATH}"
 }
 
-test_run_compose() {
+test_docker_compose() {
     cat "${SCRIPTPATH}/compose/.env"
-    run_script 'generate_yml'
+    run_script 'yml_merge'
     cd "${SCRIPTPATH}/compose/" || fatal "Failed to change to ${SCRIPTPATH}/compose/ directory."
     docker-compose config || fatal "Failed to validate ${SCRIPTPATH}/compose/docker-compose.yml file."
     cd "${SCRIPTPATH}" || fatal "Failed to change to ${SCRIPTPATH} directory."
-    run_script 'run_compose'
+    run_script 'docker_compose'
 }

--- a/.scripts/docker_prune.sh
+++ b/.scripts/docker_prune.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-prune_docker() {
+docker_prune() {
     if run_script 'question_prompt' "${PROMPT:-}" Y "Would you like to remove all unused containers, networks, volumes, images and build cache?"; then
         info "Removing unused docker resources."
     else
@@ -12,6 +12,6 @@ prune_docker() {
     docker system prune -a --volumes --force || error "Failed to remove unused docker resources."
 }
 
-test_prune_docker() {
-    run_script 'prune_docker'
+test_docker_prune() {
+    run_script 'docker_prune'
 }

--- a/.scripts/menu_config.sh
+++ b/.scripts/menu_config.sh
@@ -24,32 +24,32 @@ menu_config() {
             run_script 'config_apps'
             run_script 'config_vpn'
             run_script 'config_global'
-            run_script 'generate_yml'
-            run_script 'run_compose'
+            run_script 'yml_merge'
+            run_script 'docker_compose'
             ;;
         "Select Apps ")
             run_script 'env_update'
             run_script 'menu_app_select'
-            run_script 'generate_yml'
-            run_script 'run_compose'
+            run_script 'yml_merge'
+            run_script 'docker_compose'
             ;;
         "Set App Variables ")
             run_script 'env_update'
             run_script 'config_apps'
-            run_script 'generate_yml'
-            run_script 'run_compose'
+            run_script 'yml_merge'
+            run_script 'docker_compose'
             ;;
         "Set VPN Variables ")
             run_script 'env_update'
             run_script 'config_vpn'
-            run_script 'generate_yml'
-            run_script 'run_compose'
+            run_script 'yml_merge'
+            run_script 'docker_compose'
             ;;
         "Set Global Variables ")
             run_script 'env_update'
             run_script 'config_global'
-            run_script 'generate_yml'
-            run_script 'run_compose'
+            run_script 'yml_merge'
+            run_script 'docker_compose'
             ;;
         "Cancel")
             info "Returning to Main Menu."

--- a/.scripts/menu_main.sh
+++ b/.scripts/menu_main.sh
@@ -31,7 +31,7 @@ menu_main() {
             run_script 'menu_backup' || run_script 'menu_main'
             ;;
         "Prune Docker System ")
-            run_script 'prune_docker' || run_script 'menu_main'
+            run_script 'docker_prune' || run_script 'menu_main'
             ;;
         "Cancel")
             info "Exiting DockSTARTer."

--- a/.scripts/pm_apt_install.sh
+++ b/.scripts/pm_apt_install.sh
@@ -10,5 +10,6 @@ pm_apt_install() {
 }
 
 test_pm_apt_install() {
+    run_script 'pm_apt_repos'
     run_script 'pm_apt_install'
 }

--- a/.scripts/yml_merge.sh
+++ b/.scripts/yml_merge.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-generate_yml() {
+yml_merge() {
     run_script 'env_update'
     run_script 'appvars_create_all'
     info "Generating docker-compose.yml file."
@@ -62,11 +62,11 @@ generate_yml() {
     info "Merging docker-compose.yml complete."
 }
 
-test_generate_yml() {
+test_yml_merge() {
     run_script 'update_system'
     run_script 'appvars_create' PORTAINER
     cat "${SCRIPTPATH}/compose/.env"
-    run_script 'generate_yml'
+    run_script 'yml_merge'
     cd "${SCRIPTPATH}/compose/" || fatal "Failed to change to ${SCRIPTPATH}/compose/ directory."
     docker-compose config || fatal "Failed to validate ${SCRIPTPATH}/compose/docker-compose.yml file."
     cd "${SCRIPTPATH}" || fatal "Failed to change to ${SCRIPTPATH} directory."


### PR DESCRIPTION
## Purpose

Rename functions to more closely match the name of the primary command the function performs.

## Approach

`.scripts/run_compose.sh` → `.scripts/docker_compose.sh`
Primary commands are `docker-compose ...`

`.scripts/prune_docker.sh` → `.scripts/docker_prune.sh`
Primary command is `docker system prune`

`.scripts/generate_yml.sh` → `.scripts/yml_merge.sh`
Primary command is `yq-go m` (merge)

Testing has also been updated to resolve build errors.

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
