### PR TITLE
Only label on self (not forks)

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -15,5 +15,6 @@ jobs:
 
     steps:
     - uses: actions/labeler@v2.1.1
+      if: github.repository == 'GhostWriters/DockSTARTer'
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
# Pull request

**Purpose**
Labeling fails when PRs are made from forks. Add logic to only run on self (not forks).

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
