### PR TITLE
Add DNS to smokeping

### DIFF
--- a/compose/.apps/smokeping/smokeping.yml
+++ b/compose/.apps/smokeping/smokeping.yml
@@ -1,6 +1,9 @@
 services:
   smokeping:
     container_name: smokeping
+    dns:
+      - ${NS1}
+      - ${NS2}
     environment:
       - PGID=${PGID}
       - PUID=${PUID}


### PR DESCRIPTION
# Pull request

**Purpose**
Smokeping apparently has an issue working without DNS entries in compose?

**Approach**
Add DNS entries to compose.

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Testing `ds -u origin/sp`

**Learning**
https://github.com/linuxserver/docker-smokeping/issues/86

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
