### PR TITLE
Add healthcheck

### DIFF
--- a/compose/.apps/filebrowser/filebrowser.yml
+++ b/compose/.apps/filebrowser/filebrowser.yml
@@ -19,3 +19,5 @@ services:
       - ${DOCKERCONFDIR}/filebrowser:/config
       - ${DOCKERSTORAGEDIR}:/storage
       - ${FILEBROWSER_SHARE_DIR}:/srv
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fs http://localhost:${FILEBROWSER_PORT_80}/health || exit 1"]


### PR DESCRIPTION
Overrides built in healthcheck to fix the port that's set

# Pull request

**Purpose**
Filebrowser added a healthcheck which is incompatible with changing the port it's running on in the container

**Approach**
Override the healthcheck that comes with the container

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [x] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
