### PR TITLE
Fix permissions on .git folder

### DIFF
--- a/.scripts/update_self.sh
+++ b/.scripts/update_self.sh
@@ -24,6 +24,7 @@ update_self() {
     # git for-each-ref --format '%(refname:short)' refs/heads | grep -v master | xargs git branch -D > /dev/null 2>&1 || true
     info "Setting file ownership on repository files"
     git ls-tree -r HEAD | awk '{print $4}' | xargs chown "${DETECTED_PUID}":"${DETECTED_PGID}" > /dev/null 2>&1 || true
+    chown -R "${DETECTED_PUID}":"${DETECTED_PGID}" "${SCRIPTPATH}/.git" > /dev/null 2>&1 || true
     run_script 'env_update'
     run_script 'appvars_create_all'
 }


### PR DESCRIPTION
# Pull request

**Purpose**
The `.git` folder is often left owned by root. This corrects permissions on the folder. Likely only noticed by developers/contributors. End users would only see an effect (with root owning the folder) if they tried to run `git` commands in the repo folder.

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
