### PR TITLE
Update fireflyiii.md

### DIFF
--- a/docs/overrides/fireflyiii.md
+++ b/docs/overrides/fireflyiii.md
@@ -36,7 +36,7 @@ services:
         max-file: ${DOCKERLOGGING_MAXFILE}
         max-size: ${DOCKERLOGGING_MAXSIZE}
     ports:
-      - 8001:80
+      - 8001:8080
     restart: unless-stopped
     volumes:
       - /etc/localtime:/etc/localtime:ro


### PR DESCRIPTION
Port on the inside of container is wrong (80 should be 8080). Changing that, fixed the 404 error.

# Pull request

**Purpose**
In order to fix the 404 error uppon launching, i had to change port 8001:80 to 8001:8080

**Approach**
Read above

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [x] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
