### PR TITLE
Menu tweak

### DIFF
--- a/.scripts/menu_value_prompt.sh
+++ b/.scripts/menu_value_prompt.sh
@@ -154,7 +154,7 @@ menu_value_prompt() {
     if [[ ${CI:-} == true ]]; then
         SELECTEDVALUE="Keep Current "
     else
-        SELECTEDVALUE=$(whiptail --fb --clear --title "DockSTARTer" --menu "What would you like set for ${SET_VAR}?${VALUEDESCRIPTION:-}" 0 0 0 "${VALUEOPTIONS[@]}" 3>&1 1>&2 2>&3 || echo "Cancel")
+        SELECTEDVALUE=$(whiptail --fb --clear --title "DockSTARTer" --menu "What would you like set for ${SET_VAR}?${VALUEDESCRIPTION}" 0 0 0 "${VALUEOPTIONS[@]}" 3>&1 1>&2 2>&3 || echo "Cancel")
     fi
 
     local INPUT
@@ -172,7 +172,7 @@ menu_value_prompt() {
             INPUT=${SYSTEM_VAL}
             ;;
         "Enter New ")
-            INPUT=$(whiptail --fb --clear --title "DockSTARTer" --inputbox "What would you like set for ${SET_VAR}?" 0 0 "${CURRENT_VAL}" 3>&1 1>&2 2>&3 || echo "CancelNewEntry")
+            INPUT=$(whiptail --fb --clear --title "DockSTARTer" --inputbox "What would you like set for ${SET_VAR}?${VALUEDESCRIPTION}" 0 0 "${CURRENT_VAL}" 3>&1 1>&2 2>&3 || echo "CancelNewEntry")
             ;;
         "Cancel")
             warning "Selection of ${SET_VAR} was canceled."

--- a/compose/.env.example
+++ b/compose/.env.example
@@ -39,7 +39,7 @@ VPN_ENABLE=yes
 VPN_OPTIONS=
 VPN_OVPNDIR=~/.config/appdata/.openvpn
 VPN_PASS=
-VPN_PROV=pia
+VPN_PROV=custom
 VPN_USER=
 
 # END OF DEFAULT SETTINGS


### PR DESCRIPTION
## Purpose

Show the `VALUEDESCRIPTION` on the `Enter New`  screen. Also default `VPN_PROV` to `custom` because that's technically universal and will work with any provider as long as you put your ovpn file in place.

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
