### PR TITLE
Adjust python conflict script naming

### DIFF
--- a/.scripts/install_compose.sh
+++ b/.scripts/install_compose.sh
@@ -19,7 +19,7 @@ install_compose() {
             fi
         fi
         if vergt "${AVAILABLE_COMPOSE}" "${INSTALLED_COMPOSE}"; then
-            run_script 'package_manager_run' remove_python
+            run_script 'package_manager_run' remove_python_conflicts
             info "Installing latest python pip."
             run_script 'run_python' -m pip install -IUq pip > /dev/null 2>&1 || warn "Failed to install pip from pip. This can be ignored for now."
 

--- a/.scripts/pm_apt_remove_python_conflicts.sh
+++ b/.scripts/pm_apt_remove_python_conflicts.sh
@@ -2,12 +2,12 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-pm_apt_remove_python() {
+pm_apt_remove_python_conflicts() {
     info "Removing conflicting Python packages."
     apt-get -y remove python-cryptography \
         python3-cryptography > /dev/null 2>&1 || true
 }
 
-test_pm_apt_remove_python() {
-    run_script 'pm_apt_remove_python'
+test_pm_apt_remove_python_conflicts() {
+    run_script 'pm_apt_remove_python_conflicts'
 }

--- a/.scripts/pm_dnf_remove_python_conflicts.sh
+++ b/.scripts/pm_dnf_remove_python_conflicts.sh
@@ -2,13 +2,13 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-pm_dnf_remove_python() {
+pm_dnf_remove_python_conflicts() {
     info "Removing conflicting Python packages."
     dnf -y remove python-cryptography \
         python3-cryptography > /dev/null 2>&1 || true
 }
 
-test_pm_dnf_remove_python() {
-    # run_script 'pm_dnf_remove_python'
-    warn "CI does not test pm_dnf_remove_python."
+test_pm_dnf_remove_python_conflicts() {
+    # run_script 'pm_dnf_remove_python_conflicts'
+    warn "CI does not test pm_dnf_remove_python_conflicts."
 }

--- a/.scripts/pm_yum_remove_python_conflicts.sh
+++ b/.scripts/pm_yum_remove_python_conflicts.sh
@@ -2,13 +2,13 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-pm_yum_remove_python() {
+pm_yum_remove_python_conflicts() {
     info "Removing conflicting Python packages."
     yum -y remove python-cryptography \
         python3-cryptography > /dev/null 2>&1 || true
 }
 
-test_pm_yum_remove_python() {
-    # run_script 'pm_yum_remove_python'
-    warn "CI does not test pm_yum_remove_python."
+test_pm_yum_remove_python_conflicts() {
+    # run_script 'pm_yum_remove_python_conflicts'
+    warn "CI does not test pm_yum_remove_python_conflicts."
 }


### PR DESCRIPTION
**Purpose**
Adjust script naming to be clear that we're not removing python, rather only removing conflicting packages from python.

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
