### PR TITLE
Use NET_ADMIN instead of privileged mode

### DIFF
--- a/compose/.apps/qbittorrentvpn/qbittorrentvpn.yml
+++ b/compose/.apps/qbittorrentvpn/qbittorrentvpn.yml
@@ -1,5 +1,7 @@
 services:
   qbittorrentvpn:
+    cap_add:
+      - NET_ADMIN
     container_name: qbittorrentvpn
     environment:
       - ENABLE_PRIVOXY=${QBITTORRENTVPN_ENABLE_PRIVOXY}
@@ -19,7 +21,6 @@ services:
       options:
         max-file: ${DOCKERLOGGING_MAXFILE}
         max-size: ${DOCKERLOGGING_MAXSIZE}
-    privileged: true
     restart: unless-stopped
     volumes:
       - /etc/localtime:/etc/localtime:ro


### PR DESCRIPTION
**Purpose**
Privileged mode should be avoided. qbit required it in the past but users have reported to binhex that it is no longer required.

**Approach**
Swap privileged mode for net admin.

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Test `ds -u origin/qb-vpn`

**Learning**
https://github.com/binhex/arch-qbittorrentvpn/issues/1

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
