### PR TITLE
Fix samba ports for network discovery

### DIFF
--- a/compose/.apps/samba/samba.labels.yml
+++ b/compose/.apps/samba/samba.labels.yml
@@ -8,6 +8,8 @@ services:
       com.dockstarter.appvars.samba_network_mode: ""
       com.dockstarter.appvars.samba_nmbd: "true"
       com.dockstarter.appvars.samba_password: "ds"
+      com.dockstarter.appvars.samba_port_137: "137"
+      com.dockstarter.appvars.samba_port_138: "138"
       com.dockstarter.appvars.samba_port_139: "139"
       com.dockstarter.appvars.samba_port_445: "445"
       com.dockstarter.appvars.samba_sharename: "DockSTARTer"

--- a/compose/.apps/samba/samba.ports.yml
+++ b/compose/.apps/samba/samba.ports.yml
@@ -1,7 +1,7 @@
 services:
   samba:
     ports:
+      - ${SAMBA_PORT_137}:137/udp
+      - ${SAMBA_PORT_138}:138/udp
       - ${SAMBA_PORT_139}:139
-      - ${SAMBA_PORT_139}:139/udp
       - ${SAMBA_PORT_445}:445
-      - ${SAMBA_PORT_445}:445/udp


### PR DESCRIPTION
## Purpose

Samba is not making the shares discoverable. This fixes the issue.

## Approach

Adjust the ports used add correctly use UDP on the ports that need it.

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
