### PR TITLE
Revert "Use DH for pyload"

### DIFF
--- a/compose/.apps/pyload/pyload.aarch64.yml
+++ b/compose/.apps/pyload/pyload.aarch64.yml
@@ -1,3 +1,3 @@
 services:
   pyload:
-    image: linuxserver/pyload
+    image: ghcr.io/linuxserver/pyload

--- a/compose/.apps/pyload/pyload.armv7l.yml
+++ b/compose/.apps/pyload/pyload.armv7l.yml
@@ -1,3 +1,3 @@
 services:
   pyload:
-    image: linuxserver/pyload
+    image: ghcr.io/linuxserver/pyload

--- a/compose/.apps/pyload/pyload.x86_64.yml
+++ b/compose/.apps/pyload/pyload.x86_64.yml
@@ -1,3 +1,3 @@
 services:
   pyload:
-    image: linuxserver/pyload
+    image: ghcr.io/linuxserver/pyload


### PR DESCRIPTION
This reverts commit e36b7f77d5078577a5817e7a52e41f063221bb99.

https://github.com/linuxserver/docker-pyload

Wait for the image to be available on GHCR.
