### PR TITLE
Adjust set_permissions for travis

### DIFF
--- a/.scripts/set_permissions.sh
+++ b/.scripts/set_permissions.sh
@@ -25,11 +25,6 @@ set_permissions() {
     esac
     local CH_PUID=${2:-$DETECTED_PUID}
     local CH_PGID=${3:-$DETECTED_PGID}
-    if [[ ${CI:-} == true ]]; then
-        info "Overriding PUID and PGID for Travis."
-        CH_PUID=${DETECTED_UNAME}
-        CH_PGID=${DETECTED_UGROUP}
-    fi
     if [[ ${CH_PUID} -ne 0 ]] && [[ ${CH_PGID} -ne 0 ]]; then
         info "Taking ownership of ${CH_PATH} for user ${CH_PUID} and group ${CH_PGID}"
         chown -R "${CH_PUID}":"${CH_PGID}" "${CH_PATH}" > /dev/null 2>&1 || true


### PR DESCRIPTION
## Purpose

This is causing issues with Travis builds. It was added because Travis was unhappy without it, but it seems to pass builds workout it now.

## Approach

Remove the code causing builds to fail

#### Learning

https://travis-ci.com/GhostWriters/DockSTARTer/builds/120521276

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
