### PR TITLE
Removing Calibre non-x86_64 YML

### DIFF
--- a/compose/.apps/calibre/calibre.aarch64.yml
+++ b/compose/.apps/calibre/calibre.aarch64.yml
@@ -1,3 +1,0 @@
-services:
-  calibre:
-    image: linuxserver/calibre

--- a/compose/.apps/calibre/calibre.armv7l.yml
+++ b/compose/.apps/calibre/calibre.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  calibre:
-    image: linuxserver/calibre


### PR DESCRIPTION
# Pull request

**Purpose**
Removes arm64 and armhf YML files from Calibre

Per LSIO:

```
Architecture | Tag
-- | --
x86-64 | latest
```

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
