### PR TITLE
Fix merge quoting (again)

### DIFF
--- a/.scripts/yml_merge.sh
+++ b/.scripts/yml_merge.sh
@@ -60,7 +60,7 @@ yml_merge() {
     done < <(grep '_ENABLED=true$' < "${SCRIPTPATH}/compose/.env")
     YML_ARGS="${YML_ARGS:-} > \"${SCRIPTPATH}/compose/docker-compose.yml\""
     info "Running compiled arguments to merge docker-compose.yml file."
-    export YQ_OPTIONS="${YQ_OPTIONS:-} -v \"${SCRIPTPATH}:${SCRIPTPATH}\""
+    export YQ_OPTIONS="${YQ_OPTIONS:-} -v \"${SCRIPTPATH}\":\"${SCRIPTPATH}\""
     run_script 'run_yq' "${YML_ARGS}"
     info "Merging docker-compose.yml complete."
 }

--- a/.scripts/yml_merge.sh
+++ b/.scripts/yml_merge.sh
@@ -60,7 +60,7 @@ yml_merge() {
     done < <(grep '_ENABLED=true$' < "${SCRIPTPATH}/compose/.env")
     YML_ARGS="${YML_ARGS:-} > \"${SCRIPTPATH}/compose/docker-compose.yml\""
     info "Running compiled arguments to merge docker-compose.yml file."
-    export YQ_OPTIONS="${YQ_OPTIONS:-} -v ${SCRIPTPATH}:${SCRIPTPATH}"
+    export YQ_OPTIONS="${YQ_OPTIONS:-} -v \"${SCRIPTPATH}:${SCRIPTPATH}\""
     run_script 'run_yq' "${YML_ARGS}"
     info "Merging docker-compose.yml complete."
 }


### PR DESCRIPTION
# Pull request

**Purpose**
The environment variable being set to allow compose inside docker to see outside locations (ex: the templates used in the DS repo to merge compose) apparently also need to be quoted.

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Testing: `ds -u origin/merge-quoting`

**Learning**
Follow up to https://github.com/GhostWriters/DockSTARTer/pull/906

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
