### PR TITLE
Install deps

### DIFF
--- a/.scripts/install_compose.sh
+++ b/.scripts/install_compose.sh
@@ -23,7 +23,9 @@ install_compose() {
             fi
         fi
         if vergt "${AVAILABLE_COMPOSE}" "${INSTALLED_COMPOSE}"; then
-            # https://docs.docker.com/compose/install/
+            info "Removing previous docker-compose image."
+            docker image rm linuxserver/docker-compose:latest || true
+            # https://github.com/linuxserver/docker-docker-compose/blob/master/README.md#recommended-method
             info "Installing latest docker-compose."
             curl -fsL "https://raw.githubusercontent.com/linuxserver/docker-docker-compose/master/run.sh" -o /usr/local/bin/docker-compose > /dev/null 2>&1 || fatal "Failed to install docker-compose."
             if [[ ! -L "/usr/bin/docker-compose" ]]; then

--- a/.scripts/install_compose.sh
+++ b/.scripts/install_compose.sh
@@ -33,7 +33,7 @@ install_compose() {
             local UPDATED_COMPOSE
             UPDATED_COMPOSE=$( (/usr/local/bin/docker-compose --version 2> /dev/null || echo "0") | sed -E 's/.* version ([^,]*)(, build .*)?/\1/')
             if vergt "${AVAILABLE_COMPOSE}" "${UPDATED_COMPOSE}"; then
-                fatal "Failed to install the latest docker-compose."
+                error "Failed to install the latest docker-compose."
             fi
             if vergt "${MINIMUM_COMPOSE}" "${UPDATED_COMPOSE}"; then
                 fatal "Failed to install the minimum required docker-compose."

--- a/.scripts/install_docker.sh
+++ b/.scripts/install_docker.sh
@@ -41,9 +41,7 @@ install_docker() {
             local UPDATED_DOCKER
             UPDATED_DOCKER=$( (docker --version 2> /dev/null || echo "0") | sed -E 's/.* version ([^,]*)(, build .*)?/\1/')
             if vergt "${AVAILABLE_DOCKER}" "${UPDATED_DOCKER}"; then
-                #TODO: Better detection of most recently available version is required before this can be used.
-                echo # placeholder
-                #fatal "Failed to install the latest docker."
+                error "Failed to install the latest docker."
             fi
             if vergt "${MINIMUM_DOCKER}" "${UPDATED_DOCKER}"; then
                 fatal "Failed to install the minimum required docker."

--- a/.scripts/install_yq.sh
+++ b/.scripts/install_yq.sh
@@ -42,7 +42,7 @@ install_yq() {
             local UPDATED_YQ
             UPDATED_YQ=$( (/usr/local/bin/yq-go --version 2> /dev/null || echo "0") | sed -E 's/.* version ([^,]*)(, build .*)?/\1/')
             if vergt "${AVAILABLE_YQ}" "${UPDATED_YQ}"; then
-                fatal "Failed to install the latest yq-go."
+                error "Failed to install the latest yq-go."
             fi
             if vergt "${MINIMUM_YQ}" "${UPDATED_YQ}"; then
                 fatal "Failed to install the minimum required yq-go."


### PR DESCRIPTION
**Purpose**
Don't fatal when latest dependency install fails. There's a fatal right after that logic to endure the minimum version is installed. Instead show an error letting the user know the latest was not installed.

Remove compose image when installing compose to ensure a new image is pulled.

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
