### PR TITLE
Revert "Use DH for quasselweb"

### DIFF
--- a/compose/.apps/quasselweb/quasselweb.aarch64.yml
+++ b/compose/.apps/quasselweb/quasselweb.aarch64.yml
@@ -1,3 +1,3 @@
 services:
   quasselweb:
-    image: linuxserver/quassel-web
+    image: ghcr.io/linuxserver/quassel-web

--- a/compose/.apps/quasselweb/quasselweb.armv7l.yml
+++ b/compose/.apps/quasselweb/quasselweb.armv7l.yml
@@ -1,3 +1,3 @@
 services:
   quasselweb:
-    image: linuxserver/quassel-web
+    image: ghcr.io/linuxserver/quassel-web

--- a/compose/.apps/quasselweb/quasselweb.x86_64.yml
+++ b/compose/.apps/quasselweb/quasselweb.x86_64.yml
@@ -1,3 +1,3 @@
 services:
   quasselweb:
-    image: linuxserver/quassel-web
+    image: ghcr.io/linuxserver/quassel-web


### PR DESCRIPTION
This reverts commit 4b6925980342508fc62b41f2431a559959fe8ebf.

https://github.com/linuxserver/docker-quassel-web

Wait for the image to be available on GHCR.
