### PR TITLE
Don't git reset in CI

### DIFF
--- a/.scripts/update_self.sh
+++ b/.scripts/update_self.sh
@@ -13,9 +13,9 @@ update_self() {
     cd "${SCRIPTPATH}" || fatal "Failed to change to ${SCRIPTPATH} directory."
     info "Fetching recent changes from git."
     git fetch --all --prune > /dev/null 2>&1 || fatal "Failed to fetch recent changes from git."
-    info "Resetting to ${BRANCH}."
-    git reset --hard "${BRANCH}" > /dev/null 2>&1 || fatal "Failed to reset to ${BRANCH}."
     if [[ ${CI:-} != true ]]; then
+        info "Resetting to ${BRANCH}."
+        git reset --hard "${BRANCH}" > /dev/null 2>&1 || fatal "Failed to reset to ${BRANCH}."
         info "Pulling recent changes from git."
         git pull > /dev/null 2>&1 || fatal "Failed to pull recent changes from git."
     fi


### PR DESCRIPTION
## Purpose

CI has trouble with the git commands

## Approach

Skip the git reset in CI.

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
