### PR TITLE
Include SCRIPTPATH in YQ_OPTIONS when running yq

### DIFF
--- a/.scripts/yml_merge.sh
+++ b/.scripts/yml_merge.sh
@@ -10,6 +10,7 @@ yml_merge() {
     RUNFILE=$(mktemp) || fatal "Failed to create temporary yml merge script.\nFailing command: ${F[C]}mktemp"
     echo "#!/usr/bin/env bash" > "${RUNFILE}"
     {
+        echo "export YQ_OPTIONS=\"${YQ_OPTIONS:-} -v ${SCRIPTPATH}:${SCRIPTPATH}\""
         echo "yq -y -s 'reduce .[] as \$item ({}; . * \$item)' "\\
         echo "\"${SCRIPTPATH}/compose/.reqs/v1.yml\" \\"
         echo "\"${SCRIPTPATH}/compose/.reqs/v2.yml\" \\"


### PR DESCRIPTION
# Pull request

**Purpose**
`yq` might not be aware of the `SCRIPTPATH` when running inside docker.

**Approach**
Set `YQ_OPTIONS` to include `SCRIPTPATH` as a volume when running `yq` via `yml_merge` so that we are positive that the yml templates will be available.

**Learning**
https://github.com/linuxserver/docker-yq/blob/master/run-yq.sh

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
