### PR TITLE
Add 'Element' Matrix Web Server (Formerly Called Riot.im)

### DIFF
--- a/compose/.apps/element/element.hostname.yml
+++ b/compose/.apps/element/element.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  element:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/element/element.labels.yml
+++ b/compose/.apps/element/element.labels.yml
@@ -1,0 +1,9 @@
+services:
+  element:
+    labels:
+      com.dockstarter.appinfo.description: "Element (formerly Riot.im) is a Matrix web client."
+      com.dockstarter.appinfo.deprecated: "false"
+      com.dockstarter.appinfo.nicename: "Element"
+      com.dockstarter.appvars.element_enabled: "false"
+      com.dockstarter.appvars.element_network_mode: ""
+      com.dockstarter.appvars.element_port_80: "8010"

--- a/compose/.apps/element/element.netmode.yml
+++ b/compose/.apps/element/element.netmode.yml
@@ -1,0 +1,3 @@
+services:
+  element:
+    network_mode: ${ELEMENT_NETWORK_MODE}

--- a/compose/.apps/element/element.ports.yml
+++ b/compose/.apps/element/element.ports.yml
@@ -1,0 +1,4 @@
+services:
+  element:
+    ports:
+      - ${ELEMENT_PORT_80}:80

--- a/compose/.apps/element/element.x86_64.yml
+++ b/compose/.apps/element/element.x86_64.yml
@@ -1,0 +1,3 @@
+services:
+  element:
+    image: vectorim/riot-web

--- a/compose/.apps/element/element.yml
+++ b/compose/.apps/element/element.yml
@@ -1,0 +1,17 @@
+services:
+  element:
+    container_name: element
+    environment:
+      - PGID=${PGID}
+      - PUID=${PUID}
+      - TZ=${TZ}
+    logging:
+      driver: json-file
+      options:
+        max-file: ${DOCKERLOGGING_MAXFILE}
+        max-size: ${DOCKERLOGGING_MAXSIZE}
+    restart: unless-stopped
+    volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - ${DOCKERCONFDIR}/element:/app
+      - ${DOCKERSHAREDDIR}:/shared


### PR DESCRIPTION
# Pull request

**Purpose**
Element (formerly Riot.im) is a Matrix web client.

**Approach**
Added new application

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
