### PR TITLE
Better handling of binaries in PATH

### DIFF
--- a/.scripts/install_compose.sh
+++ b/.scripts/install_compose.sh
@@ -9,7 +9,7 @@ install_compose() {
     if [[ ${FORCE:-} == true ]] && [[ -n ${INSTALL:-} ]]; then
         INSTALLED_COMPOSE="0"
     else
-        INSTALLED_COMPOSE=$( (/usr/local/bin/docker-compose --version 2> /dev/null || echo "0") | sed -E 's/.* version ([^,]*)(, build .*)?/\1/')
+        INSTALLED_COMPOSE=$( (docker-compose --version 2> /dev/null || echo "0") | sed -E 's/.* version ([^,]*)(, build .*)?/\1/')
     fi
     if vergt "${MINIMUM_COMPOSE}" "${INSTALLED_COMPOSE}"; then
         local AVAILABLE_COMPOSE
@@ -28,12 +28,13 @@ install_compose() {
             # https://github.com/linuxserver/docker-docker-compose/blob/master/README.md#recommended-method
             info "Installing latest docker-compose."
             curl -fsL "https://raw.githubusercontent.com/linuxserver/docker-docker-compose/master/run.sh" -o /usr/local/bin/docker-compose > /dev/null 2>&1 || fatal "Failed to install docker-compose."
+            chmod +x /usr/local/bin/docker-compose > /dev/null 2>&1 || true
             if [[ ! -L "/usr/bin/docker-compose" ]]; then
+                rm -f /usr/bin/docker-compose || warn "Failed to remove /usr/bin/docker-compose"
                 ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose || fatal "Failed to create /usr/bin/docker-compose symlink."
             fi
-            chmod +x /usr/local/bin/docker-compose > /dev/null 2>&1 || true
             local UPDATED_COMPOSE
-            UPDATED_COMPOSE=$( (/usr/local/bin/docker-compose --version 2> /dev/null || echo "0") | sed -E 's/.* version ([^,]*)(, build .*)?/\1/')
+            UPDATED_COMPOSE=$( (docker-compose --version 2> /dev/null || echo "0") | sed -E 's/.* version ([^,]*)(, build .*)?/\1/')
             if vergt "${AVAILABLE_COMPOSE}" "${UPDATED_COMPOSE}"; then
                 error "Failed to install the latest docker-compose."
             fi
@@ -46,5 +47,5 @@ install_compose() {
 
 test_install_compose() {
     run_script 'install_compose'
-    /usr/local/bin/docker-compose --version || fatal "Failed to determine docker-compose version."
+    docker-compose --version || fatal "Failed to determine docker-compose version."
 }

--- a/.scripts/install_yq.sh
+++ b/.scripts/install_yq.sh
@@ -8,7 +8,7 @@ install_yq() {
     if [[ ${FORCE:-} == true ]] && [[ -n ${INSTALL:-} ]]; then
         INSTALLED_YQ="0"
     else
-        INSTALLED_YQ=$( (/usr/local/bin/yq-go --version 2> /dev/null || echo "0") | sed -E 's/.* version ([^,]*)(, build .*)?/\1/')
+        INSTALLED_YQ=$( (yq-go --version 2> /dev/null || echo "0") | sed -E 's/.* version ([^,]*)(, build .*)?/\1/')
     fi
     if vergt "${MINIMUM_YQ}" "${INSTALLED_YQ}"; then
         local AVAILABLE_YQ
@@ -35,12 +35,13 @@ install_yq() {
                 YQ_ARCH="yq_linux_amd64"
             fi
             curl -fsL "https://github.com/mikefarah/yq/releases/download/${AVAILABLE_YQ}/${YQ_ARCH}" -o /usr/local/bin/yq-go > /dev/null 2>&1 || fatal "Failed to install yq-go."
+            chmod +x /usr/local/bin/yq-go > /dev/null 2>&1 || true
             if [[ ! -L "/usr/bin/yq-go" ]]; then
+                rm -f /usr/bin/yq-go || warn "Failed to remove /usr/bin/yq-go"
                 ln -s /usr/local/bin/yq-go /usr/bin/yq-go || fatal "Failed to create /usr/bin/yq-go symlink."
             fi
-            chmod +x /usr/local/bin/yq-go > /dev/null 2>&1 || true
             local UPDATED_YQ
-            UPDATED_YQ=$( (/usr/local/bin/yq-go --version 2> /dev/null || echo "0") | sed -E 's/.* version ([^,]*)(, build .*)?/\1/')
+            UPDATED_YQ=$( (yq-go --version 2> /dev/null || echo "0") | sed -E 's/.* version ([^,]*)(, build .*)?/\1/')
             if vergt "${AVAILABLE_YQ}" "${UPDATED_YQ}"; then
                 error "Failed to install the latest yq-go."
             fi
@@ -53,5 +54,5 @@ install_yq() {
 
 test_install_yq() {
     run_script 'install_yq'
-    /usr/local/bin/yq-go --version || fatal "Failed to determine yq-go version."
+    yq-go --version || fatal "Failed to determine yq-go version."
 }

--- a/.scripts/symlink_ds.sh
+++ b/.scripts/symlink_ds.sh
@@ -8,7 +8,7 @@ symlink_ds() {
     # /usr/bin/ds
     if [[ -L "/usr/bin/ds" ]] && [[ ${SCRIPTNAME} != "$(readlink -f /usr/bin/ds)" ]]; then
         info "Attempting to remove /usr/bin/ds symlink."
-        rm "/usr/bin/ds" || fatal "Failed to remove /usr/bin/ds"
+        rm -f "/usr/bin/ds" || fatal "Failed to remove /usr/bin/ds"
     fi
     if [[ ! -L "/usr/bin/ds" ]]; then
         info "Creating /usr/bin/ds symbolic link for DockSTARTer."
@@ -18,7 +18,7 @@ symlink_ds() {
     # /usr/local/bin/ds
     if [[ -L "/usr/local/bin/ds" ]] && [[ ${SCRIPTNAME} != "$(readlink -f /usr/local/bin/ds)" ]]; then
         info "Attempting to remove /usr/local/bin/ds symlink."
-        rm "/usr/local/bin/ds" || fatal "Failed to remove /usr/local/bin/ds"
+        rm -f "/usr/local/bin/ds" || fatal "Failed to remove /usr/local/bin/ds"
     fi
     if [[ ! -L "/usr/local/bin/ds" ]]; then
         info "Creating /usr/local/bin/ds symbolic link for DockSTARTer."

--- a/.scripts/yml_get.sh
+++ b/.scripts/yml_get.sh
@@ -7,7 +7,7 @@ yml_get() {
     local GET_VAR=${2:-}
     local FILENAME=${APPNAME,,}
     run_script 'install_yq'
-    /usr/local/bin/yq-go m "${SCRIPTPATH}"/compose/.apps/"${FILENAME}"/*.yml 2> /dev/null | /usr/local/bin/yq-go r - "${GET_VAR}" 2> /dev/null || return 1
+    yq-go m "${SCRIPTPATH}"/compose/.apps/"${FILENAME}"/*.yml 2> /dev/null | yq-go r - "${GET_VAR}" 2> /dev/null || return 1
 }
 
 test_yml_get() {

--- a/.scripts/yml_merge.sh
+++ b/.scripts/yml_merge.sh
@@ -10,7 +10,7 @@ yml_merge() {
     RUNFILE=$(mktemp) || fatal "Failed to create temporary yml merge script."
     echo "#!/usr/bin/env bash" > "${RUNFILE}"
     {
-        echo '/usr/local/bin/yq-go m '\\
+        echo 'yq-go m '\\
         echo "\"${SCRIPTPATH}/compose/.reqs/v1.yml\" \\"
         echo "\"${SCRIPTPATH}/compose/.reqs/v2.yml\" \\"
     } >> "${RUNFILE}"


### PR DESCRIPTION
# Pull request

**Purpose**
Don't call binaries using full paths, use what is in `$PATH` for better compatibility.
`rm` binaries where DS requires symlinks when installing compose and yq.

This begins working towards compatibility with more distros such as Arch.

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
