### PR TITLE
Portainer default

### DIFF
--- a/compose/.apps/portainer/portainer.labels.yml
+++ b/compose/.apps/portainer/portainer.labels.yml
@@ -4,6 +4,6 @@ services:
       com.dockstarter.appinfo.description: "Simple management UI for Docker"
       com.dockstarter.appinfo.deprecated: "false"
       com.dockstarter.appinfo.nicename: "Portainer"
-      com.dockstarter.appvars.portainer_enabled: "true"
+      com.dockstarter.appvars.portainer_enabled: "false"
       com.dockstarter.appvars.portainer_network_mode: ""
       com.dockstarter.appvars.portainer_port_9000: "9000"

--- a/docs/advanced/advanced-usage.md
+++ b/docs/advanced/advanced-usage.md
@@ -92,8 +92,8 @@ You may also need to fill in or adjust any other variables prefixed with the `AP
 
 This is the best place to change your default ports.
 
-Please note, Portainer and Ouroboros are enabled by default. [Portainer](https://hub.docker.com/r/portainer/portainer/) provides a snazzy management interface at `your.ip.address:9000` and [Ouroboros](https://hub.docker.com/r/pyouroboros/uroboros/) checks for updates to the Containers you are using, __NOT__ DockSTARTer itself.
-See [here](https://dockstarter.com/faq#ouroboros-and-portainer-i-didnt-select-them-but-they-installed-anyway) for a (little) more or you can disable them if you wish.
+Please note, Ouroboros is enabled by default. [Ouroboros](https://hub.docker.com/r/pyouroboros/uroboros/) checks for updates to the Containers you are using, __NOT__ DockSTARTer itself.
+See [here](https://dockstarter.com/faq) for a (little) more or you can disable it if you wish.
 
 #### Removing Apps
 

--- a/docs/basics/faq.md
+++ b/docs/basics/faq.md
@@ -3,15 +3,13 @@
 ## Support
 Refer to our [Support Page](https://dockstarter.com/basics/support/) for our Support Channels and Tutorials we have found users have made with DockSTARTer!
 
-## Ouroboros And Portainer Enabled By Default
+## Ouroboros Enabled By Default
 
-These tools are extremely useful for people getting used to running docker. Their official documentation should explain why but you can disable either or both of them if you want.
+This tool is extremely useful for people getting used to running docker. It's official documentation should explain why but you can disable it if you want.
 
 > [Ouroboros](https://hub.docker.com/r/pyouroboros/ouroboros/) will monitor (all or specified) running docker containers and update them to the (latest or tagged) available image in the remote registry.
->
-> [Portainer](https://hub.docker.com/r/portainer/portainer/) allows you to manage your Docker stacks, containers, images, volumes, networks and more! It is compatible with the standalone Docker engine and with Docker Swarm.
 
-In short, Ouroboros keeps your Containers up to date and Portainer gives you a WebGUI for starting and stopping Containers. Have a look, at `www.appropriateaddress.com:9000` .
+In short, Ouroboros keeps your Containers up to date.
 
 DockSTARTer previously enabled Watchtower by default before Ouroboros. The two do almost the same thing, but Ouroboros has more options.
 
@@ -23,8 +21,7 @@ With Ouroboros (or Watchtower) your containers will be updated to the latest ima
 
 ## General troubleshooting help
 
-You can see the (quite helpful) logs of each container with a Quick action in Portainer:
-![Portainer log quick action](https://gist.github.com/juligreen/aaf72244b8b4a9c09fc80112ba25e79d/raw/05b94051569fa4fc3c73593069de6293af5dfa50/Portainer%2520quick.PNG)
+You can see the (quite helpful) logs of each container with the `docker logs <appname>` command.
 
 ## Reported Issues
 


### PR DESCRIPTION
# Pull request

**Purpose**
Do not enable portainer by default. It's a good tool, but with DS it's propose is more to see what's happening and not to take actions. Enabling it by default implies it is intended to be used.

**Approach**
Disable portainer by default. Update docs.

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
