### PR TITLE
Check minimum required deps

### DIFF
--- a/.scripts/install_compose.sh
+++ b/.scripts/install_compose.sh
@@ -41,6 +41,9 @@ install_compose() {
             if vergt "${AVAILABLE_COMPOSE}" "${UPDATED_COMPOSE}"; then
                 fatal "Failed to install the latest docker-compose."
             fi
+            if vergt "${MINIMUM_COMPOSE}" "${UPDATED_COMPOSE}"; then
+                fatal "Failed to install the minimum required docker-compose."
+            fi
         fi
     fi
 }

--- a/.scripts/install_docker.sh
+++ b/.scripts/install_docker.sh
@@ -41,6 +41,9 @@ install_docker() {
                 echo # placeholder
                 #fatal "Failed to install the latest docker."
             fi
+            if vergt "${MINIMUM_DOCKER}" "${UPDATED_DOCKER}"; then
+                fatal "Failed to install the minimum required docker."
+            fi
         fi
     fi
 }

--- a/.scripts/install_yq.sh
+++ b/.scripts/install_yq.sh
@@ -40,6 +40,9 @@ install_yq() {
             if vergt "${AVAILABLE_YQ}" "${UPDATED_YQ}"; then
                 fatal "Failed to install the latest yq-go."
             fi
+            if vergt "${MINIMUM_YQ}" "${UPDATED_YQ}"; then
+                fatal "Failed to install the minimum required yq-go."
+            fi
         fi
     fi
 }


### PR DESCRIPTION
**Purpose**
Ensure that we get the minimum required version of dependencies installed. The need for this was discovered while testing setting the minimum version for yq to 3 which at the time of testing and writing this is unreleased. The rest of the script thought the minimum version had been installed because the version that was installed was not less than the latest available version.

We should never set the minimum version higher than the latest available version, but the logic should be in place to catch this scenario.

**Approach**
Add a check against the minimum version and the updated version (the version just installed).

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
