### PR TITLE
Add codeserver

### DIFF
--- a/compose/.apps/codeserver/codeserver.hostname.yml
+++ b/compose/.apps/codeserver/codeserver.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  codeserver:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/codeserver/codeserver.labels.yml
+++ b/compose/.apps/codeserver/codeserver.labels.yml
@@ -1,0 +1,11 @@
+services:
+  codeserver:
+    labels:
+      com.dockstarter.appinfo.description: "VS Code running on a remote server, accessible through the browser"
+      com.dockstarter.appinfo.nicename: "code-server"
+      com.dockstarter.appvars.codeserver_backup_config: "true"
+      com.dockstarter.appvars.codeserver_enabled: "false"
+      com.dockstarter.appvars.codeserver_network_mode: ""
+      com.dockstarter.appvars.codeserver_password: ""
+      com.dockstarter.appvars.codeserver_port_8443: "8443"
+      com.dockstarter.appvars.codeserver_sudo_password: ""

--- a/compose/.apps/codeserver/codeserver.netmode.yml
+++ b/compose/.apps/codeserver/codeserver.netmode.yml
@@ -1,0 +1,3 @@
+services:
+  codeserver:
+    network_mode: ${CODESERVER_NETWORK_MODE}

--- a/compose/.apps/codeserver/codeserver.ports.yml
+++ b/compose/.apps/codeserver/codeserver.ports.yml
@@ -1,0 +1,4 @@
+services:
+  codeserver:
+    ports:
+      - ${CODESERVER_PORT_8443}:8443

--- a/compose/.apps/codeserver/codeserver.x86_64.yml
+++ b/compose/.apps/codeserver/codeserver.x86_64.yml
@@ -1,0 +1,3 @@
+services:
+  codeserver:
+    image: linuxserver/code-server

--- a/compose/.apps/codeserver/codeserver.yml
+++ b/compose/.apps/codeserver/codeserver.yml
@@ -1,0 +1,19 @@
+services:
+  codeserver:
+    container_name: codeserver
+    environment:
+      - PASSWORD=${CODESERVER_PASSWORD}
+      - PGID=${PGID}
+      - PUID=${PUID}
+      - SUDO_PASSWORD=${CODESERVER_SUDO_PASSWORD}
+      - TZ=${TZ}
+    logging:
+      driver: json-file
+      options:
+        max-file: ${DOCKERLOGGING_MAXFILE}
+        max-size: ${DOCKERLOGGING_MAXSIZE}
+    restart: unless-stopped
+    volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - ${DOCKERCONFDIR}/codeserver:/config
+      - ${DOCKERSHAREDDIR}:/shared


### PR DESCRIPTION
## Purpose

Add Code-Server

## Approach

Removed the `-` in the name so it can be used in DS.

#### Learning

https://hub.docker.com/r/linuxserver/code-server

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
