### PR TITLE
Update xteve.yml

### DIFF
--- a/compose/.apps/xteve/xteve.yml
+++ b/compose/.apps/xteve/xteve.yml
@@ -5,7 +5,7 @@ services:
       - PGID=${PGID}
       - PUID=${PUID}
       - TZ=${TZ}
-      - XTEVE_BRACH=${XTEVE_BRANCH}
+      - XTEVE_BRANCH=${XTEVE_BRANCH}
       - XTEVE_DEBUG=${XTEVE_DEBUG}
     logging:
       driver: json-file
@@ -15,6 +15,6 @@ services:
     restart: unless-stopped
     volumes:
       - /etc/localtime:/etc/localtime:ro
-      - ${DOCKERCONFDIR}/xteve:/config
+      - ${DOCKERCONFDIR}/xteve:/home/xteve/conf
       - ${DOCKERCONFDIR}/xteve/tmp:/tmp/xteve
       - ${DOCKERSHAREDDIR}:/shared


### PR DESCRIPTION
fix variable name
fix conf location

# Pull request

**Purpose**
The xteve app was not respecting the BRANCH variable. It was also resetting the config after each restart.

**Approach**
Follows the official documentation for the conf location [dnsforge/xteve](https://github.com/dnsforge-repo/xteve#default-container-paths)

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Read the documentation for [dnsforge/xteve](https://github.com/dnsforge-repo/xteve#default-container-paths) and discovered the correct volume locations and environment variable names

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
