### PR TITLE
Add Arch Linux Support

### DIFF
--- a/.scripts/package_manager_run.sh
+++ b/.scripts/package_manager_run.sh
@@ -11,10 +11,10 @@ package_manager_run() {
     elif [[ -n "$(command -v yum)" ]]; then
         run_script "pm_yum_${ACTION}"
     elif [[ -n "$(command -v pacman)" ]]; then
-        warn "Arch Linux based distributions are not officially supported."
-        warn "You will need to install docker and docker-compose manually."
+        info "Docker packages for Arch Linux based distributions are not installed automatically."
+        run_script "pm_pacman_${ACTION}"
     else
-        fatal "Package manager not detected!"
+        fatal "Supported package manager not detected!"
     fi
 }
 

--- a/.scripts/package_manager_run.sh
+++ b/.scripts/package_manager_run.sh
@@ -11,7 +11,6 @@ package_manager_run() {
     elif [[ -n "$(command -v yum)" ]]; then
         run_script "pm_yum_${ACTION}"
     elif [[ -n "$(command -v pacman)" ]]; then
-        info "Docker packages for Arch Linux based distributions are not installed automatically."
         run_script "pm_pacman_${ACTION}"
     else
         fatal "Supported package manager not detected!"

--- a/.scripts/package_manager_run.sh
+++ b/.scripts/package_manager_run.sh
@@ -10,6 +10,9 @@ package_manager_run() {
         run_script "pm_dnf_${ACTION}"
     elif [[ -n "$(command -v yum)" ]]; then
         run_script "pm_yum_${ACTION}"
+    elif [[ -n "$(command -v pacman)" ]]; then
+        warn "Arch Linux based distributions are not officially supported."
+        warn "You will need to install docker and docker-compose manually."
     else
         fatal "Package manager not detected!"
     fi

--- a/.scripts/pm_pacman_clean.sh
+++ b/.scripts/pm_pacman_clean.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+pm_pacman_clean() {
+    info "Cleaning up package cache."
+    pacman -Sc --noconfirm > /dev/null 2>&1 || info "Failed to cleanup pacman cache."
+}
+
+test_pm_pacman_clean() {
+    # run_script 'pm_pacman_clean'
+    warn "CI does not test pm_pacman_clean."
+}

--- a/.scripts/pm_pacman_install.sh
+++ b/.scripts/pm_pacman_install.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+pm_pacman_install() {
+    info "Installing dependencies."
+    pacman -Sy --noconfirm curl git grep libnewt sed > /dev/null 2>&1 || fatal "Failed to install dependencies using pacman."
+}
+
+test_pm_pacman_install() {
+    # run_script 'pm_pacman_install'
+    warn "CI does not test pm_pacman_install."
+}

--- a/.scripts/pm_pacman_remove_docker.sh
+++ b/.scripts/pm_pacman_remove_docker.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+pm_pacman_remove_docker() {
+    info "This script does not install or remove docker with pacman. You will need to do this manually."
+}
+
+test_pm_pacman_remove_docker() {
+    # run_script 'pm_pacman_remove_docker'
+    warn "CI does not test pm_pacman_remove_docker."
+}

--- a/.scripts/pm_pacman_repos.sh
+++ b/.scripts/pm_pacman_repos.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 IFS=$'\n\t'
 
 pm_pacman_repos() {
-    return # All packages needed are in the Arch repos
+    info "This script does not manage pacman repositories for you. All packages needed should be in the default Arch repos."
 }
 
 test_pm_pacman_repos() {

--- a/.scripts/pm_pacman_repos.sh
+++ b/.scripts/pm_pacman_repos.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+pm_pacman_repos() {
+    return # All packages needed are in the Arch repos
+}
+
+test_pm_pacman_repos() {
+    # run_script 'pm_pacman_repos'
+    warn "CI does not test pm_pacman_repos."
+}

--- a/.scripts/pm_pacman_upgrade.sh
+++ b/.scripts/pm_pacman_upgrade.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+pm_pacman_upgrade() {
+    if [[ ${CI:-} != true ]]; then
+        notice "Upgrading packages. Please be patient, this can take a while."
+        local REDIRECT="> /dev/null 2>&1"
+        if [[ -n ${VERBOSE:-} ]] || run_script 'question_prompt' "${PROMPT:-CLI}" N "Would you like to display the command output?"; then
+            REDIRECT=""
+        fi
+        eval pacman -Syu --noconfirm "${REDIRECT}" || fatal "Failed to upgrade packages from pacman."
+    fi
+}
+
+test_pm_pacman_upgrade() {
+    # run_script 'pm_pacman_upgrade'
+    warn "CI does not test pm_pacman_upgrade."
+}

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ sudo yum install curl git
 
 ## NOTE: Do not sudo the next line.
 git clone https://github.com/GhostWriters/DockSTARTer "/home/${USER}/.docker"
-sudo bash /home/${USER}/.docker/main.sh -i
+sudo bash /home/${USER}/.docker/main.sh -vi
 sudo reboot
 ```
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ sudo reboot
 > Note that systems with the `pacman` package manager will not install `docker` via the [https://get.docker.com](https://get.docker.com) script that is used for other distros. The instructions below provide information on installing all required packages manually prior to installing DockSTARTer.
 
 ```bash
-sudo pacman -Sy curl docker docker-compose git
+sudo pacman -Sy curl docker git
 bash -c "$(curl -fsSL https://get.dockstarter.com)"
 sudo reboot
 ```

--- a/README.md
+++ b/README.md
@@ -65,6 +65,16 @@ bash -c "$(curl -fsSL https://get.dockstarter.com)"
 sudo reboot
 ```
 
+- Pacman Systems (Arch, Manjaro, EndeavourOS, etc)
+
+> Note that systems with the `pacman` package manager will not install `docker` via the [https://get.docker.com](https://get.docker.com) script that is used for other distros. The instructions below provide information on installing all required packages manually prior to installing DockSTARTer.
+
+```bash
+sudo pacman -Sy curl docker docker-compose git
+bash -c "$(curl -fsSL https://get.dockstarter.com)"
+sudo reboot
+```
+
 <details>
   <summary>Alternate install (any system)</summary>
 


### PR DESCRIPTION
We currently don't detect pacman, and it looks like there is no package manager. Instead of exiting, tell the user they need to install docker and docker-compose (both from Arch repos, easy to do) and let the script work normally. This allows DockSTARTer to work on Arch despite not officially supporting it in the same manner as other distributions.