### PR TITLE
Add compose template links to all app docs

### DIFF
--- a/docs/apps/airdcpp.md
+++ b/docs/apps/airdcpp.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/gangefors/airdcpp-webclient?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/gangefors/airdcpp-webclient)
 [![GitHub Stars](https://img.shields.io/github/stars/gangefors/docker-airdcpp-webclient?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/gangefors/docker-airdcpp-webclient)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/airdcpp)
 
 ## Description
 

--- a/docs/apps/airsonic.md
+++ b/docs/apps/airsonic.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/airsonic?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/airsonic)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-airsonic?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-airsonic)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/airsonic)
 
 ## Description
 

--- a/docs/apps/amd.md
+++ b/docs/apps/amd.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/halianelf/amd?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/halianelf/amd)
 [![GitHub Stars](https://img.shields.io/github/stars/halianelf/docker-amd?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/halianelf/docker-amd)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/amd)
 
 ## Description
 

--- a/docs/apps/amd.md
+++ b/docs/apps/amd.md
@@ -6,4 +6,4 @@
 
 ## Description
 
-Automatic Music Downloader (AMD) is a Lidarr companion script to automatically download music for Lidarr.
+[Automatic Music Downloader (AMD)](https://github.com/RandomNinjaAtk/docker-amd) is a Lidarr companion script to automatically download music for Lidarr.

--- a/docs/apps/apcupsd.md
+++ b/docs/apps/apcupsd.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/atribe/apcupsd-influxdb-exporter?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/atribe/apcupsd-influxdb-exporter)
 [![GitHub Stars](https://img.shields.io/github/stars/atribe/apcupsd-influxdb-exporter?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/atribe/apcupsd-influxdb-exporter)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/apcupsd)
 
 ## Description
 

--- a/docs/apps/bazarr.md
+++ b/docs/apps/bazarr.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/bazarr?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/bazarr)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-bazarr?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-bazarr)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/bazarr)
 
 ## Description
 

--- a/docs/apps/beets.md
+++ b/docs/apps/beets.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/beets?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/beets)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-beets?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-beets)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/beets)
 
 ## Description
 

--- a/docs/apps/bitwarden.md
+++ b/docs/apps/bitwarden.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/bitwardenrs/server?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/bitwardenrs/server)
 [![GitHub Stars](https://img.shields.io/github/stars/dani-garcia/bitwarden_rs?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/dani-garcia/bitwarden_rs)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/bitwarden)
 
 ## Description
 

--- a/docs/apps/booksonic.md
+++ b/docs/apps/booksonic.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/booksonic?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/booksonic)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-booksonic?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-booksonic)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/booksonic)
 
 ## Description
 

--- a/docs/apps/bookstack.md
+++ b/docs/apps/bookstack.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/bookstack?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/bookstack)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-bookstack?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-bookstack)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/bookstack)
 
 ## Description
 

--- a/docs/apps/calibre.md
+++ b/docs/apps/calibre.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/calibre?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/calibre)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-calibre?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-calibre)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/calibre)
 
 ## Description
 

--- a/docs/apps/calibreweb.md
+++ b/docs/apps/calibreweb.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/calibre-web?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/calibre-web)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-calibre-web?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-calibre-web)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/calibreweb)
 
 ## Description
 

--- a/docs/apps/cloudcmd.md
+++ b/docs/apps/cloudcmd.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/coderaiser/cloudcmd?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/coderaiser/cloudcmd)
 [![GitHub Stars](https://img.shields.io/github/stars/coderaiser/cloudcmd?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/coderaiser/cloudcmd)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/cloudcmd)
 
 ## Description
 

--- a/docs/apps/cloudflareddns.md
+++ b/docs/apps/cloudflareddns.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/hotio/cloudflare-ddns?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/hotio/cloudflare-ddns)
 [![GitHub Stars](https://img.shields.io/github/stars/hotio/docker-cloudflare-ddns?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/hotio/docker-cloudflare-ddns)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/cloudflareddns)
 
 ## Description
 

--- a/docs/apps/codeserver.md
+++ b/docs/apps/codeserver.md
@@ -6,4 +6,4 @@
 
 ## Description
 
-Run [VS Code](https://github.com/Microsoft/vscode) on any machine anywhere and access it in the browser.
+[Code-server](https://coder.com/) is VS Code running on a remote server, accessible through the browser.

--- a/docs/apps/codeserver.md
+++ b/docs/apps/codeserver.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/code-server?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/code-server)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-code-server?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-code-server)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/codeserver)
 
 ## Description
 

--- a/docs/apps/couchpotato.md
+++ b/docs/apps/couchpotato.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/couchpotato?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/couchpotato)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-couchpotato?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-couchpotato)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/couchpotato)
 
 ## Description
 

--- a/docs/apps/dasshio.md
+++ b/docs/apps/dasshio.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/danimtb/amd64-dasshio?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/danimtb/amd64-dasshio)
 [![GitHub Stars](https://img.shields.io/github/stars/danimtb/dasshio?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/danimtb/dasshio)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/dasshio)
 
 ## Description
 

--- a/docs/apps/dasshio.md
+++ b/docs/apps/dasshio.md
@@ -6,4 +6,4 @@
 
 ## Description
 
-Dasshio is a [Hass.io](https://www.home-assistant.io/hassio/) add-on to easily use Amazon Dash Buttons with Home Assistant
+[Dasshio](https://github.com/danimtb/dasshio) is a [Hass.io](https://www.home-assistant.io/hassio/) add-on to easily use Amazon Dash Buttons with Home Assistant

--- a/docs/apps/ddclient.md
+++ b/docs/apps/ddclient.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/ddclient?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/ddclient)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-ddclient?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-ddclient)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/ddclient)
 
 ## Description
 

--- a/docs/apps/deemix.md
+++ b/docs/apps/deemix.md
@@ -4,7 +4,6 @@
 [![GitLab Repo](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=gitlab&message=repo)](https://gitlab.com/Bockiii/deemix-docker)
 [![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/duplicacy)
 
-
 ## Description
 
 [Deemix](https://gitlab.com/Bockiii/deemix-docker) is a deezer downloader built from the ashes of Deezloader Remix. The base library (or core) can be used as a stand alone CLI app or implemented in an UI using the API.

--- a/docs/apps/deemix.md
+++ b/docs/apps/deemix.md
@@ -1,6 +1,9 @@
 # Deemix
 
-[![GitLab Pipeline](https://img.shields.io/gitlab/pipeline/Bockiii/deemix-docker?style=flat-square&color=607D8B&label=gitlab%20pipeline&logo=github)](https://gitlab.com/Bockiii/deemix-docker)
+[![GitLab Container](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=gitlab&message=container)](https://gitlab.com/Bockiii/deemix-docker/container_registry)
+[![GitLab Repo](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=gitlab&message=repo)](https://gitlab.com/Bockiii/deemix-docker)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/duplicacy)
+
 
 ## Description
 

--- a/docs/apps/deluge.md
+++ b/docs/apps/deluge.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/deluge?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](hhttps://hub.docker.com/r/linuxserver/deluge)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-deluge?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-deluge)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/deluge)
 
 ## Description
 

--- a/docs/apps/delugevpn.md
+++ b/docs/apps/delugevpn.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/binhex/arch-delugevpn?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/binhex/arch-delugevpn)
 [![GitHub Stars](https://img.shields.io/github/stars/binhex/arch-delugevpn?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/binhex/arch-delugevpn)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/delugevpn)
 
 ## Description
 

--- a/docs/apps/dozzle.md
+++ b/docs/apps/dozzle.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/amir20/dozzle?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/amir20/dozzle)
 [![GitHub Stars](https://img.shields.io/github/stars/amir20/dozzle?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/amir20/dozzle)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/dozzle)
 
 ## Description
 

--- a/docs/apps/duckdns.md
+++ b/docs/apps/duckdns.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/duckdns?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/duckdns)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-duckdns?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-duckdns)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/duckdns)
 
 ## Description
 

--- a/docs/apps/duplicacy.md
+++ b/docs/apps/duplicacy.md
@@ -1,6 +1,8 @@
 # Duplicacy
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/saspus/duplicacy-web?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/saspus/duplicacy-web)
+[![Bitbucket Repo](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=bitbucket&message=repo)](https://bitbucket.org/saspus/duplicacy-web-docker-container/)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/duplicacy)
 
 ## Description
 

--- a/docs/apps/duplicati.md
+++ b/docs/apps/duplicati.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/duplicati?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/duplicati)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-duplicati?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-duplicati)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/duplicati)
 
 ## Description
 

--- a/docs/apps/emby.md
+++ b/docs/apps/emby.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/emby?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/emby)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-emby?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-emby)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/emby)
 
 ## Description
 

--- a/docs/apps/filebot.md
+++ b/docs/apps/filebot.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/jlesage/filebot?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/jlesage/filebot)
 [![GitHub Stars](https://img.shields.io/github/stars/jlesage/docker-filebot?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/jlesage/docker-filebot)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/filebot)
 
 ## Description
 

--- a/docs/apps/freshrss.md
+++ b/docs/apps/freshrss.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/duplicati?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/freshrss)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-freshrss?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-freshrss)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/freshrss)
 
 ## Description
 

--- a/docs/apps/glances.md
+++ b/docs/apps/glances.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/nicolargo/glances?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/nicolargo/glances)
 [![GitHub Stars](https://img.shields.io/github/stars/nicolargo/glances?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/nicolargo/glances)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/glances)
 
 ## Description
 

--- a/docs/apps/goaccess.md
+++ b/docs/apps/goaccess.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/gregyankovoy/goaccess?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/gregyankovoy/goaccess)
 [![GitHub Stars](https://img.shields.io/github/stars/GregYankovoy/docker-goaccess?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/GregYankovoy/docker-goaccess)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/goaccess)
 
 ## Description
 

--- a/docs/apps/grafana.md
+++ b/docs/apps/grafana.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/grafana/grafana?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/grafana/grafana)
 [![GitHub Stars](https://img.shields.io/github/stars/grafana/grafana?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/grafana/grafana)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/grafana)
 
 ## Description
 

--- a/docs/apps/grocy.md
+++ b/docs/apps/grocy.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/grocy?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/grocy)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-grocy?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-grocy)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/grocy)
 
 ## Description
 

--- a/docs/apps/guacamole.md
+++ b/docs/apps/guacamole.md
@@ -6,7 +6,7 @@
 
 ## Description
 
-Guacamole is a Docker container for [Apache Guacamole](https://guacamole.apache.org/), a client-less remote desktop gateway. It supports standard protocols like VNC, RDP, and SSH over HTML5.
+[Guacamole](https://guacamole.apache.org/) is a client-less remote desktop gateway. It supports standard protocols like VNC, RDP, and SSH over HTML5.
 
 ## Install/Setup
 

--- a/docs/apps/guacamole.md
+++ b/docs/apps/guacamole.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/oznu/guacamole?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/oznu/guacamole)
 [![GitHub Stars](https://img.shields.io/github/stars/oznu/docker-guacamole?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/oznu/docker-guacamole)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/guacamole)
 
 ## Description
 

--- a/docs/apps/h5ai.md
+++ b/docs/apps/h5ai.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/bixidock/h5ai?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/bixidock/h5ai)
 [![GitHub Stars](https://img.shields.io/github/stars/PixiBixi/dockerfiles?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/PixiBixi/dockerfiles/tree/master/h5ai)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/h5ai)
 
 ## Description
 

--- a/docs/apps/handbrake.md
+++ b/docs/apps/handbrake.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/jlesage/handbrake?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r//jlesage/handbrake)
 [![GitHub Stars](https://img.shields.io/github/stars/jlesage/docker-handbrake?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/jlesage/docker-handbrake)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/handbrake)
 
 ## Description
 

--- a/docs/apps/headphones.md
+++ b/docs/apps/headphones.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/headphones?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/headphones)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-headphones?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-headphones)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/headphones)
 
 ## Description
 

--- a/docs/apps/heimdall.md
+++ b/docs/apps/heimdall.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/heimdall?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/heimdall)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-heimdall?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-heimdall)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/heimdall)
 
 ## Description
 

--- a/docs/apps/homeassistant.md
+++ b/docs/apps/homeassistant.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/homeassistant/home-assistant?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/homeassistant/home-assistant)
 [![GitHub Stars](https://img.shields.io/github/stars/home-assistant/core?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/home-assistant/core)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/homeassistant)
 
 ## Description
 

--- a/docs/apps/htpcmanager.md
+++ b/docs/apps/htpcmanager.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/htpcmanager?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/htpcmanager)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-htpcmanager?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-htpcmanager)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/htpcmanager)
 
 ## Description
 

--- a/docs/apps/httpserver.md
+++ b/docs/apps/httpserver.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/patrickdappollonio/docker-http-server?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/patrickdappollonio/docker-http-server)
 [![GitHub Stars](https://img.shields.io/github/stars/patrickdappollonio/http-server?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com//patrickdappollonio/http-server)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/httpserver)
 
 ## Description
 

--- a/docs/apps/huginn.md
+++ b/docs/apps/huginn.md
@@ -6,7 +6,7 @@
 
 ## Description
 
-Huginn is a system for building agents that perform automated tasks for you online. They can read the web, watch for events, and take actions on your behalf. Huginn's Agents create and consume events, propagating them along a directed graph. Think of it as a hackable version of IFTTT or Zapier on your own server. You always know who has your data. You do.
+[Huginn](https://github.com/huginn/huginn) is a system for building agents that perform automated tasks for you online. They can read the web, watch for events, and take actions on your behalf. Huginn's Agents create and consume events, propagating them along a directed graph. Think of it as a hackable version of IFTTT or Zapier on your own server. You always know who has your data. You do.
 
 ## Install/Setup
 

--- a/docs/apps/huginn.md
+++ b/docs/apps/huginn.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/huginn/huginn?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/huginn/huginn)
 [![GitHub Stars](https://img.shields.io/github/stars/huginn/huginn?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/huginn/huginn)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/huginn)
 
 ## Description
 

--- a/docs/apps/influxdb.md
+++ b/docs/apps/influxdb.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/_/influxdb?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/_/influxdb)
 [![GitHub Stars](https://img.shields.io/github/stars/influxdata/influxdata-docker?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/influxdata/influxdata-docker)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/influxdb)
 
 ## Description
 

--- a/docs/apps/jackett.md
+++ b/docs/apps/jackett.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/jackett?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/jackett)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-jackett?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-jackett)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/jackett)
 
 ## Description
 

--- a/docs/apps/jellyfin.md
+++ b/docs/apps/jellyfin.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/jellyfin?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/jellyfin)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-jellyfin?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-jellyfin)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/jellyfin)
 
 ## Description
 

--- a/docs/apps/lazylibrarian.md
+++ b/docs/apps/lazylibrarian.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/lazylibrarian?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/lazylibrarian)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-lazylibrarian?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-lazylibrarian)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/lazylibrarian)
 
 ## Description
 

--- a/docs/apps/librespeed.md
+++ b/docs/apps/librespeed.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/librespeed?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/librespeed)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-librespeed?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-librespeed)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/librespeed)
 
 ## Description
 

--- a/docs/apps/lidarr.md
+++ b/docs/apps/lidarr.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/lidarr?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/lidarr)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-lidarr?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-lidarr)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/lidarr)
 
 ## Description
 

--- a/docs/apps/limnoria.md
+++ b/docs/apps/limnoria.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/limnoria?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/limnoria)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-limnoria?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-limnoria)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/limnoria)
 
 ## Description
 

--- a/docs/apps/logarr.md
+++ b/docs/apps/logarr.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/monitorr/logarr?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/monitorr/logarr/)
 [![GitHub Stars](https://img.shields.io/github/stars/monitorr/logarr?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/Monitorr/logarr)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/logarr)
 
 ## Description
 

--- a/docs/apps/logitechmediaserver.md
+++ b/docs/apps/logitechmediaserver.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/doliana/logitech-media-server?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/doliana/logitech-media-server)
 [![GitHub Stars](https://img.shields.io/github/stars/DOliana/docker-image-logitech-media-server?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/DOliana/docker-image-logitech-media-server)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/logitechmediaserver)
 
 ## Description
 

--- a/docs/apps/makemkv.md
+++ b/docs/apps/makemkv.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/jlesage/makemkv?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/jlesage/makemkv)
 [![GitHub Stars](https://img.shields.io/github/stars/jlesage/docker-makemkv?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/jlesage/docker-makemkv)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/makemkv)
 
 ## Description
 

--- a/docs/apps/mariadb.md
+++ b/docs/apps/mariadb.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/mariadb?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/mariadb)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-mariadb?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-mariadb)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/mariadb)
 
 ## Description
 

--- a/docs/apps/mcmyadmin2.md
+++ b/docs/apps/mcmyadmin2.md
@@ -1,5 +1,0 @@
-# McMyAdmin
-
-## This container has been DEPRECATED
-
-No replacement.

--- a/docs/apps/medusa.md
+++ b/docs/apps/medusa.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/medusa?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/medusa)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-medusa?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-medusa)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/medusa)
 
 ## Description
 

--- a/docs/apps/minecraft_bedrock_server.md
+++ b/docs/apps/minecraft_bedrock_server.md
@@ -6,4 +6,4 @@
 
 ## Description
 
-This docker image provides a Minecraft Server that will automatically download the latest stable version at startup. Bedrock Dedicated Server is official server software to host your own server for Minecraft (Bedrock).
+[Minecraft Bedrock Server](https://www.minecraft.net/en-us/download/server/bedrock) will automatically download the latest stable version at startup. Bedrock Dedicated Server is official server software to host your own server for Minecraft (Bedrock).

--- a/docs/apps/minecraft_bedrock_server.md
+++ b/docs/apps/minecraft_bedrock_server.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/itzg/minecraft-bedrock-server?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/itzg/minecraft-bedrock-server)
 [![GitHub Stars](https://img.shields.io/github/stars/itzg/docker-minecraft-bedrock-server?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/itzg/docker-minecraft-bedrock-server)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/minecraft_bedrock_server)
 
 ## Description
 

--- a/docs/apps/minecraft_server.md
+++ b/docs/apps/minecraft_server.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/itzg/minecraft-server?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/itzg/minecraft-server)
 [![GitHub Stars](https://img.shields.io/github/stars/itzg/docker-minecraft-server?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/itzg/docker-minecraft-server)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/minecraft_server)
 
 ## Description
 

--- a/docs/apps/minecraft_server.md
+++ b/docs/apps/minecraft_server.md
@@ -6,4 +6,4 @@
 
 ## Description
 
-This docker image provides a Minecraft Server that will automatically download the latest stable version at startup. You can also run/upgrade to any specific version or the latest snapshot.
+[Minecraft Server](https://www.minecraft.net/en-us/download/server) will automatically download the latest stable version at startup. You can also run/upgrade to any specific version or the latest snapshot.

--- a/docs/apps/monitorr.md
+++ b/docs/apps/monitorr.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/monitorr/monitorr?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/monitorr/monitorr)
 [![GitHub Stars](https://img.shields.io/github/stars/monitorr/monitorr?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/monitorr/monitorr)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/monitorr)
 
 ## Description
 

--- a/docs/apps/murmur.md
+++ b/docs/apps/murmur.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/goofball222/murmur?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/goofball222/murmur)
 [![GitHub Stars](https://img.shields.io/github/stars/goofball222/murmur?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/goofball222/murmur)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/murmur)
 
 ## Description
 

--- a/docs/apps/muximux.md
+++ b/docs/apps/muximux.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/muximux?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/muximux)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-muximux?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-muximux)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/muximux)
 
 ## Description
 

--- a/docs/apps/mylar.md
+++ b/docs/apps/mylar.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/mylar?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/mylar)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-mylar?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-mylar)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/mylar)
 
 ## Description
 

--- a/docs/apps/netdata.md
+++ b/docs/apps/netdata.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/netdata/netdata?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/netdata/netdata)
 [![GitHub Stars](https://img.shields.io/github/stars/netdata/netdata?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/netdata/netdata)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/netdata)
 
 ## Description
 

--- a/docs/apps/nextcloud.md
+++ b/docs/apps/nextcloud.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/nextcloud?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/nextcloud)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-nextcloud?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-nextcloud)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/nextcloud)
 
 ## Description
 

--- a/docs/apps/nzbget.md
+++ b/docs/apps/nzbget.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/nzbget?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/nzbget)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-nzbget?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-nzbget)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/nzbget)
 
 ## Description
 

--- a/docs/apps/nzbgetvpn.md
+++ b/docs/apps/nzbgetvpn.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/jshridha/docker-nzbgetvpn?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/jshridha/docker-nzbgetvpn)
 [![GitHub Stars](https://img.shields.io/github/stars/jshridha/docker-nzbgetvpn?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/jshridha/docker-nzbgetvpn)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/nzbgetvpn)
 
 ## Description
 

--- a/docs/apps/nzbhydra2.md
+++ b/docs/apps/nzbhydra2.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/nzbhydra2?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/nzbhydra2)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-nzbhydra2?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-nzbhydra2)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/nzbhydra2)
 
 ## Description
 

--- a/docs/apps/omadacontroller.md
+++ b/docs/apps/omadacontroller.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/mbentley/omada-controller?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/mbentley/omada-controller)
 [![GitHub Stars](https://img.shields.io/github/stars/mbentley/docker-omada-controller?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/mbentley/docker-omada-controller)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/omadacontroller)
 
 ## Description
 

--- a/docs/apps/ombi.md
+++ b/docs/apps/ombi.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/duplicati?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/ombi)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-ombi?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-ombi)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/ombi)
 
 ## Description
 

--- a/docs/apps/openvpnas.md
+++ b/docs/apps/openvpnas.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/openvpn-as?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/openvpn-as)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-openvpn-as?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-openvpn-as)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/openvpnas)
 
 ## Description
 

--- a/docs/apps/organizr.md
+++ b/docs/apps/organizr.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/organizr/organizr?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/organizr/organizr)
 [![GitHub Stars](https://img.shields.io/github/stars/Organizr/docker-organizr?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/Organizr/docker-organizr)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/organizr)
 
 ## Description
 

--- a/docs/apps/ouroboros.md
+++ b/docs/apps/ouroboros.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/pyouroboros/ouroboros?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/pyouroboros/ouroboros)
 [![GitHub Stars](https://img.shields.io/github/stars/pyouroboros/ouroboros?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/pyouroboros/ouroboros)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/ouroboros)
 
 ## Description
 

--- a/docs/apps/photoshow.md
+++ b/docs/apps/photoshow.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/photoshow?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/photoshow)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-photoshow?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-photoshow)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/photoshow)
 
 ## Description
 

--- a/docs/apps/photostructure.md
+++ b/docs/apps/photostructure.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/photostructure/server?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/photostructure/server)
 [![GitHub Stars](https://img.shields.io/github/stars/photostructure/photostructure-for-servers?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/photostructure/photostructure-for-servers)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/photostructure)
 
 ## Description
 

--- a/docs/apps/phpmyadmin.md
+++ b/docs/apps/phpmyadmin.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/phpmyadmin/phpmyadmin?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/phpmyadmin/phpmyadmin)
 [![GitHub Stars](https://img.shields.io/github/stars/phpmyadmin/phpmyadmin?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/phpmyadmin/phpmyadmin)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/phpmyadmin)
 
 ## Description
 

--- a/docs/apps/pihole.md
+++ b/docs/apps/pihole.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/pihole/pihole?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/pihole/pihole)
 [![GitHub Stars](https://img.shields.io/github/stars/pi-hole/docker-pi-hole?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/pi-hole/docker-pi-hole)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/pihole)
 
 ## Description
 

--- a/docs/apps/piwigo.md
+++ b/docs/apps/piwigo.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/piwigo?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/piwigo)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-piwigo?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-piwigo)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/piwigo)
 
 ## Description
 

--- a/docs/apps/plex.md
+++ b/docs/apps/plex.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/plex?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/plex)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-plex?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-plex)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/plex)
 
 ## Description
 

--- a/docs/apps/portainer.md
+++ b/docs/apps/portainer.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/portainer/portainer?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/portainer/portainer)
 [![GitHub Stars](https://img.shields.io/github/stars/portainer/portainer?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/portainer/portainer)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/portainer)
 
 ## Description
 

--- a/docs/apps/portaineragent.md
+++ b/docs/apps/portaineragent.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/portainer/agent?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/portainer/agent)
 [![GitHub Stars](https://img.shields.io/github/stars/portainer/agent?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/portainer/agent)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/portaineragent)
 
 ## Description
 

--- a/docs/apps/portaineragent.md
+++ b/docs/apps/portaineragent.md
@@ -6,14 +6,4 @@
 
 ## Description
 
-The purpose of the agent is to work around a Docker API limitation. When using the Docker API to manage a Docker environment, the user interactions with specific resources (containers, networks, volumes and images) are limited to these available on the node targeted by the Docker API request.
-
-Docker Swarm mode introduces the concept of cluster of Docker nodes. With that concept, it also introduces the services, tasks, configs and secrets which are cluster aware resources. This means that you can query for the list of service or inspect a task inside any node on the cluster as long as you're executing the Docker API request on a manager node.
-
-Containers, networks, volumes and images are node specific resources, not cluster aware. If you want to get the list of all the volumes available on the node number 3 inside your cluster, you need to execute the request to query the volumes on that specific node.
-
-The agent purpose aims to solve that issue and make the containers, networks and volumes resources cluster aware while keeping the Docker API request format.
-
-This means that you only need to execute one Docker API request to retrieve all the volumes inside your cluster for example.
-
-The final goal is to bring a better Docker UX when managing Swarm clusters.
+[The Portainer Agent](https://github.com/portainer/agent) allows the Docker host to be managed by an instance of Portainer running on another machine.

--- a/docs/apps/prometheus.md
+++ b/docs/apps/prometheus.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/prom/prometheus?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/prom/prometheus/)
 [![GitHub Stars](https://img.shields.io/github/stars/prometheus/prometheus?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/https://github.com/prometheus/prometheus)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/prometheus)
 
 ## Description
 

--- a/docs/apps/pyload.md
+++ b/docs/apps/pyload.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/pyload?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/pyload)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-pyload?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-pyload)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/pyload)
 
 ## Description
 

--- a/docs/apps/qbittorrent.md
+++ b/docs/apps/qbittorrent.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/qbittorrent?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/qbittorrent)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-qbittorrent?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-qbittorrent)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/qbittorrent)
 
 ## Description
 

--- a/docs/apps/qbittorrentvpn.md
+++ b/docs/apps/qbittorrentvpn.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/binhex/arch-qbittorrentvpn?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/binhex/arch-qbittorrentvpn)
 [![GitHub Stars](https://img.shields.io/github/stars/binhex/arch-qbittorrentvpn?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/binhex/arch-qbittorrentvpn)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/qbittorrentvpn)
 
 ## Description
 

--- a/docs/apps/quasselcore.md
+++ b/docs/apps/quasselcore.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/quassel-core?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/quassel-core)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-quassel-core?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-quassel-core)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/quasselcore)
 
 ## Description
 

--- a/docs/apps/quasselweb.md
+++ b/docs/apps/quasselweb.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/quassel-web?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/quassel-web)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-quassel-web?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-quassel-web)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/quasselweb)
 
 ## Description
 

--- a/docs/apps/radarr.md
+++ b/docs/apps/radarr.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/radarr?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/radarr)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-radarr?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-radarr)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/radarr)
 
 ## Description
 

--- a/docs/apps/resiliosync.md
+++ b/docs/apps/resiliosync.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/resilio-sync?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/resilio-sync)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-resilio-sync?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-resilio-sync)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/resiliosync)
 
 ## Description
 

--- a/docs/apps/rsnapshot.md
+++ b/docs/apps/rsnapshot.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/rsnapshot?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/rsnapshot)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-rsnapshot?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-rsnapshot)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/rsnapshot)
 
 ## Description
 

--- a/docs/apps/rtorrentvpn.md
+++ b/docs/apps/rtorrentvpn.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/binhex/arch-rtorrentvpn?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/binhex/arch-rtorrentvpn)
 [![GitHub Stars](https://img.shields.io/github/stars/binhex/arch-rtorrentvpn?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/binhex/arch-rtorrentvpn)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/rtorrentvpn)
 
 ## Description
 

--- a/docs/apps/rutorrent.md
+++ b/docs/apps/rutorrent.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/rutorrent?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/rutorrent)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-rutorrent?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-rutorrent)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/rutorrent)
 
 ## Description
 

--- a/docs/apps/sabnzbd.md
+++ b/docs/apps/sabnzbd.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/sabnzbd?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/sabnzbd)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-sabnzbd?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-sabnzbd)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/sabnzbd)
 
 ## Description
 

--- a/docs/apps/sabnzbdvpn.md
+++ b/docs/apps/sabnzbdvpn.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/binhex/arch-sabnzbdvpn?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/binhex/arch-sabnzbdvpn)
 [![GitHub Stars](https://img.shields.io/github/stars/binhex/arch-sabnzbdvpn?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/binhex/arch-sabnzbdvpn)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/sabnzbdvpn)
 
 ## Description
 

--- a/docs/apps/samba.md
+++ b/docs/apps/samba.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/dperson/samba?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/dperson/samba)
 [![GitHub Stars](https://img.shields.io/github/stars/dperson/samba?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/dperson/samba)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/samba)
 
 ## Description
 

--- a/docs/apps/samba.md
+++ b/docs/apps/samba.md
@@ -6,7 +6,7 @@
 
 ## Description
 
-Samba is using the `SMB` protocol to share Linux mounts, which then are accessible and mountable on a Windows computer.
+[Samba](https://www.samba.org/) is using the `SMB` protocol to share Linux mounts, which then are accessible and mountable on a Windows computer.
 
 By default, Samba will share all media directories and [Docker config directory](https://dockstarter.com/basics/env-var-info/#dockerconfdir) over SMB on the host. All of these directories will be placed inside whatever share name is specified for `SAMBA_SHARENAME` on your `.env` file. These shares are protected with username `ds` and password `ds` by default, but **can and should be** changed on your `.env` file.
 

--- a/docs/apps/sickchill.md
+++ b/docs/apps/sickchill.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/sickchill?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/sickchill)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-sickchill?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-sickchill)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/sickchill)
 
 ## Description
 

--- a/docs/apps/sickrage.md
+++ b/docs/apps/sickrage.md
@@ -1,3 +1,0 @@
-# SickRage
-
-## This container has been DEPRECATED

--- a/docs/apps/smokeping.md
+++ b/docs/apps/smokeping.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/smokeping?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/smokeping)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-smokeping?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-smokeping)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/smokeping)
 
 ## Description
 

--- a/docs/apps/sonarr.md
+++ b/docs/apps/sonarr.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/sonarr?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/sonarr)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-sonarr?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-sonarr)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/sonarr)
 
 ## Description
 

--- a/docs/apps/speedtest.md
+++ b/docs/apps/speedtest.md
@@ -6,7 +6,7 @@
 
 ## Description
 
-This program runs a speedtest check every hour and graphs the results. The back-end is written in `Laravel` and the front-end uses `React`. It uses the Ookla's Speedtest cli package to get the data and uses `Chart.js` to plot the results.
+[Speedtest Tracker](https://github.com/henrywhitaker3/Speedtest-Tracker) runs a speedtest check every hour and graphs the results. The back-end is written in `Laravel` and the front-end uses `React`. It uses the Ookla's Speedtest cli package to get the data and uses `Chart.js` to plot the results.
 
 This program can also be used a home page item in [Organizr](https://organizr.app).
 

--- a/docs/apps/speedtest.md
+++ b/docs/apps/speedtest.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/henrywhitaker3/speedtest-tracker?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/henrywhitaker3/speedtest-tracker)
 [![GitHub Stars](https://img.shields.io/github/stars/henrywhitaker3/Speedtest-Tracker?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/henrywhitaker3/Speedtest-Tracker)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/speedtest)
 
 ## Description
 

--- a/docs/apps/swag.md
+++ b/docs/apps/swag.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/swag?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/swag)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-swag?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-swag)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/swag)
 
 ## Description
 

--- a/docs/apps/synclounge.md
+++ b/docs/apps/synclounge.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/synclounge?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/synclounge)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-synclounge?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-synclounge)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/synclounge)
 
 ## Description
 

--- a/docs/apps/syncthing.md
+++ b/docs/apps/syncthing.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/syncthing?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/syncthing)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-syncthing?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-syncthing)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/syncthing)
 
 ## Description
 

--- a/docs/apps/tautulli.md
+++ b/docs/apps/tautulli.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/tautulli?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/tautulli)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-tautulli?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-tautulli)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/tautulli)
 
 ## Description
 

--- a/docs/apps/tdarr.md
+++ b/docs/apps/tdarr.md
@@ -6,7 +6,7 @@
 
 ## Description
 
-Tdarr is a self hosted web-app for automating media library transcode/remux management and making sure your files are exactly how you need them to be in terms of codecs/streams/containers etc. Designed to work alongside Sonarr/Radarr and built with the aim of modularisation, parallelisation and scalability, each library you add has its own transcode settings, filters and schedule. Workers can be fired up and closed down as necessary, and are split into 3 types - 'general', 'transcode' and 'health check'. Worker limits can be managed by the scheduler as well as manually.
+[Tdarr](https://github.com/haveagitgat/tdarr) is a self hosted web-app for automating media library transcode/remux management and making sure your files are exactly how you need them to be in terms of codecs/streams/containers etc. Designed to work alongside Sonarr/Radarr and built with the aim of modularisation, parallelisation and scalability, each library you add has its own transcode settings, filters and schedule. Workers can be fired up and closed down as necessary, and are split into 3 types - 'general', 'transcode' and 'health check'. Worker limits can be managed by the scheduler as well as manually.
 
 ## Install/Setup
 

--- a/docs/apps/tdarr.md
+++ b/docs/apps/tdarr.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/haveagitgat/tdarr?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/haveagitgat/tdarr)
 [![GitHub Stars](https://img.shields.io/github/stars/haveagitgat/tdarr?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/haveagitgat/tdarr)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/tdarr)
 
 ## Description
 

--- a/docs/apps/telegraf.md
+++ b/docs/apps/telegraf.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/_/telegraf?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/_/telegraf)
 [![GitHub Stars](https://img.shields.io/github/stars/influxdata/telegraf?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/influxdata/telegraf)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/telegraf)
 
 ## Description
 

--- a/docs/apps/thelounge.md
+++ b/docs/apps/thelounge.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/thelounge?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/thelounge)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-thelounge?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-thelounge)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/thelounge)
 
 ## Description
 

--- a/docs/apps/traktarr.md
+++ b/docs/apps/traktarr.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/l3uddz/traktarr?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/l3uddz/traktarr)
 [![GitHub Stars](https://img.shields.io/github/stars/l3uddz/Traktarr?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/l3uddz/Traktarr)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/traktarr)
 
 ## Description
 

--- a/docs/apps/transmission.md
+++ b/docs/apps/transmission.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/transmission?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/transmission)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-transmission?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-transmission)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/transmission)
 
 ## Description
 

--- a/docs/apps/transmissionvpn.md
+++ b/docs/apps/transmissionvpn.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/haugene/transmission-openvpn?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/haugene/transmission-openvpn)
 [![GitHub Stars](https://img.shields.io/github/stars/haugene/docker-transmission-openvpn?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/haugene/docker-transmission-openvpn)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/transmissionvpn)
 
 ## Description
 

--- a/docs/apps/tvheadend.md
+++ b/docs/apps/tvheadend.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/tvheadend?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/tvheadend)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-tvheadend?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-tvheadend)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/tvheadend)
 
 ## Description
 

--- a/docs/apps/ubooquity.md
+++ b/docs/apps/ubooquity.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/ubooquity?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/ubooquity)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-ubooquity?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-ubooquity)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/ubooquity)
 
 ## Description
 

--- a/docs/apps/unificontroller.md
+++ b/docs/apps/unificontroller.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/unifi-controller?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/unifi-controller)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-unifi-controller?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-unifi-controller)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/unificontroller)
 
 ## Description
 

--- a/docs/apps/unmanic.md
+++ b/docs/apps/unmanic.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/josh5/unmanic?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/josh5/unmanic)
 [![GitHub Stars](https://img.shields.io/github/stars/josh5/unmanic?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/josh5/unmanic)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/unmanic)
 
 ## Description
 

--- a/docs/apps/varken.md
+++ b/docs/apps/varken.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/boerderij/varken?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/boerderij/varken)
 [![GitHub Stars](https://img.shields.io/github/stars/Boerderij/Varken?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/Boerderij/Varken)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/varken)
 
 ## Description
 

--- a/docs/apps/vsftpd.md
+++ b/docs/apps/vsftpd.md
@@ -6,4 +6,4 @@
 
 ## Description
 
-This Docker container implements a [vsftpd server](https://security.appspot.com/vsftpd.html#about).
+[vsftpd](https://security.appspot.com/vsftpd.html) is an FTP server for Unix-like systems.

--- a/docs/apps/vsftpd.md
+++ b/docs/apps/vsftpd.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/fauria/vsftpd?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/fauria/vsftpd)
 [![GitHub Stars](https://img.shields.io/github/stars/fauria/docker-vsftpd?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/fauria/docker-vsftpd)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/vsftpd)
 
 ## Description
 

--- a/docs/apps/watchtower.md
+++ b/docs/apps/watchtower.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/containrrr/watchtower?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/containrrr/watchtower)
 [![GitHub Stars](https://img.shields.io/github/stars/containrrr/watchtower?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/containrrr/watchtower)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/watchtower)
 
 ## Description
 

--- a/docs/apps/xbackbone.md
+++ b/docs/apps/xbackbone.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/pe46dro/xbackbone-docker?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/pe46dro/xbackbone-docker)
 [![GitHub Stars](https://img.shields.io/github/stars/Pe46dro/XBackBone-docker?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/Pe46dro/XBackBone-docker)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/xbackbone)
 
 ## Description
 

--- a/docs/apps/xteve.md
+++ b/docs/apps/xteve.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/dnsforge/xteve?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/dnsforge/xteve)
 [![GitHub Stars](https://img.shields.io/github/stars/xteve-project/xTeVe?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/xteve-project/xTeVe)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/xteve)
 
 ## Description
 

--- a/docs/apps/youtubedl.md
+++ b/docs/apps/youtubedl.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/nbr23/youtube-dl-server?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/nbr23/youtube-dl-server)
 [![GitHub Stars](https://img.shields.io/github/stars/nbr23/youtube-dl-server?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/nbr23/youtube-dl-server)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/youtubedl)
 
 ## Description
 

--- a/docs/apps/znc.md
+++ b/docs/apps/znc.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/znc?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/znc)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-znc?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-znc)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/znc)
 
 ## Description
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,6 +34,7 @@ plugins:
         apps/hydra2.md: https://dockstarter.com/apps/nzbhydra2/
         apps/letsencrypt.md: https://dockstarter.com/apps/swag/
         apps/plexrequests.md: https://dockstarter.com/apps/ombi/
+        apps/sickrage.md: https://dockstarter.com/apps/sickchill/
         apps/ttrss.md: https://dockstarter.com/apps/freshrss/
         apps/unifi.md: https://dockstarter.com/apps/unificontroller/
         discord.md: https://discord.gg/xR3cyUb


### PR DESCRIPTION
# Pull request

**Purpose**
Link from our docs to the repo to easily access the compose templates. This should make it easier for users to see what DS is stitching together and whether there is an architecture specific file for the app.

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
