### PR TITLE
Replace python36u with python3 for CentOS

### DIFF
--- a/.scripts/pm_yum_install.sh
+++ b/.scripts/pm_yum_install.sh
@@ -4,10 +4,10 @@ IFS=$'\n\t'
 
 pm_yum_install() {
     info "Installing dependencies."
-    yum -y install curl git grep newt python36u python36u-pip rsync sed > /dev/null 2>&1 || fatal "Failed to install dependencies from yum."
+    yum -y install curl git grep newt python3 python3-pip rsync sed > /dev/null 2>&1 || fatal "Failed to install dependencies from yum."
     # https://cryptography.io/en/latest/installation/#building-cryptography-on-linux
     info "Installing python dependencies."
-    yum -y install redhat-rpm-config gcc libffi-devel python36u-devel openssl-devel > /dev/null 2>&1 || fatal "Failed to install python cryptography dependencies from yum."
+    yum -y install redhat-rpm-config gcc libffi-devel python3-devel openssl-devel > /dev/null 2>&1 || fatal "Failed to install python cryptography dependencies from yum."
 }
 
 test_pm_yum_install() {

--- a/.scripts/pm_yum_remove_python.sh
+++ b/.scripts/pm_yum_remove_python.sh
@@ -5,9 +5,7 @@ IFS=$'\n\t'
 pm_yum_remove_python() {
     info "Removing conflicting Python packages."
     yum -y remove python-cryptography \
-        python3-cryptography \
-        python36 \
-        python36-pip > /dev/null 2>&1 || true
+        python3-cryptography > /dev/null 2>&1 || true
 }
 
 test_pm_yum_remove_python() {


### PR DESCRIPTION
## Purpose

Package python36u-pip is obsoleted by python3-pip

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
