### PR TITLE
Append temp logs on cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ compose/docker-compose.override.yml
 compose/docker-compose.yml
 config/
 configs/
+dockstarter.log
 share/
 shared/

--- a/main.sh
+++ b/main.sh
@@ -379,6 +379,9 @@ cleanup() {
     if [[ ${EXIT_CODE} -ne 0 ]]; then
         error "DockSTARTer did not finish running successfully."
     fi
+
+    sudo sh -c "cat ${LOG_TEMP} >> ${SCRIPTPATH}/dockstarter.log" || true
+
     exit ${EXIT_CODE}
     trap - 0 1 2 3 6 14 15
 }


### PR DESCRIPTION
**Purpose**
Instructing a user to locate their log file will be increasingly difficult since https://github.com/GhostWriters/DockSTARTer/pull/914 which was primarily introduced to resolve permission issues with Ubuntu 20.04 and things previously seen on CentOS and Fedora. This will consolidate the logging back into a location that is easily found by the user.

There is the potential that this could cause other permissions related issues for users, but since it fires as one of the very last things the script does, and we are using `|| true` to force the exit code it should be fine hopefully. 

**Approach**
Continue printing logs to the temp location but bring them into a central location when the script terminates.

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [x] Test `ds -u origin/log`

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
