### PR TITLE
Add Murmur VoIP server

### DIFF
--- a/compose/.apps/murmur/murmur.hostname.yml
+++ b/compose/.apps/murmur/murmur.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  monitorr:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/murmur/murmur.hostname.yml
+++ b/compose/.apps/murmur/murmur.hostname.yml
@@ -1,3 +1,3 @@
 services:
-  monitorr:
+  murmur:
     hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/murmur/murmur.labels.yml
+++ b/compose/.apps/murmur/murmur.labels.yml
@@ -1,5 +1,5 @@
 services:
-  monitorr:
+  murmur:
     labels:
       com.dockstarter.appinfo.description: "Murmur is the server for Mumble, a voice over IP application"
       com.dockstarter.appinfo.deprecated: "false"

--- a/compose/.apps/murmur/murmur.labels.yml
+++ b/compose/.apps/murmur/murmur.labels.yml
@@ -7,3 +7,4 @@ services:
       com.dockstarter.appvars.murmur_enabled: "false"
       com.dockstarter.appvars.murmur_network_mode: ""
       com.dockstarter.appvars.murmur_port_64738: "64738"
+      com.dockstarter.appvars.murmur_supw: ""

--- a/compose/.apps/murmur/murmur.labels.yml
+++ b/compose/.apps/murmur/murmur.labels.yml
@@ -1,0 +1,9 @@
+services:
+  monitorr:
+    labels:
+      com.dockstarter.appinfo.description: "Murmur is the server for Mumble, a voice over IP application"
+      com.dockstarter.appinfo.deprecated: "false"
+      com.dockstarter.appinfo.nicename: "Murmur"
+      com.dockstarter.appvars.murmur_enabled: "false"
+      com.dockstarter.appvars.murmur_network_mode: ""
+      com.dockstarter.appvars.murmur_port_64738: "64738"

--- a/compose/.apps/murmur/murmur.netmode.yml
+++ b/compose/.apps/murmur/murmur.netmode.yml
@@ -1,3 +1,3 @@
 services:
-  jackett:
+  murmur:
     network_mode: ${MURMUR_NETWORK_MODE}

--- a/compose/.apps/murmur/murmur.netmode.yml
+++ b/compose/.apps/murmur/murmur.netmode.yml
@@ -1,0 +1,3 @@
+services:
+  jackett:
+    network_mode: ${MURMUR_NETWORK_MODE}

--- a/compose/.apps/murmur/murmur.ports.yml
+++ b/compose/.apps/murmur/murmur.ports.yml
@@ -2,3 +2,4 @@ services:
   murmur:
     ports:
       - ${MURMUR_PORT_64738}:64738
+      - ${MURMUR_PORT_64738}:64738/udp

--- a/compose/.apps/murmur/murmur.ports.yml
+++ b/compose/.apps/murmur/murmur.ports.yml
@@ -1,0 +1,4 @@
+services:
+  murmur:
+    ports:
+      - ${MURMUR_PORT_64738}:64738

--- a/compose/.apps/murmur/murmur.x86_64.yml
+++ b/compose/.apps/murmur/murmur.x86_64.yml
@@ -1,0 +1,3 @@
+services:
+  murmur:
+    image: coppit/mumble-server

--- a/compose/.apps/murmur/murmur.x86_64.yml
+++ b/compose/.apps/murmur/murmur.x86_64.yml
@@ -1,3 +1,3 @@
 services:
   murmur:
-    image: coppit/mumble-server
+    image: goofball222/murmur

--- a/compose/.apps/murmur/murmur.yml
+++ b/compose/.apps/murmur/murmur.yml
@@ -13,5 +13,8 @@ services:
     restart: unless-stopped
     volumes:
       - /etc/localtime:/etc/localtime:ro
-      - ${DOCKERCONFDIR}/murmur:/opt/murmur
+      - ${DOCKERCONFDIR}/murmur/cert:/opt/murmur/cert
+      - ${DOCKERCONFDIR}/murmur/config:/opt/murmur/config
+      - ${DOCKERCONFDIR}/murmur//data:/opt/murmur/data
+      - ${DOCKERCONFDIR}/murmur//log:/opt/murmur/log
       - ${DOCKERSHAREDDIR}:/shared

--- a/compose/.apps/murmur/murmur.yml
+++ b/compose/.apps/murmur/murmur.yml
@@ -5,6 +5,7 @@ services:
       - PGID=${PGID}
       - PUID=${PUID}
       - TZ=${TZ}
+      - MURMUR_SUPW=${MURMUR_SUPW}
     logging:
       driver: json-file
       options:

--- a/compose/.apps/murmur/murmur.yml
+++ b/compose/.apps/murmur/murmur.yml
@@ -15,6 +15,6 @@ services:
       - /etc/localtime:/etc/localtime:ro
       - ${DOCKERCONFDIR}/murmur/cert:/opt/murmur/cert
       - ${DOCKERCONFDIR}/murmur/config:/opt/murmur/config
-      - ${DOCKERCONFDIR}/murmur//data:/opt/murmur/data
-      - ${DOCKERCONFDIR}/murmur//log:/opt/murmur/log
+      - ${DOCKERCONFDIR}/murmur/data:/opt/murmur/data
+      - ${DOCKERCONFDIR}/murmur/log:/opt/murmur/log
       - ${DOCKERSHAREDDIR}:/shared

--- a/compose/.apps/murmur/murmur.yml
+++ b/compose/.apps/murmur/murmur.yml
@@ -2,10 +2,10 @@ services:
   murmur:
     container_name: murmur
     environment:
+      - MURMUR_SUPW=${MURMUR_SUPW}
       - PGID=${PGID}
       - PUID=${PUID}
       - TZ=${TZ}
-      - MURMUR_SUPW=${MURMUR_SUPW}
     logging:
       driver: json-file
       options:

--- a/compose/.apps/murmur/murmur.yml
+++ b/compose/.apps/murmur/murmur.yml
@@ -1,0 +1,17 @@
+services:
+  murmur:
+    container_name: murmur
+    environment:
+      - PGID=${PGID}
+      - PUID=${PUID}
+      - TZ=${TZ}
+    logging:
+      driver: json-file
+      options:
+        max-file: ${DOCKERLOGGING_MAXFILE}
+        max-size: ${DOCKERLOGGING_MAXSIZE}
+    restart: unless-stopped
+    volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - ${DOCKERCONFDIR}/murmur:/data
+      - ${DOCKERSHAREDDIR}:/shared

--- a/compose/.apps/murmur/murmur.yml
+++ b/compose/.apps/murmur/murmur.yml
@@ -13,5 +13,5 @@ services:
     restart: unless-stopped
     volumes:
       - /etc/localtime:/etc/localtime:ro
-      - ${DOCKERCONFDIR}/murmur:/data
+      - ${DOCKERCONFDIR}/murmur:/opt/murmur
       - ${DOCKERSHAREDDIR}:/shared

--- a/docs/apps/murmur.md
+++ b/docs/apps/murmur.md
@@ -6,3 +6,9 @@
 ## Description
 
 [Murmur](https://github.com/mumble-voip/mumble) is an VoIP server for Mumble. It is an open-source application that is similar to programs such as Ventrilo or TeamSpeak.
+
+### SuperUser Password
+
+The default user on a Murmur server is called 'SuperUser'. An initial password is generated for this user on first run, and you can find it by looking at the Docker logs for the Murmur container. It will be in a line that looks like `Password for 'SuperUser' set to 'something'`. You can use this password to login. It is possible to use an environment variable on the docker container to set the password, but due to a quirk with the way Murmur is implemented, if you set this SuperUser password variable, it will simply update the SuperUser password and exit. As such, this variable needs to be unset to start Murmur normally.
+
+To set a supervisor password, edit the `~/.docker/compose/.apps/murmur/murmur.yml` file and in the `environment` section, set the `MURMUR_SUPW` variable to your desired password. Start the Murmur service, let the password update, and edit the murmur.yml file again to remove the line. Once the line is removed, restart the service and your desired SuperUser password will be set.

--- a/docs/apps/murmur.md
+++ b/docs/apps/murmur.md
@@ -9,6 +9,8 @@
 
 ### SuperUser Password
 
-The default user on a Murmur server is called 'SuperUser'. An initial password is generated for this user on first run, and you can find it by looking at the Docker logs for the Murmur container. It will be in a line that looks like `Password for 'SuperUser' set to 'something'`. You can use this password to login. It is possible to use an environment variable on the docker container to set the password, but due to a quirk with the way Murmur is implemented, if you set this SuperUser password variable, it will simply update the SuperUser password and exit. As such, this variable needs to be unset to start Murmur normally.
+The default user on a Murmur server is called 'SuperUser'. An initial password is generated for this user on first run, and you can find it by looking at the Docker logs for the Murmur container. It will be in a line that looks like `Password for 'SuperUser' set to 'something'`. You can use this password to login.
 
-To set a supervisor password, edit the `~/.docker/compose/.apps/murmur/murmur.yml` file and in the `environment` section, set the `MURMUR_SUPW` variable to your desired password. Start the Murmur service, let the password update, and edit the murmur.yml file again to remove the line. Once the line is removed, restart the service and your desired SuperUser password will be set.
+It is possible to set a specific SuperUser password by using an environment variable on the docker container, but due to a quirk with the way Murmur is implemented, if you set this SuperUser password variable, the container will simply update the SuperUser password and exit. As such, this variable needs to be unset to start Murmur normally.
+
+To set a supervisor password, as an override for murmur, set the `MURMUR_SUPW` variable to your desired password. Start the Murmur service, let the password update, and then remove the variable. Once it is removed, restart the service and your desired SuperUser password will be set.

--- a/docs/apps/murmur.md
+++ b/docs/apps/murmur.md
@@ -11,6 +11,4 @@
 
 The default user on a Murmur server is called 'SuperUser'. An initial password is generated for this user on first run, and you can find it by looking at the Docker logs for the Murmur container. It will be in a line that looks like `Password for 'SuperUser' set to 'something'`. You can use this password to login.
 
-It is possible to set a specific SuperUser password by using an environment variable on the docker container, but due to a quirk with the way Murmur is implemented, if you set this SuperUser password variable, the container will simply update the SuperUser password and exit. As such, this variable needs to be unset to start Murmur normally.
-
-To set a supervisor password, as an override for murmur, set the `MURMUR_SUPW` variable to your desired password. Start the Murmur service, let the password update, and then remove the variable. Once it is removed, restart the service and your desired SuperUser password will be set.
+It is possible to set a specific SuperUser password by using the `MURMUR_SUPW` environment variable on the docker container, but due to a quirk with the way Murmur is implemented, if you set this SuperUser password variable, the container will simply update the SuperUser password and exit. As such, this variable needs to be unset to start Murmur normally.

--- a/docs/apps/murmur.md
+++ b/docs/apps/murmur.md
@@ -1,0 +1,8 @@
+# Murmur
+
+[![Docker Pulls](https://img.shields.io/docker/pulls/goofball222/murmur?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/goofball222/murmur)
+[![GitHub Stars](https://img.shields.io/github/stars/goofball222/murmur?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/goofball222/murmur)
+
+## Description
+
+[Murmur](https://github.com/mumble-voip/mumble) is an VoIP server for Mumble. It is an open-source application that is similar to programs such as Ventrilo or TeamSpeak.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -113,6 +113,7 @@ nav:
     - "apps/minecraft_bedrock_server.md"
     - "apps/minecraft_server.md"
     - "apps/monitorr.md"
+    - "apps/murmur.md"
     - "apps/muximux.md"
     - "apps/mylar.md"
     - "apps/netdata.md"


### PR DESCRIPTION
# Pull request

**Purpose**
Murmur is the server for the Mumble voice-over-ip client.

**Approach**
This adds Murmur, a new application 

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
