### PR TITLE
Use mkdocs-material from pip

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -10,14 +10,14 @@ jobs:
     name: Deploy docs
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2.3.2
+      - uses: actions/checkout@v2.3.2
 
-      - name: Copy README.md to docs/index.md
-        run: cp README.md docs/index.md
+      - run: cp README.md docs/index.md
 
-      - name: Deploy docs
-        uses: mhausenblas/mkdocs-deploy-gh-pages@1.14
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CUSTOM_DOMAIN: dockstarter.com
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.x
+
+      - run: pip install mkdocs-material
+
+      - run: mkdocs gh-deploy --force

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -14,7 +14,7 @@ jobs:
 
       - run: cp README.md docs/index.md
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v2.1.2
         with:
           python-version: 3.x
 

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+dockstarter.com


### PR DESCRIPTION
# Pull request

**Purpose**
This is a more direct approach and will use direct versions from mkdocs-material rather than abstracting the version behind another GHA.

**Learning**
https://github.com/squidfunk/mkdocs-material/blob/master/docs/publishing-your-site.md

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
