### PR TITLE
Revert "Use DH for beets"

### DIFF
--- a/compose/.apps/beets/beets.aarch64.yml
+++ b/compose/.apps/beets/beets.aarch64.yml
@@ -1,3 +1,3 @@
 services:
   beets:
-    image: linuxserver/beets
+    image: ghcr.io/linuxserver/beets

--- a/compose/.apps/beets/beets.armv7l.yml
+++ b/compose/.apps/beets/beets.armv7l.yml
@@ -1,3 +1,3 @@
 services:
   beets:
-    image: linuxserver/beets
+    image: ghcr.io/linuxserver/beets

--- a/compose/.apps/beets/beets.x86_64.yml
+++ b/compose/.apps/beets/beets.x86_64.yml
@@ -1,3 +1,3 @@
 services:
   beets:
-    image: linuxserver/beets
+    image: ghcr.io/linuxserver/beets


### PR DESCRIPTION
This reverts commit e5345e510d12a6175edc9e8038becfacb038ab13.

https://github.com/linuxserver/docker-beets

Wait for the image to be available on GHCR.