### PR TITLE
Add API Token option to CloudflareDDNS

### DIFF
--- a/compose/.apps/cloudflareddns/cloudflareddns.labels.yml
+++ b/compose/.apps/cloudflareddns/cloudflareddns.labels.yml
@@ -3,6 +3,7 @@ services:
     labels:
       com.dockstarter.appinfo.description: "Free service which will point a DNS to an IP of your choice"
       com.dockstarter.appinfo.nicename: "CloudFlareDDNS"
+      com.dockstarter.appvars.cloudflareddns_apitoken: ""
       com.dockstarter.appvars.cloudflareddns_apikey: ""
       com.dockstarter.appvars.cloudflareddns_args: ""
       com.dockstarter.appvars.cloudflareddns_detection_mode: "dig-google.com"

--- a/compose/.apps/cloudflareddns/cloudflareddns.yml
+++ b/compose/.apps/cloudflareddns/cloudflareddns.yml
@@ -3,6 +3,7 @@ services:
     container_name: cloudflareddns
     environment:
       - ARGS=${CLOUDFLAREDDNS_ARGS}
+      - CF_APITOKEN=${CLOUDFLAREDDNS_APITOKEN}
       - CF_APIKEY=${CLOUDFLAREDDNS_APIKEY}
       - CF_HOSTS=${CLOUDFLAREDDNS_HOSTS}
       - CF_RECORDTYPES=${CLOUDFLAREDDNS_RECORDTYPES}


### PR DESCRIPTION
**Purpose**
Cloudflare has added API Tokens for more granular control of access to your account. The API Key can still be used but API Tokens are a more secure approach.

**Approach**
Adding the supported variable, CF_APITOKEN, to the yml makes this possible.

**Learning**
After trying to use an API Token for the API Key, the container provided an error that the configuration was invalid. Looking at the documentation at https://hub.docker.com/r/hotio/cloudflare-ddns/ the container supports the use of API Tokens in lieu of using an API Key (CF_APIKEY) with CF_USER

**Requirements**
Check all boxes as they are completed

- [X] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [X] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
