### PR TITLE
First install with verbose

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -393,7 +393,7 @@ main() {
             fi
             git clone https://github.com/GhostWriters/DockSTARTer "${DETECTED_HOMEDIR}/.docker" || fatal "Failed to clone DockSTARTer repo to ${DETECTED_HOMEDIR}/.docker location."
             notice "Performing first run install."
-            exec sudo bash "${DETECTED_HOMEDIR}/.docker/main.sh" "-i"
+            exec sudo bash "${DETECTED_HOMEDIR}/.docker/main.sh" "-vi"
         fi
     fi
     # Sudo Check


### PR DESCRIPTION
## Purpose

Some people have reported first install gets stuck due to prompts requiring user interaction that are hidden by DS. Using verbose mode these should not be hidden.

## Approach

Add the verbose flag to the first install flag.

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
