### PR TITLE
Ovpn

### DIFF
--- a/.scripts/config_vpn.sh
+++ b/.scripts/config_vpn.sh
@@ -4,7 +4,7 @@ IFS=$'\n\t'
 
 config_vpn() {
     local APPNAME="VPN"
-    local VARNAMES=(LAN_NETWORK NS1 NS2 VPN_ENABLE VPN_USER VPN_PASS VPN_PROV VPN_OPTIONS)
+    local VARNAMES=(LAN_NETWORK NS1 NS2 VPN_ENABLE VPN_USER VPN_PASS VPN_PROV VPN_OVPNDIR VPN_OPTIONS)
     local APPVARS
     APPVARS=$(for v in "${VARNAMES[@]}"; do echo "${v}=$(run_script 'env_get' "${v}")"; done)
 

--- a/.scripts/env_sanitize.sh
+++ b/.scripts/env_sanitize.sh
@@ -47,6 +47,7 @@ env_sanitize() {
         local DOCKERCONFDIR
         DOCKERCONFDIR=$(run_script 'env_get' DOCKERCONFDIR)
         find "${DOCKERCONFDIR}" -regex '.*\/openvpn\/.*\.ovpn$' -exec cp {} "${VPN_OVPNDIR}" \; | info "No ovpn files to found."
+        find "${DOCKERCONFDIR}" -regex '.*\/openvpn\/.*\.crt$' -exec cp {} "${VPN_OVPNDIR}" \; | info "No crt files to found."
     fi
 }
 

--- a/.scripts/env_sanitize.sh
+++ b/.scripts/env_sanitize.sh
@@ -35,6 +35,19 @@ env_sanitize() {
     if [[ ${WATCHTOWER_NETWORK_MODE} == "none" ]]; then
         run_script 'env_set' WATCHTOWER_NETWORK_MODE ""
     fi
+
+    # TEMPORARY
+    # There is no good place to put this code that makes sense to keep permanently
+    # This code should be removed after allowing a period of time for existing users to upgrade
+    local VPN_OVPNDIR
+    VPN_OVPNDIR=$(run_script 'env_get' VPN_OVPNDIR)
+    if grep -q 'VPN_ENABLED=true$' "${SCRIPTPATH}/compose/.env" && [[ ${VPN_OVPNDIR} != "" ]]; then
+        mkdir -p "${VPN_OVPNDIR}" || fatal "${VPN_OVPNDIR} folder could not be created."
+        run_script 'set_permissions' "${VPN_OVPNDIR}"
+        local DOCKERCONFDIR
+        DOCKERCONFDIR=$(run_script 'env_get' DOCKERCONFDIR)
+        find "${DOCKERCONFDIR}" -regex '.*\/openvpn\/.*\.ovpn$' -exec cp {} "${VPN_OVPNDIR}" \;
+    fi
 }
 
 test_env_sanitize() {

--- a/.scripts/env_sanitize.sh
+++ b/.scripts/env_sanitize.sh
@@ -46,7 +46,7 @@ env_sanitize() {
         run_script 'set_permissions' "${VPN_OVPNDIR}"
         local DOCKERCONFDIR
         DOCKERCONFDIR=$(run_script 'env_get' DOCKERCONFDIR)
-        find "${DOCKERCONFDIR}" -regex '.*\/openvpn\/.*\.ovpn$' -exec cp {} "${VPN_OVPNDIR}" \;
+        find "${DOCKERCONFDIR}" -regex '.*\/openvpn\/.*\.ovpn$' -exec cp {} "${VPN_OVPNDIR}" \; | info "No ovpn files to found."
     fi
 }
 

--- a/.scripts/env_sanitize.sh
+++ b/.scripts/env_sanitize.sh
@@ -10,7 +10,7 @@ env_sanitize() {
 
     local LAN_NETWORK
     LAN_NETWORK=$(run_script 'env_get' LAN_NETWORK)
-    if echo "${LAN_NETWORK}" | grep -q 'x'; then
+    if echo "${LAN_NETWORK}" | grep -q 'x' || [[ ${LAN_NETWORK} == "" ]]; then
         local DETECTED_LAN_NETWORK
         DETECTED_LAN_NETWORK=$(run_script 'detect_lan_network')
         run_script 'env_set' LAN_NETWORK "${DETECTED_LAN_NETWORK}"

--- a/compose/.apps/delugevpn/delugevpn.yml
+++ b/compose/.apps/delugevpn/delugevpn.yml
@@ -27,3 +27,4 @@ services:
       - ${DOCKERSHAREDDIR}:/shared
       - ${DOWNLOADSDIR}:/data
       - ${DOWNLOADSDIR}:/downloads
+      - ${VPN_OVPNDIR}:/config/openvpn

--- a/compose/.apps/nzbgetvpn/nzbgetvpn.yml
+++ b/compose/.apps/nzbgetvpn/nzbgetvpn.yml
@@ -27,3 +27,4 @@ services:
       - ${DOCKERSHAREDDIR}:/shared
       - ${DOWNLOADSDIR}:/data
       - ${DOWNLOADSDIR}:/downloads
+      - ${VPN_OVPNDIR}:/config/openvpn

--- a/compose/.apps/qbittorrentvpn/qbittorrentvpn.yml
+++ b/compose/.apps/qbittorrentvpn/qbittorrentvpn.yml
@@ -27,3 +27,4 @@ services:
       - ${DOCKERSHAREDDIR}:/shared
       - ${DOWNLOADSDIR}:/data
       - ${DOWNLOADSDIR}:/downloads
+      - ${VPN_OVPNDIR}:/config/openvpn

--- a/compose/.apps/rtorrentvpn/rtorrentvpn.yml
+++ b/compose/.apps/rtorrentvpn/rtorrentvpn.yml
@@ -30,3 +30,4 @@ services:
       - ${DOCKERSHAREDDIR}:/shared
       - ${DOWNLOADSDIR}:/data
       - ${DOWNLOADSDIR}:/downloads
+      - ${VPN_OVPNDIR}:/config/openvpn

--- a/compose/.apps/sabnzbdvpn/sabnzbdvpn.yml
+++ b/compose/.apps/sabnzbdvpn/sabnzbdvpn.yml
@@ -27,3 +27,4 @@ services:
       - ${DOCKERSHAREDDIR}:/shared
       - ${DOWNLOADSDIR}:/data
       - ${DOWNLOADSDIR}:/downloads
+      - ${VPN_OVPNDIR}:/config/openvpn

--- a/compose/.apps/transmissionvpn/transmissionvpn.yml
+++ b/compose/.apps/transmissionvpn/transmissionvpn.yml
@@ -32,3 +32,4 @@ services:
       - ${DOCKERSHAREDDIR}:/shared
       - ${DOWNLOADSDIR}:/data
       - ${DOWNLOADSDIR}:/downloads
+      - ${VPN_OVPNDIR}:/etc/openvpn/custom/

--- a/compose/.env.example
+++ b/compose/.env.example
@@ -37,6 +37,7 @@ NS1=1.1.1.1
 NS2=8.8.8.8
 VPN_ENABLE=yes
 VPN_OPTIONS=
+VPN_OVPNDIR=~/.config/appdata/.openvpn
 VPN_PASS=
 VPN_PROV=pia
 VPN_USER=


### PR DESCRIPTION
## Purpose

This closes #759

## Approach

Add a `VPN_OVPNDIR` variable and prompt for it with the other VPN variables. Use `VPN_OVPNDIR` in all VPN+download client containers in the proper locations.

Temporarily include code to collect `*.ovpn` files from the app folders inside `DOCKERCONFDIR` and copy them to the new `VPN_OVPNDIR`.

#### Open Questions and Pre-Merge TODOs

- [x] Test `ds -u origin/ovpn`

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
