### PR TITLE
Change log behavior

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -245,20 +245,25 @@ readonly NC=$(tcolor NC)
 # Log Functions
 readonly LOG_FILE="/tmp/dockstarter.log"
 sudo -E chown "${DETECTED_PUID:-$DETECTED_UNAME}":"${DETECTED_PGID:-$DETECTED_UGROUP}" "${LOG_FILE}" > /dev/null 2>&1 || true
-trace() { if [[ -n ${TRACE:-} ]]; then
-    echo -e "${NC}$(date +"%F %T") ${F[B]}[TRACE ]${NC}   $*${NC}" | tee -a "${LOG_FILE}" >&2
-fi; }
-debug() { if [[ -n ${DEBUG:-} ]]; then
-    echo -e "${NC}$(date +"%F %T") ${F[B]}[DEBUG ]${NC}   $*${NC}" | tee -a "${LOG_FILE}" >&2
-fi; }
-info() { if [[ -n ${VERBOSE:-} ]]; then
-    echo -e "${NC}$(date +"%F %T") ${F[B]}[INFO  ]${NC}   $*${NC}" | tee -a "${LOG_FILE}" >&2
-fi; }
-notice() { echo -e "${NC}$(date +"%F %T") ${F[G]}[NOTICE]${NC}   $*${NC}" | tee -a "${LOG_FILE}" >&2; }
-warn() { echo -e "${NC}$(date +"%F %T") ${F[Y]}[WARN  ]${NC}   $*${NC}" | tee -a "${LOG_FILE}" >&2; }
-error() { echo -e "${NC}$(date +"%F %T") ${F[R]}[ERROR ]${NC}   $*${NC}" | tee -a "${LOG_FILE}" >&2; }
+log() {
+    local TOTERM=${1:-}
+    local MESSAGE=${2:-}
+    echo -e "${MESSAGE:-}" | (
+        if [[ -n ${TOTERM} ]]; then
+            tee -a "${LOG_FILE}" >&2
+        else
+            cat >> "${LOG_FILE}" 2>&1
+        fi
+    )
+}
+trace() { log "${TRACE:-}" "${NC}$(date +"%F %T") ${F[B]}[TRACE ]${NC}   $*${NC}"; }
+debug() { log "${DEBUG:-}" "${NC}$(date +"%F %T") ${F[B]}[DEBUG ]${NC}   $*${NC}"; }
+info() { log "${VERBOSE:-}" "${NC}$(date +"%F %T") ${F[B]}[INFO  ]${NC}   $*${NC}"; }
+notice() { log "true" "${NC}$(date +"%F %T") ${F[G]}[NOTICE]${NC}   $*${NC}"; }
+warn() { log "true" "${NC}$(date +"%F %T") ${F[Y]}[WARN  ]${NC}   $*${NC}"; }
+error() { log "true" "${NC}$(date +"%F %T") ${F[R]}[ERROR ]${NC}   $*${NC}"; }
 fatal() {
-    echo -e "${NC}$(date +"%F %T") ${B[R]}${F[W]}[FATAL ]${NC}   $*${NC}" | tee -a "${LOG_FILE}" >&2
+    log "true" "${NC}$(date +"%F %T") ${B[R]}${F[W]}[FATAL ]${NC}   $*${NC}"
     exit 1
 }
 


### PR DESCRIPTION
**Purpose**
Always output to file even if not outputting to the console.

**Approach**
Create a `log` function that handles output from other log functions. The new `log` function is passed two parameters; one to determine if output should go to the console, and the other containing what is being logged (the message). Logging always goes to the log file, but only goes to the console when the first parameter is a truthy value. We are continuing to use `tee -a` when logging to the console and log file. We are using `cat >>` when only logging to the log file.

No changes to the use of existing log functions is required.

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [x] Consider better options (using `cat` instead of `tee` when only outputting to the log file)

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
