### PR TITLE
Reduce prompts

### DIFF
--- a/.scripts/appvars_purge.sh
+++ b/.scripts/appvars_purge.sh
@@ -16,7 +16,7 @@ appvars_purge() {
         return
     fi
 
-    if [[ ${CI:-} == true ]] || run_script 'question_prompt' "${PROMPT:-}" Y "Would you like to purge these settings for ${APPNAME}?\\n\\n${APPVARS}"; then
+    if [[ ${CI:-} == true ]] || run_script 'question_prompt' "${PROMPT:-CLI}" Y "Would you like to purge these settings for ${APPNAME}?\\n\\n${APPVARS}"; then
         info "Purging ${APPNAME} .env variables."
         sed -i "/^${APPNAME}_/d" "${SCRIPTPATH}/compose/.env" || fatal "Failed to purge ${APPNAME} variables."
     else

--- a/.scripts/appvars_purge_all.sh
+++ b/.scripts/appvars_purge_all.sh
@@ -4,7 +4,7 @@ IFS=$'\n\t'
 
 appvars_purge_all() {
     if grep -q '_ENABLED=false$' "${SCRIPTPATH}/compose/.env"; then
-        if [[ ${CI:-} == true ]] || run_script 'question_prompt' "${PROMPT:-}" Y "Would you like to purge variables for all disabled apps?"; then
+        if [[ ${CI:-} == true ]] || run_script 'question_prompt' "${PROMPT:-CLI}" Y "Would you like to purge variables for all disabled apps?"; then
             info "Purging disabled app variables."
             while IFS= read -r line; do
                 local APPNAME=${line%%_ENABLED=false}

--- a/.scripts/install_compose.sh
+++ b/.scripts/install_compose.sh
@@ -6,7 +6,7 @@ install_compose() {
     local MINIMUM_COMPOSE="1.17.0"
     # Find minimum compatible version at https://docs.docker.com/release-notes/docker-compose/
     local INSTALLED_COMPOSE
-    if [[ ${FORCE:-} == true ]]; then
+    if [[ ${FORCE:-} == true ]] && [[ -n ${INSTALL:-} ]]; then
         INSTALLED_COMPOSE="0"
     else
         INSTALLED_COMPOSE=$( (/usr/local/bin/docker-compose --version 2> /dev/null || echo "0") | sed -E 's/.* version ([^,]*)(, build .*)?/\1/')

--- a/.scripts/install_docker.sh
+++ b/.scripts/install_docker.sh
@@ -7,7 +7,7 @@ install_docker() {
     # Find minimum compatible version at https://docs.docker.com/engine/release-notes/
     run_script 'remove_snap_docker'
     local INSTALLED_DOCKER
-    if [[ ${FORCE:-} == true ]]; then
+    if [[ ${FORCE:-} == true ]] && [[ -n ${INSTALL:-} ]]; then
         INSTALLED_DOCKER="0"
     else
         INSTALLED_DOCKER=$( (docker --version 2> /dev/null || echo "0") | sed -E 's/.* version ([^,]*)(, build .*)?/\1/')
@@ -33,7 +33,7 @@ install_docker() {
             curl -fsSL get.docker.com -o "${GET_DOCKER}" > /dev/null 2>&1 || fatal "Failed to get docker install script."
             info "Running docker install script."
             local REDIRECT="> /dev/null 2>&1"
-            if [[ -n ${VERBOSE:-} ]] || run_script 'question_prompt' "${PROMPT:-}" N "Would you like to display the command output?"; then
+            if [[ -n ${VERBOSE:-} ]] || run_script 'question_prompt' "${PROMPT:-CLI}" N "Would you like to display the command output?"; then
                 REDIRECT=""
             fi
             eval sh "${GET_DOCKER}" "${REDIRECT}" || fatal "Failed to install docker."

--- a/.scripts/install_yq.sh
+++ b/.scripts/install_yq.sh
@@ -5,7 +5,7 @@ IFS=$'\n\t'
 install_yq() {
     local MINIMUM_YQ="3.2.1"
     local INSTALLED_YQ
-    if [[ ${FORCE:-} == true ]]; then
+    if [[ ${FORCE:-} == true ]] && [[ -n ${INSTALL:-} ]]; then
         INSTALLED_YQ="0"
     else
         INSTALLED_YQ=$( (/usr/local/bin/yq-go --version 2> /dev/null || echo "0") | sed -E 's/.* version ([^,]*)(, build .*)?/\1/')

--- a/.scripts/pm_apt_upgrade.sh
+++ b/.scripts/pm_apt_upgrade.sh
@@ -6,7 +6,7 @@ pm_apt_upgrade() {
     if [[ ${CI:-} != true ]]; then
         notice "Upgrading packages. Please be patient, this can take a while."
         local REDIRECT="> /dev/null 2>&1"
-        if [[ -n ${VERBOSE:-} ]] || run_script 'question_prompt' "${PROMPT:-}" N "Would you like to display the command output?"; then
+        if [[ -n ${VERBOSE:-} ]] || run_script 'question_prompt' "${PROMPT:-CLI}" N "Would you like to display the command output?"; then
             REDIRECT=""
         fi
         eval apt-get -y dist-upgrade "${REDIRECT}" || fatal "Failed to upgrade packages from apt."

--- a/.scripts/pm_dnf_upgrade.sh
+++ b/.scripts/pm_dnf_upgrade.sh
@@ -6,7 +6,7 @@ pm_dnf_upgrade() {
     if [[ ${CI:-} != true ]]; then
         notice "Upgrading packages. Please be patient, this can take a while."
         local REDIRECT="> /dev/null 2>&1"
-        if [[ -n ${VERBOSE:-} ]] || run_script 'question_prompt' "${PROMPT:-}" N "Would you like to display the command output?"; then
+        if [[ -n ${VERBOSE:-} ]] || run_script 'question_prompt' "${PROMPT:-CLI}" N "Would you like to display the command output?"; then
             REDIRECT=""
         fi
         eval dnf -y upgrade --refresh "${REDIRECT}" || fatal "Failed to upgrade packages from dnf."

--- a/.scripts/pm_yum_repos.sh
+++ b/.scripts/pm_yum_repos.sh
@@ -10,7 +10,7 @@ pm_yum_repos() {
     curl -fsSL setup.ius.io -o "${GET_IUS}" > /dev/null 2>&1 || fatal "Failed to get IUS install script."
     info "Running IUS install script."
     local REDIRECT="> /dev/null 2>&1"
-    if [[ -n ${VERBOSE:-} ]] || run_script 'question_prompt' "${PROMPT:-}" N "Would you like to display the command output?"; then
+    if [[ -n ${VERBOSE:-} ]] || run_script 'question_prompt' "${PROMPT:-CLI}" N "Would you like to display the command output?"; then
         REDIRECT=""
     fi
     eval bash "${GET_IUS}" "${REDIRECT}" || warn "Failed to install IUS."

--- a/.scripts/pm_yum_upgrade.sh
+++ b/.scripts/pm_yum_upgrade.sh
@@ -6,7 +6,7 @@ pm_yum_upgrade() {
     if [[ ${CI:-} != true ]]; then
         notice "Upgrading packages. Please be patient, this can take a while."
         local REDIRECT="> /dev/null 2>&1"
-        if [[ -n ${VERBOSE:-} ]] || run_script 'question_prompt' "${PROMPT:-}" N "Would you like to display the command output?"; then
+        if [[ -n ${VERBOSE:-} ]] || run_script 'question_prompt' "${PROMPT:-CLI}" N "Would you like to display the command output?"; then
             REDIRECT=""
         fi
         eval yum -y upgrade "${REDIRECT}" || fatal "Failed to upgrade packages from yum."

--- a/.scripts/question_prompt.sh
+++ b/.scripts/question_prompt.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 IFS=$'\n\t'
 
 question_prompt() {
-    local PROMPT=${1:-CLI}
+    local PROMPT=${1:-}
     local DEFAULT=${2:-Y}
     local QUESTION=${3:-}
     local YN

--- a/main.sh
+++ b/main.sh
@@ -416,15 +416,11 @@ main() {
         DS_SYMLINK=$(readlink -f "${DS_COMMAND}")
         if [[ ${SCRIPTNAME} != "${DS_SYMLINK}" ]]; then
             if repo_exists; then
-                if [[ ${PROMPT:-} != "GUI" ]]; then
-                    PROMPT="CLI"
-                fi
-                if run_script 'question_prompt' "${PROMPT:-}" N "DockSTARTer installation found at ${DS_SYMLINK} location. Would you like to run ${SCRIPTNAME} instead?"; then
+                if run_script 'question_prompt' "${PROMPT:-CLI}" N "DockSTARTer installation found at ${DS_SYMLINK} location. Would you like to run ${SCRIPTNAME} instead?"; then
                     run_script 'symlink_ds'
                     DS_COMMAND=$(command -v ds || true)
                     DS_SYMLINK=$(readlink -f "${DS_COMMAND}")
                 fi
-                unset PROMPT
             fi
             warn "Attempting to run DockSTARTer from ${DS_SYMLINK} location."
             sudo -E bash "${DS_SYMLINK}" -vu
@@ -489,7 +485,7 @@ main() {
                 fi
                 ;;
             --env-set)
-                if [[ ${ENVVAR:-} != "" && ${ENVVAL:-} != "" ]]; then
+                if [[ ${ENVVAR:-} != "" ]] && [[ ${ENVVAL:-} != "" ]]; then
                     run_script 'env_set' "${ENVVAR}" "${ENVVAL}"
                 else
                     echo "Invalid usage. Must be"
@@ -534,14 +530,14 @@ main() {
     fi
     if [[ -n ${YMLMETHOD:-} ]]; then
         if [[ ${YMLAPPNAME:-} == "${YMLVAR:-}" ]]; then
-            if [[ ${YMLVAR:-} != "" && ${YMLVAR:-} =~ services* ]]; then
+            if [[ ${YMLVAR:-} != "" ]] && [[ ${YMLVAR:-} =~ services* ]]; then
                 YMLAPPNAME=${YMLVAR#services.}
                 YMLAPPNAME=${YMLAPPNAME%%.*}
             else
                 YMLAPPNAME=""
             fi
         fi
-        if [[ ${YMLAPPNAME:-} != "" && ${YMLVAR:-} != "" ]]; then
+        if [[ ${YMLAPPNAME:-} != "" ]] && [[ ${YMLVAR:-} != "" ]]; then
             run_script 'yml_get' "${YMLAPPNAME}" "${YMLVAR}" || error "Could not find '${YMLVAR}' in '${YMLAPPNAME}'"
         else
             echo "Invalid usage. Must be one of the following:"


### PR DESCRIPTION
**Purpose**
Don't show users a prompt when they run most CLI flags. Some will still require a prompt because we would not want to purge user data without a confirmation.

Slipped in only forcing install for compose/docker/yq when running the install flag (with the force flag). Also corrected some syntax `[[ cond1 && cond2 ]]` => `[[ cond1 ]] && [[ cond2 ]]`.

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [x] Test `ds -u origin/reduce-prompts`

**Learning**
Following up from #780 which unintentionally had the side effect of bringing prompts back for everything.
Prompts were debated on discord and voted to be removed for CLI. This was completed in https://github.com/GhostWriters/DockSTARTer/pull/577 and adjusted a bit in https://github.com/GhostWriters/DockSTARTer/pull/585

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
