### PR TITLE
Update removal of conflicting docker packages

### DIFF
--- a/.scripts/pm_apt_remove_docker.sh
+++ b/.scripts/pm_apt_remove_docker.sh
@@ -6,10 +6,12 @@ pm_apt_remove_docker() {
     # https://docs.docker.com/install/linux/docker-ce/debian/
     # https://docs.docker.com/install/linux/docker-ce/ubuntu/
     info "Removing conflicting Docker packages."
-    apt-get -y remove docker \
+    apt-get -y remove containerd \
+        docker \
         docker-compose \
         docker-engine \
-        docker.io > /dev/null 2>&1 || true
+        docker.io \
+        runc > /dev/null 2>&1 || true
 }
 
 test_pm_apt_remove_docker() {

--- a/.scripts/pm_dnf_remove_docker.sh
+++ b/.scripts/pm_dnf_remove_docker.sh
@@ -10,12 +10,12 @@ pm_dnf_remove_docker() {
         docker-client-latest \
         docker-common \
         docker-compose \
+        docker-engine \
+        docker-engine-selinux \
         docker-latest \
         docker-latest-logrotate \
         docker-logrotate \
-        docker-selinux \
-        docker-engine-selinux \
-        docker-engine > /dev/null 2>&1 || true
+        docker-selinux > /dev/null 2>&1 || true
 }
 
 test_pm_dnf_remove_docker() {

--- a/.scripts/pm_yum_remove_docker.sh
+++ b/.scripts/pm_yum_remove_docker.sh
@@ -10,12 +10,10 @@ pm_yum_remove_docker() {
         docker-client-latest \
         docker-common \
         docker-compose \
+        docker-engine \
         docker-latest \
         docker-latest-logrotate \
-        docker-logrotate \
-        docker-selinux \
-        docker-engine-selinux \
-        docker-engine > /dev/null 2>&1 || true
+        docker-logrotate > /dev/null 2>&1 || true
 }
 
 test_pm_yum_remove_docker() {


### PR DESCRIPTION
## Purpose

The ubuntu/debian pages contained two new packages that should be removed, `containerd` and `runc`. The centos page did not contain some packages that we were attempting to remove, which was likely because originally the yum and dnf scripts were copied from each other. Aside from that I have sorted the packages alphabetically just for cleanliness.

NOTE: The `docker-compose` package is not mentioned to be removed in any of the documentation (links below) but I have found at least on ubuntu that this is necessary if compose was installed via apt. I've included it in all the pm remove scripts just in case.

#### Learning

https://docs.docker.com/install/linux/docker-ce/centos/#uninstall-old-versions
https://docs.docker.com/install/linux/docker-ce/debian/#uninstall-old-versions
https://docs.docker.com/install/linux/docker-ce/fedora/#uninstall-old-versions
https://docs.docker.com/install/linux/docker-ce/ubuntu/#uninstall-old-versions

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
