### PR TITLE
Run update and install from curl

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -382,6 +382,8 @@ main() {
                 unset PROMPT
             fi
             warn "Attempting to run DockSTARTer from ${DS_SYMLINK} location."
+            sudo bash "${DS_SYMLINK}" -vu
+            sudo bash "${DS_SYMLINK}" -vi
             exec sudo bash "${DS_SYMLINK}" "${ARGS[@]:-}"
         fi
     else


### PR DESCRIPTION
## Purpose

This closes #796 

## Approach

Run update and then install if DS repo is detected but the script running is not in the repo location. This is aimed at users who run the bash curl install command after already having DS installed. A common reason for this is if the install fails on the first attempt and the user reruns the command.

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
