### PR TITLE
Remove ovpn relocation

### DIFF
--- a/.scripts/env_sanitize.sh
+++ b/.scripts/env_sanitize.sh
@@ -35,20 +35,6 @@ env_sanitize() {
     if [[ ${WATCHTOWER_NETWORK_MODE} == "none" ]]; then
         run_script 'env_set' WATCHTOWER_NETWORK_MODE ""
     fi
-
-    # TEMPORARY
-    # There is no good place to put this code that makes sense to keep permanently
-    # This code should be removed after allowing a period of time for existing users to upgrade
-    local VPN_OVPNDIR
-    VPN_OVPNDIR=$(run_script 'env_get' VPN_OVPNDIR)
-    if grep -q 'VPN_ENABLED=true$' "${SCRIPTPATH}/compose/.env" && [[ ${VPN_OVPNDIR} != "" ]]; then
-        mkdir -p "${VPN_OVPNDIR}" || fatal "${VPN_OVPNDIR} folder could not be created."
-        run_script 'set_permissions' "${VPN_OVPNDIR}"
-        local DOCKERCONFDIR
-        DOCKERCONFDIR=$(run_script 'env_get' DOCKERCONFDIR)
-        find "${DOCKERCONFDIR}" -regex '.*\/openvpn\/.*\.ovpn$' -exec cp {} "${VPN_OVPNDIR}" \; | info "No ovpn files found."
-        find "${DOCKERCONFDIR}" -regex '.*\/openvpn\/.*\.crt$' -exec cp {} "${VPN_OVPNDIR}" \; | info "No crt files found."
-    fi
 }
 
 test_env_sanitize() {


### PR DESCRIPTION
**Purpose**
Remove the code (that was meant to be temporary anyway) that relocates ovpn files from individual app config folders into a global folder. We've had a long enough transition period, and have had a number of issues raised (Reddit and discord) about slowness caused by this code.

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
