### PR TITLE
Transmissionvpn

### DIFF
--- a/compose/.apps/transmissionvpn/transmissionvpn.yml
+++ b/compose/.apps/transmissionvpn/transmissionvpn.yml
@@ -9,6 +9,7 @@ services:
       - ${NS1}
       - ${NS2}
     environment:
+      - CREATE_TUN_DEVICE=true
       - LOCAL_NETWORK=${LAN_NETWORK}
       - OPENVPN_OPTS=${VPN_OPTIONS}
       - OPENVPN_PASSWORD=${VPN_PASS}
@@ -16,8 +17,8 @@ services:
       - OPENVPN_USERNAME=${VPN_USER}
       - PGID=${PGID}
       - PUID=${PUID}
-      - TRANSMISSION_HOME=/config
       - TRANSMISSION_DOWNLOAD_DIR=/downloads/completed
+      - TRANSMISSION_HOME=/config
       - TRANSMISSION_INCOMPLETE_DIR=/downloads/incomplete
       - TRANSMISSION_WATCH_DIR=/downloads/watch
       - TZ=${TZ}

--- a/compose/.apps/transmissionvpn/transmissionvpn.yml
+++ b/compose/.apps/transmissionvpn/transmissionvpn.yml
@@ -16,6 +16,7 @@ services:
       - OPENVPN_USERNAME=${VPN_USER}
       - PGID=${PGID}
       - PUID=${PUID}
+      - TRANSMISSION_HOME=/config
       - TRANSMISSION_DOWNLOAD_DIR=/downloads/completed
       - TRANSMISSION_INCOMPLETE_DIR=/downloads/incomplete
       - TRANSMISSION_WATCH_DIR=/downloads/watch

--- a/compose/.apps/transmissionvpn/transmissionvpn.yml
+++ b/compose/.apps/transmissionvpn/transmissionvpn.yml
@@ -34,4 +34,5 @@ services:
       - ${DOCKERSHAREDDIR}:/shared
       - ${DOWNLOADSDIR}:/data
       - ${DOWNLOADSDIR}:/downloads
+      - ${VPN_OVPNDIR}:/config/openvpn
       - ${VPN_OVPNDIR}:/etc/openvpn/custom/


### PR DESCRIPTION
## Purpose

This closes #771

## Approach

TransmissionVPN stores state information and other important things in `TRANSMISSION_HOME` so we are now persisting that as a volume. I have also added a second location for `VPN_OVPNDIR` so that *.ovpn files can reference this location for credential files.

#### Learning

This is unfortunately not documented as of writing, however the code can be seen in commits and in the repo https://github.com/haugene/docker-transmission-openvpn/search?q=TRANSMISSION_HOME

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
