### PR TITLE
Fix filebrowser port inconsistencies

### DIFF
--- a/compose/.apps/filebrowser/filebrowser.labels.yml
+++ b/compose/.apps/filebrowser/filebrowser.labels.yml
@@ -9,5 +9,5 @@ services:
       com.dockstarter.appvars.filebrowser_enabled: "false"
       com.dockstarter.appvars.filebrowser_log: "/config/filebrowser.log"
       com.dockstarter.appvars.filebrowser_network_mode: ""
-      com.dockstarter.appvars.filebrowser_port_8080: "8080"
+      com.dockstarter.appvars.filebrowser_port_80: "8080"
       com.dockstarter.appvars.filebrowser_share_dir: "~/.config/appdata/filebrowser/share"

--- a/compose/.apps/filebrowser/filebrowser.ports.yml
+++ b/compose/.apps/filebrowser/filebrowser.ports.yml
@@ -1,4 +1,4 @@
 services:
   filebrowser:
     ports:
-      - ${FILEBROWSER_PORT_8080}:80
+      - ${FILEBROWSER_PORT_80}:${FILEBROWSER_PORT_80}

--- a/compose/.apps/filebrowser/filebrowser.yml
+++ b/compose/.apps/filebrowser/filebrowser.yml
@@ -5,7 +5,7 @@ services:
       - FB_BASEURL=${FILEBROWSER_BASEURL}
       - FB_DATABASE=${FILEBROWSER_DATABASE}
       - FB_LOG=${FILEBROWSER_LOG}
-      - FB_PORT=${FILEBROWSER_PORT_8080}
+      - FB_PORT=${FILEBROWSER_PORT_80}
       - TZ=${TZ}
     logging:
       driver: json-file


### PR DESCRIPTION
# Pull request

**Purpose**
Fixes https://github.com/GhostWriters/DockSTARTer/issues/1175

**Approach**
The port documented is 80, however we went with 8080 by default originally due to host user permissions. This keeps the default port 8080 but applies it in a way that the app and container should both recognize.

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
