### PR TITLE
Fix #799

### DIFF
--- a/compose/.apps/codeserver/codeserver.labels.yml
+++ b/compose/.apps/codeserver/codeserver.labels.yml
@@ -2,7 +2,7 @@ services:
   codeserver:
     labels:
       com.dockstarter.appinfo.description: "VS Code running on a remote server, accessible through the browser"
-      com.dockstarter.appinfo.nicename: "code-server"
+      com.dockstarter.appinfo.nicename: "codeserver"
       com.dockstarter.appvars.codeserver_backup_config: "true"
       com.dockstarter.appvars.codeserver_enabled: "false"
       com.dockstarter.appvars.codeserver_network_mode: ""


### PR DESCRIPTION
## Purpose

`code-server` was incorrect. `codeserver` is correct. Affected users can review `~/.config/appdata/.compose.backups/.env.*` add restore as needed to `~/.docker/compose/.env`

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
