### PR TITLE
Add missing volume for cloudflareddns

### DIFF
--- a/compose/.apps/cloudflareddns/cloudflareddns.yml
+++ b/compose/.apps/cloudflareddns/cloudflareddns.yml
@@ -23,4 +23,5 @@ services:
     restart: unless-stopped
     volumes:
       - /etc/localtime:/etc/localtime:ro
+      - ${DOCKERCONFDIR}/cloudflareddns:/config
       - ${DOCKERSTORAGEDIR}:/storage


### PR DESCRIPTION
Using
```shell
docker ps -a --format '{{ .ID }}' | xargs -I {} docker inspect -f '{{ .Name }}{{ printf "\n" }}{{ range .Mounts }}{{ printf "\n\t" }}{{ .Type }} {{ if eq .Type "bind" }}{{ .Source }}{{ end }}{{ .Name }} => {{ .Destination }}{{ end }}{{ printf "\n" }}' {}
```
to find volumes not being created as bind. Each one may need to be handled differently.