### PR TITLE
Fix letsencrypt description

### DIFF
--- a/compose/.apps/letsencrypt/letsencrypt.labels.yml
+++ b/compose/.apps/letsencrypt/letsencrypt.labels.yml
@@ -1,7 +1,7 @@
 services:
   letsencrypt:
     labels:
-      com.dockstarter.appinfo.description: "Certificate authority that provides free X.509 certificates"
+      com.dockstarter.appinfo.description: "Nginx webserver and reverse proxy with php"
       com.dockstarter.appinfo.nicename: "LetsEncrypt"
       com.dockstarter.appvars.letsencrypt_dnsplugin: ""
       com.dockstarter.appvars.letsencrypt_duckdnstoken: ""


### PR DESCRIPTION
**Purpose**
Better description for the letsencrypt container.

**Learning**
https://github.com/linuxserver/docker-letsencrypt

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
