### PR TITLE
Pin yq-go version to 3.4.1

### DIFF
--- a/.scripts/install_yq.sh
+++ b/.scripts/install_yq.sh
@@ -13,6 +13,8 @@ install_yq() {
     if vergt "${MINIMUM_YQ}" "${INSTALLED_YQ}"; then
         local AVAILABLE_YQ
         AVAILABLE_YQ=$( (curl -H "${GH_HEADER:-}" -fsL "https://api.github.com/repos/mikefarah/yq/releases/latest" | grep -Po '"tag_name": "[Vv]?\K.*?(?=")') || echo "0")
+        # Pin yq-go version to 3.4.1 since 4.x has breaking changes we will need to adjust for.
+        AVAILABLE_YQ="3.4.1"
         if [[ ${AVAILABLE_YQ} == "0" ]]; then
             if [[ ${INSTALLED_YQ} == "0" ]]; then
                 fatal "The latest available version of yq-go could not be confirmed. This is usually caused by exhausting the rate limit on GitHub's API. Please check https://api.github.com/rate_limit"


### PR DESCRIPTION
# Pull request

**Purpose**
4.x has breaking changes we will need to adjust for

**Approach**
Hardcode the `AVAILABLE_YQ` so that DS does not install anything newer than the defined version.

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
