### PR TITLE
Revert "Use DH for unificontroller"

### DIFF
--- a/compose/.apps/unificontroller/unificontroller.aarch64.yml
+++ b/compose/.apps/unificontroller/unificontroller.aarch64.yml
@@ -1,3 +1,3 @@
 services:
   unificontroller:
-    image: linuxserver/unifi-controller
+    image: ghcr.io/linuxserver/unifi-controller

--- a/compose/.apps/unificontroller/unificontroller.armv7l.yml
+++ b/compose/.apps/unificontroller/unificontroller.armv7l.yml
@@ -1,3 +1,3 @@
 services:
   unificontroller:
-    image: linuxserver/unifi-controller
+    image: ghcr.io/linuxserver/unifi-controller

--- a/compose/.apps/unificontroller/unificontroller.x86_64.yml
+++ b/compose/.apps/unificontroller/unificontroller.x86_64.yml
@@ -1,3 +1,3 @@
 services:
   unificontroller:
-    image: linuxserver/unifi-controller
+    image: ghcr.io/linuxserver/unifi-controller


### PR DESCRIPTION
This reverts commit f7c815d3629201a90ad230cdfcc2f824fc59e373.

https://github.com/linuxserver/docker-unifi-controller

Wait for the image to be available on GHCR.
