### PR TITLE
Correct variable name for speedtest service

### DIFF
--- a/compose/.apps/speedtest/speedtest.yml
+++ b/compose/.apps/speedtest/speedtest.yml
@@ -2,10 +2,10 @@ services:
   speedtest:
     container_name: speedtest
     environment:
+      - OOKLA_EULA_GDPR=${SPEEDTEST_OOKLA_EULA_GDPR}
       - PGID=${PGID}
       - PUID=${PUID}
       - SPEEDTEST_BASE_PATH=${SPEEDTEST_BASE_PATH}
-      - SPEEDTEST_OOKLA_EULA_GDPR=${SPEEDTEST_OOKLA_EULA_GDPR}
       - TZ=${TZ}
     logging:
       driver: json-file


### PR DESCRIPTION
This is a bug fix. The container expects the variable to be OOKLA_EULA_GDPR. The service does not start as-is.

From the container logs: 

```
[cont-init.d] 50-speedtest: executing... 
##################################################################################################################################
##################################################################################################################################
You haven't accepted the Ookla EULA. Please re-create the container with the environment variable 'OOKLA_EULA_GDPR' set to 'true'.
##################################################################################################################################
##################################################################################################################################
[cont-init.d] 50-speedtest: exited 1.
```