### PR TITLE
Add discord invite redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![DockSTARTer](https://github.com/GhostWriters/DockSTARTer/raw/master/docs/img/logo.png)](https://dockstarter.com)
 
 [![Supporters on Open Collective](https://img.shields.io/opencollective/all/DockSTARTer.svg?style=flat-square&color=607D8B)](#supporters)
-[![Discord chat](https://img.shields.io/discord/477959324183035936.svg?style=flat-square&color=607D8B&logo=discord)](https://discord.gg/YFyJpmH)
+[![Discord chat](https://img.shields.io/discord/477959324183035936.svg?style=flat-square&color=607D8B&logo=discord)](https://dockstarter.com/discord)
 [![GitHub contributors](https://img.shields.io/github/contributors/GhostWriters/DockSTARTer.svg?style=flat-square&color=607D8B)](https://github.com/GhostWriters/DockSTARTer/graphs/contributors)
 [![GitHub last commit master](https://img.shields.io/github/last-commit/GhostWriters/DockSTARTer/master.svg?style=flat-square&color=607D8B&label=code%20committed)](https://github.com/GhostWriters/DockSTARTer/commits/master)
 [![GitHub license](https://img.shields.io/github/license/GhostWriters/DockSTARTer.svg?style=flat-square&color=607D8B)](https://github.com/GhostWriters/DockSTARTer/blob/master/LICENSE.md)
@@ -96,7 +96,7 @@ See our [documentation](https://dockstarter.com/introduction/) for more detailed
 
 ## Support
 
-[![Discord chat](https://img.shields.io/discord/477959324183035936.svg?style=flat-square&color=607D8B&logo=discord)](https://discord.gg/YFyJpmH)
+[![Discord chat](https://img.shields.io/discord/477959324183035936.svg?style=flat-square&color=607D8B&logo=discord)](https://dockstarter.com/discord)
 
 Click the chat badge to join us on Discord for support!
 

--- a/docs/basics/support.md
+++ b/docs/basics/support.md
@@ -2,7 +2,7 @@
 
 ## Official Support
 
-[![Discord chat](https://img.shields.io/discord/477959324183035936.svg?style=flat-square&color=607D8B&logo=discord)](https://discord.gg/YFyJpmH)
+[![Discord chat](https://img.shields.io/discord/477959324183035936.svg?style=flat-square&color=607D8B&logo=discord)](https://dockstarter.com/discord)
 
 Click the chat badge to join us on Discord for support!
 

--- a/docs/discord.md
+++ b/docs/discord.md
@@ -1,0 +1,4 @@
+---
+title: DockSTARTer Discord
+redirect: https://discord.gg/xR3cyUb
+---

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,7 +14,7 @@ extra:
   manifest: manifest.webmanifest
   social:
     - icon: fontawesome/brands/discord
-      link: https://discord.gg/YFyJpmH
+      link: https://dockstarter.com/discord
     - icon: fontawesome/brands/github-square
       link: https://github.com/GhostWriters/DockSTARTer
 


### PR DESCRIPTION
# Pull request

**Purpose**
Remade the invite link on discord to point to the rules channel (first channel users will see when joining). Setup a vanity url (redirect) for the invite (this makes it easier to update only one place in the future if we need to remake the invite again). Update all references to the invite link to the new vanity url.

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
