### PR TITLE
Tweaks to main script ordering and small logic handling

### DIFF
--- a/.scripts/appvars_create.sh
+++ b/.scripts/appvars_create.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
 appvars_create() {

--- a/.scripts/appvars_create_all.sh
+++ b/.scripts/appvars_create_all.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
 appvars_create_all() {

--- a/.scripts/appvars_purge.sh
+++ b/.scripts/appvars_purge.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
 appvars_purge() {

--- a/.scripts/appvars_purge_all.sh
+++ b/.scripts/appvars_purge_all.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
 appvars_purge_all() {

--- a/.scripts/config_apps.sh
+++ b/.scripts/config_apps.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
 config_apps() {

--- a/.scripts/config_global.sh
+++ b/.scripts/config_global.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
 config_global() {

--- a/.scripts/config_vpn.sh
+++ b/.scripts/config_vpn.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
 config_vpn() {

--- a/.scripts/detect_lan_network.sh
+++ b/.scripts/detect_lan_network.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
 detect_lan_network() {

--- a/.scripts/docker_compose.sh
+++ b/.scripts/docker_compose.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
 docker_compose() {

--- a/.scripts/docker_prune.sh
+++ b/.scripts/docker_prune.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
 docker_prune() {

--- a/.scripts/enable_docker_systemd.sh
+++ b/.scripts/enable_docker_systemd.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
 enable_docker_systemd() {

--- a/.scripts/env_backup.sh
+++ b/.scripts/env_backup.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
 env_backup() {

--- a/.scripts/env_create.sh
+++ b/.scripts/env_create.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
 env_create() {

--- a/.scripts/env_get.sh
+++ b/.scripts/env_get.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
 env_get() {

--- a/.scripts/env_sanitize.sh
+++ b/.scripts/env_sanitize.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
 env_sanitize() {

--- a/.scripts/env_set.sh
+++ b/.scripts/env_set.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
 env_set() {

--- a/.scripts/env_update.sh
+++ b/.scripts/env_update.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
 env_update() {

--- a/.scripts/install_compose.sh
+++ b/.scripts/install_compose.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
 install_compose() {

--- a/.scripts/install_compose_completion.sh
+++ b/.scripts/install_compose_completion.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
 install_compose_completion() {

--- a/.scripts/install_docker.sh
+++ b/.scripts/install_docker.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
 install_docker() {

--- a/.scripts/install_machine_completion.sh
+++ b/.scripts/install_machine_completion.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
 install_machine_completion() {

--- a/.scripts/install_yq.sh
+++ b/.scripts/install_yq.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
 install_yq() {

--- a/.scripts/menu_app_select.sh
+++ b/.scripts/menu_app_select.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
 menu_app_select() {

--- a/.scripts/menu_app_vars.sh
+++ b/.scripts/menu_app_vars.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
 menu_app_vars() {

--- a/.scripts/menu_config.sh
+++ b/.scripts/menu_config.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
 menu_config() {

--- a/.scripts/menu_main.sh
+++ b/.scripts/menu_main.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
 menu_main() {

--- a/.scripts/menu_value_prompt.sh
+++ b/.scripts/menu_value_prompt.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
 menu_value_prompt() {

--- a/.scripts/override_backup.sh
+++ b/.scripts/override_backup.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
 override_backup() {

--- a/.scripts/package_manager_run.sh
+++ b/.scripts/package_manager_run.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
 package_manager_run() {

--- a/.scripts/pm_apt_clean.sh
+++ b/.scripts/pm_apt_clean.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
 pm_apt_clean() {

--- a/.scripts/pm_apt_install.sh
+++ b/.scripts/pm_apt_install.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
 pm_apt_install() {

--- a/.scripts/pm_apt_remove_docker.sh
+++ b/.scripts/pm_apt_remove_docker.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
 pm_apt_remove_docker() {

--- a/.scripts/pm_apt_repos.sh
+++ b/.scripts/pm_apt_repos.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
 pm_apt_repos() {

--- a/.scripts/pm_apt_upgrade.sh
+++ b/.scripts/pm_apt_upgrade.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
 pm_apt_upgrade() {

--- a/.scripts/pm_dnf_clean.sh
+++ b/.scripts/pm_dnf_clean.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
 pm_dnf_clean() {

--- a/.scripts/pm_dnf_install.sh
+++ b/.scripts/pm_dnf_install.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
 pm_dnf_install() {

--- a/.scripts/pm_dnf_remove_docker.sh
+++ b/.scripts/pm_dnf_remove_docker.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
 pm_dnf_remove_docker() {

--- a/.scripts/pm_dnf_repos.sh
+++ b/.scripts/pm_dnf_repos.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
 pm_dnf_repos() {

--- a/.scripts/pm_dnf_upgrade.sh
+++ b/.scripts/pm_dnf_upgrade.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
 pm_dnf_upgrade() {

--- a/.scripts/pm_pacman_clean.sh
+++ b/.scripts/pm_pacman_clean.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
 pm_pacman_clean() {

--- a/.scripts/pm_pacman_install.sh
+++ b/.scripts/pm_pacman_install.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
 pm_pacman_install() {

--- a/.scripts/pm_pacman_remove_docker.sh
+++ b/.scripts/pm_pacman_remove_docker.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
 pm_pacman_remove_docker() {

--- a/.scripts/pm_pacman_repos.sh
+++ b/.scripts/pm_pacman_repos.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
 pm_pacman_repos() {

--- a/.scripts/pm_pacman_upgrade.sh
+++ b/.scripts/pm_pacman_upgrade.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
 pm_pacman_upgrade() {

--- a/.scripts/pm_yum_clean.sh
+++ b/.scripts/pm_yum_clean.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
 pm_yum_clean() {

--- a/.scripts/pm_yum_install.sh
+++ b/.scripts/pm_yum_install.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
 pm_yum_install() {

--- a/.scripts/pm_yum_remove_docker.sh
+++ b/.scripts/pm_yum_remove_docker.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
 pm_yum_remove_docker() {

--- a/.scripts/pm_yum_repos.sh
+++ b/.scripts/pm_yum_repos.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
 pm_yum_repos() {

--- a/.scripts/pm_yum_upgrade.sh
+++ b/.scripts/pm_yum_upgrade.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
 pm_yum_upgrade() {

--- a/.scripts/question_prompt.sh
+++ b/.scripts/question_prompt.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
 question_prompt() {

--- a/.scripts/remove_snap_docker.sh
+++ b/.scripts/remove_snap_docker.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
 remove_snap_docker() {

--- a/.scripts/request_reboot.sh
+++ b/.scripts/request_reboot.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
 request_reboot() {

--- a/.scripts/run_install.sh
+++ b/.scripts/run_install.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
 run_install() {

--- a/.scripts/set_permissions.sh
+++ b/.scripts/set_permissions.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
 set_permissions() {

--- a/.scripts/setup_docker_group.sh
+++ b/.scripts/setup_docker_group.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
 setup_docker_group() {

--- a/.scripts/symlink_ds.sh
+++ b/.scripts/symlink_ds.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
 symlink_ds() {

--- a/.scripts/update_self.sh
+++ b/.scripts/update_self.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
 update_self() {

--- a/.scripts/update_system.sh
+++ b/.scripts/update_system.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
 update_system() {

--- a/.scripts/yml_merge.sh
+++ b/.scripts/yml_merge.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
 yml_merge() {

--- a/docs/apps/plex.md
+++ b/docs/apps/plex.md
@@ -22,7 +22,7 @@ Or place a custom init script in your config (ex: `~/.config/appdata/plex/custom
 
 ```bash
 #!/usr/bin/with-contenv bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
 rm -rf "/config/Library/Application Support/Plex Media Server/Codecs"

--- a/main.sh
+++ b/main.sh
@@ -86,7 +86,6 @@ cleanup() {
 }
 trap 'cleanup' ERR EXIT SIGABRT SIGALRM SIGHUP SIGINT SIGQUIT SIGTERM
 
-
 # Command Line Arguments
 readonly ARGS=("$@")
 cmdline() {

--- a/main.sh
+++ b/main.sh
@@ -70,7 +70,7 @@ readonly SCRIPTNAME
 # Cleanup Function
 cleanup() {
     local -ri EXIT_CODE=$?
-    sudo sh -c "cat ${LOG_TEMP:-} >> ${SCRIPTPATH}/dockstarter.log" || true
+    sudo sh -c "cat ${LOG_TEMP:-/dev/null} >> ${SCRIPTPATH}/dockstarter.log" || true
     sudo -E chmod +x "${SCRIPTNAME}" > /dev/null 2>&1 || true
 
     if [[ ${CI:-} == true ]] && [[ ${TRAVIS_SECURE_ENV_VARS:-} == false ]]; then

--- a/main.sh
+++ b/main.sh
@@ -3,7 +3,7 @@ set -Eeuo pipefail
 IFS=$'\n\t'
 
 usage() {
-    cat <<EOF
+    cat << EOF
 Usage: ds [OPTION]
 NOTE: ds shortcut is only available after the first run of
     bash main.sh

--- a/main.sh
+++ b/main.sh
@@ -1,54 +1,91 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
-# Usage Information
-#/ Usage: sudo ds [OPTION]
-#/ NOTE: ds shortcut is only available after the first run of
-#/       sudo bash main.sh
-#/
-#/ This is the main DockSTARTer script.
-#/ For regular usage you can run without providing any options.
-#/
-#/  -a --add <appname>
-#/      add the default .env variables for the app specified
-#/  -c --compose
-#/      run docker-compose up with confirmation prompt
-#/  -c --compose <up/down/restart/pull>
-#/      run docker-compose commands without confirmation prompts
-#/  -e --env
-#/      update your .env file with new variables
-#/  --env-get=<var>
-#/      get the value of a <var>iable in .env
-#/  --env-set=<var>,<val>
-#/      Set the <val>ue of a <var>iable in .env
-#/  -f --force
-#/      force certain install/upgrade actions to run even if they would not be needed
-#/  -h --help
-#/      show this usage information
-#/  -i --install
-#/      install/update docker, docker-compose, yq and all dependencies
-#/  -p --prune
-#/      remove unused docker resources
-#/  -r --remove
-#/      prompt to remove .env variables for all disabled apps
-#/  -r --remove <appname>
-#/      prompt to remove the .env variables for the app specified
-#/  -t --test <test_name>
-#/      run tests to check the program
-#/  -u --update
-#/      update DockSTARTer to the latest stable commits
-#/  -u --update <branch>
-#/      update DockSTARTer to the latest commits from the specified branch
-#/  -v --verbose
-#/      verbose
-#/  -x --debug
-#/      debug
-#/
 usage() {
-    grep --color=never -Po '^#/\K.*' "${BASH_SOURCE[0]:-$0}" || echo "Failed to display usage information."
+    cat <<EOF
+Usage: ds [OPTION]
+NOTE: ds shortcut is only available after the first run of
+    bash main.sh
+
+This is the main DockSTARTer script.
+For regular usage you can run without providing any options.
+
+-a --add <appname>
+    add the default .env variables for the app specified
+-c --compose
+    run docker-compose up with confirmation prompt
+-c --compose <up/down/restart/pull>
+    run docker-compose commands without confirmation prompts
+-e --env
+    update your .env file with new variables
+--env-get=<var>
+    get the value of a <var>iable in .env
+--env-set=<var>,<val>
+    Set the <val>ue of a <var>iable in .env
+-f --force
+    force certain install/upgrade actions to run even if they would not be needed
+-h --help
+    show this usage information
+-i --install
+    install/update docker, docker-compose, yq and all dependencies
+-p --prune
+    remove unused docker resources
+-r --remove
+    prompt to remove .env variables for all disabled apps
+-r --remove <appname>
+    prompt to remove the .env variables for the app specified
+-t --test <test_name>
+    run tests to check the program
+-u --update
+    update DockSTARTer to the latest stable commits
+-u --update <branch>
+    update DockSTARTer to the latest commits from the specified branch
+-v --verbose
+    verbose
+-x --debug
+    debug
+EOF
     exit
 }
+
+# Script Information
+# https://stackoverflow.com/questions/59895/get-the-source-directory-of-a-bash-script-from-within-the-script-itself/246128#246128
+get_scriptname() {
+    # https://stackoverflow.com/questions/35006457/choosing-between-0-and-bash-source/35006505#35006505
+    local SOURCE=${BASH_SOURCE[0]:-$0}
+    while [[ -L ${SOURCE} ]]; do # resolve ${SOURCE} until the file is no longer a symlink
+        local DIR
+        DIR=$(cd -P "$(dirname "${SOURCE}")" > /dev/null 2>&1 && pwd)
+        SOURCE=$(readlink "${SOURCE}")
+        [[ ${SOURCE} != /* ]] && SOURCE="${DIR}/${SOURCE}" # if ${SOURCE} was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+    done
+    echo "${SOURCE}"
+}
+SCRIPTPATH=$(cd -P "$(dirname "$(get_scriptname)")" > /dev/null 2>&1 && pwd)
+readonly SCRIPTPATH
+SCRIPTNAME="${SCRIPTPATH}/$(basename "$(get_scriptname)")"
+readonly SCRIPTNAME
+
+# Cleanup Function
+cleanup() {
+    local -ri EXIT_CODE=$?
+    sudo sh -c "cat ${LOG_TEMP:-} >> ${SCRIPTPATH}/dockstarter.log" || true
+    sudo -E chmod +x "${SCRIPTNAME}" > /dev/null 2>&1 || true
+
+    if [[ ${CI:-} == true ]] && [[ ${TRAVIS_SECURE_ENV_VARS:-} == false ]]; then
+        echo "TRAVIS_SECURE_ENV_VARS is false for Pull Requests from remote branches. Please retry failed builds!"
+    fi
+
+    if [[ ${EXIT_CODE} -ne 0 ]]; then
+        echo "DockSTARTer did not finish running successfully."
+    fi
+
+    exit ${EXIT_CODE}
+    trap - ERR EXIT SIGABRT SIGALRM SIGHUP SIGINT SIGQUIT SIGTERM
+}
+trap 'cleanup' ERR EXIT SIGABRT SIGALRM SIGHUP SIGINT SIGQUIT SIGTERM
+
 
 # Command Line Arguments
 readonly ARGS=("$@")
@@ -182,49 +219,9 @@ if [[ -n ${DEBUG:-} ]] && [[ -n ${VERBOSE:-} ]]; then
     readonly TRACE=1
 fi
 
-# Github Token for Travis CI
-if [[ ${CI:-} == true ]] && [[ ${TRAVIS_SECURE_ENV_VARS:-} == true ]]; then
-    readonly GH_HEADER="Authorization: token ${GH_TOKEN}"
-    export GH_HEADER
-fi
-
-# Script Information
-# https://stackoverflow.com/questions/59895/get-the-source-directory-of-a-bash-script-from-within-the-script-itself/246128#246128
-get_scriptname() {
-    # https://stackoverflow.com/questions/35006457/choosing-between-0-and-bash-source/35006505#35006505
-    local SOURCE=${BASH_SOURCE[0]:-$0}
-    while [[ -L ${SOURCE} ]]; do # resolve ${SOURCE} until the file is no longer a symlink
-        local DIR
-        DIR=$(cd -P "$(dirname "${SOURCE}")" > /dev/null 2>&1 && pwd)
-        SOURCE=$(readlink "${SOURCE}")
-        [[ ${SOURCE} != /* ]] && SOURCE="${DIR}/${SOURCE}" # if ${SOURCE} was a relative symlink, we need to resolve it relative to the path where the symlink file was located
-    done
-    echo "${SOURCE}"
-}
-SCRIPTPATH=$(cd -P "$(dirname "$(get_scriptname)")" > /dev/null 2>&1 && pwd)
-readonly SCRIPTPATH
-SCRIPTNAME="${SCRIPTPATH}/$(basename "$(get_scriptname)")"
-readonly SCRIPTNAME
-
-# User/Group Information
-readonly DETECTED_PUID=${SUDO_UID:-$UID}
-DETECTED_UNAME=$(id -un "${DETECTED_PUID}" 2> /dev/null || true)
-readonly DETECTED_UNAME
-DETECTED_PGID=$(id -g "${DETECTED_PUID}" 2> /dev/null || true)
-readonly DETECTED_PGID
-export DETECTED_PGID
-DETECTED_UGROUP=$(id -gn "${DETECTED_PUID}" 2> /dev/null || true)
-readonly DETECTED_UGROUP
-export DETECTED_UGROUP
-DETECTED_HOMEDIR=$(eval echo "~${DETECTED_UNAME}" 2> /dev/null || true)
-readonly DETECTED_HOMEDIR
-
 # Terminal Colors
-if [[ ${CI:-} == true ]] || [[ -t 1 ]]; then
-    readonly SCRIPTTERM=true
-fi
 tcolor() {
-    if [[ -n ${SCRIPTTERM:-} ]]; then
+    if [[ ${CI:-} == true || -t 1 ]] && [[ $(tput colors 2> /dev/null) -ge 8 ]]; then
         # http://linuxcommand.org/lc3_adv_tput.php
         local BF=${1:-}
         local CAP
@@ -250,9 +247,7 @@ tcolor() {
             esac
         fi
         local COLOR_OUT
-        if [[ $(tput colors 2> /dev/null) -ge 8 ]]; then
-            COLOR_OUT=$(eval tput ${CAP:-} ${VAL:-} 2> /dev/null)
-        fi
+        COLOR_OUT=$(eval tput ${CAP:-} ${VAL:-} 2> /dev/null)
         echo "${COLOR_OUT:-}"
     else
         return
@@ -306,6 +301,19 @@ fatal() {
     log "true" "${NC}$(date +"%F %T") ${B[R]}${F[W]}[FATAL ]${NC}   $*${NC}"
     exit 1
 }
+
+# User/Group Information
+readonly DETECTED_PUID=${SUDO_UID:-$UID}
+DETECTED_UNAME=$(id -un "${DETECTED_PUID}" 2> /dev/null || true)
+readonly DETECTED_UNAME
+DETECTED_PGID=$(id -g "${DETECTED_PUID}" 2> /dev/null || true)
+readonly DETECTED_PGID
+export DETECTED_PGID
+DETECTED_UGROUP=$(id -gn "${DETECTED_PUID}" 2> /dev/null || true)
+readonly DETECTED_UGROUP
+export DETECTED_UGROUP
+DETECTED_HOMEDIR=$(eval echo "~${DETECTED_UNAME}" 2> /dev/null || true)
+readonly DETECTED_HOMEDIR
 
 # Repo Exists Function
 repo_exists() {
@@ -362,28 +370,11 @@ vergt() { ! vergte "${2}" "${1}"; }
 verlte() { printf '%s\n%s' "${1}" "${2}" | sort -C -V; }
 verlt() { ! verlte "${2}" "${1}"; }
 
-# Cleanup Function
-cleanup() {
-    local -ri EXIT_CODE=$?
-
-    if repo_exists; then
-        info "Setting executable permission on ${SCRIPTNAME}"
-        sudo -E chmod +x "${SCRIPTNAME}" > /dev/null 2>&1 || fatal "ds must be executable.\nFailing command: ${F[C]}sudo -E chmod +x \"${SCRIPTNAME}\""
-    fi
-    if [[ ${CI:-} == true ]] && [[ ${TRAVIS_SECURE_ENV_VARS:-} == false ]]; then
-        warn "TRAVIS_SECURE_ENV_VARS is false for Pull Requests from remote branches. Please retry failed builds!"
-    fi
-
-    if [[ ${EXIT_CODE} -ne 0 ]]; then
-        error "DockSTARTer did not finish running successfully."
-    fi
-
-    sudo sh -c "cat ${LOG_TEMP} >> ${SCRIPTPATH}/dockstarter.log" || true
-
-    exit ${EXIT_CODE}
-    trap - 0 1 2 3 6 14 15
-}
-trap 'cleanup' 0 1 2 3 6 14 15
+# Github Token for Travis CI
+if [[ ${CI:-} == true ]] && [[ ${TRAVIS_SECURE_ENV_VARS:-} == true ]]; then
+    readonly GH_HEADER="Authorization: token ${GH_TOKEN}"
+    export GH_HEADER
+fi
 
 # Main Function
 main() {

--- a/main.sh
+++ b/main.sh
@@ -220,60 +220,27 @@ if [[ -n ${DEBUG:-} ]] && [[ -n ${VERBOSE:-} ]]; then
 fi
 
 # Terminal Colors
-tcolor() {
-    if [[ ${CI:-} == true || -t 1 ]] && [[ $(tput colors 2> /dev/null) -ge 8 ]]; then
-        # http://linuxcommand.org/lc3_adv_tput.php
-        local BF=${1:-}
-        local CAP
-        case ${BF} in
-            [Bb]) CAP=setab ;;
-            [Ff]) CAP=setaf ;;
-            [Nn][Cc]) CAP=sgr0 ;;
-            *) return ;;
-        esac
-        local COLOR_IN=${2:-}
-        local VAL
-        if [[ ${CAP} != "sgr0" ]]; then
-            case ${COLOR_IN} in
-                [Bb4]) VAL=4 ;; # Blue
-                [Cc6]) VAL=6 ;; # Cyan
-                [Gg2]) VAL=2 ;; # Green
-                [Kk0]) VAL=0 ;; # Black
-                [Mm5]) VAL=5 ;; # Magenta
-                [Rr1]) VAL=1 ;; # Red
-                [Ww7]) VAL=7 ;; # White
-                [Yy3]) VAL=3 ;; # Yellow
-                *) return ;;
-            esac
-        fi
-        local COLOR_OUT
-        COLOR_OUT=$(eval tput ${CAP:-} ${VAL:-} 2> /dev/null)
-        echo "${COLOR_OUT:-}"
-    else
-        return
-    fi
-}
-declare -Agr B=(
-    [B]=$(tcolor B B)
-    [C]=$(tcolor B C)
-    [G]=$(tcolor B G)
-    [K]=$(tcolor B K)
-    [M]=$(tcolor B M)
-    [R]=$(tcolor B R)
-    [W]=$(tcolor B W)
-    [Y]=$(tcolor B Y)
+declare -Agr B=( # Background
+    [B]=$(tput setab 4 || echo -e "\e[44m") # Blue
+    [C]=$(tput setab 6 || echo -e "\e[46m") # Cyan
+    [G]=$(tput setab 2 || echo -e "\e[42m") # Green
+    [K]=$(tput setab 0 || echo -e "\e[40m") # Black
+    [M]=$(tput setab 5 || echo -e "\e[45m") # Magenta
+    [R]=$(tput setab 1 || echo -e "\e[41m") # Red
+    [W]=$(tput setab 7 || echo -e "\e[47m") # White
+    [Y]=$(tput setab 3 || echo -e "\e[43m") # Yellow
 )
-declare -Agr F=(
-    [B]=$(tcolor F B)
-    [C]=$(tcolor F C)
-    [G]=$(tcolor F G)
-    [K]=$(tcolor F K)
-    [M]=$(tcolor F M)
-    [R]=$(tcolor F R)
-    [W]=$(tcolor F W)
-    [Y]=$(tcolor F Y)
+declare -Agr F=( # Foreground
+    [B]=$(tput setaf 4 || echo -e "\e[34m") # Blue
+    [C]=$(tput setaf 6 || echo -e "\e[36m") # Cyan
+    [G]=$(tput setaf 2 || echo -e "\e[32m") # Green
+    [K]=$(tput setaf 0 || echo -e "\e[30m") # Black
+    [M]=$(tput setaf 5 || echo -e "\e[35m") # Magenta
+    [R]=$(tput setaf 1 || echo -e "\e[31m") # Red
+    [W]=$(tput setaf 7 || echo -e "\e[37m") # White
+    [Y]=$(tput setaf 3 || echo -e "\e[33m") # Yellow
 )
-NC=$(tcolor NC)
+NC=$(tput sgr0 || echo -e "\e[0m")
 readonly NC
 
 # Log Functions

--- a/main.sh
+++ b/main.sh
@@ -220,7 +220,7 @@ if [[ -n ${DEBUG:-} ]] && [[ -n ${VERBOSE:-} ]]; then
 fi
 
 # Terminal Colors
-declare -Agr B=( # Background
+declare -Agr B=(# Background
     [B]=$(tput setab 4 || echo -e "\e[44m") # Blue
     [C]=$(tput setab 6 || echo -e "\e[46m") # Cyan
     [G]=$(tput setab 2 || echo -e "\e[42m") # Green
@@ -230,7 +230,7 @@ declare -Agr B=( # Background
     [W]=$(tput setab 7 || echo -e "\e[47m") # White
     [Y]=$(tput setab 3 || echo -e "\e[43m") # Yellow
 )
-declare -Agr F=( # Foreground
+declare -Agr F=(# Foreground
     [B]=$(tput setaf 4 || echo -e "\e[34m") # Blue
     [C]=$(tput setaf 6 || echo -e "\e[36m") # Cyan
     [G]=$(tput setaf 2 || echo -e "\e[32m") # Green


### PR DESCRIPTION
# Pull request

**Purpose**
Lightly taking some inspiration from https://betterdev.blog/minimal-safe-bash-script-template/

**Approach**

- Use `-E` with bash scripts to catch `ERR` exit
- Uncomplicate `usage` function by just using `echo` with a heredoc
- Move `cleanup` function as high as possible so traps can happen on everything after (required moving `get_scriptname` up as well, this would be the only potential point of failure not covered by a trap exit)
- Remove `tcolors` (lots of logic for very little payoff) and simply call `tput` but cover scenarios where `tput` is missing by using `|| echo ...` with the ascii color. Possible side effect; terminals with no color capability may see strange output.
- Reorder a few functions and variable declarations. End result makes most of what's at the top of DS reusable as if to be a template for other scripts (not the goal, but an unintended side effect)

**Learning**
https://betterdev.blog/minimal-safe-bash-script-template/

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
