### PR TITLE
Use run_script for compose and yq

### DIFF
--- a/.scripts/docker_compose.sh
+++ b/.scripts/docker_compose.sh
@@ -40,14 +40,8 @@ docker_compose() {
         return 1
     fi
     run_script 'install_docker'
-    local MKTEMP_RUN_COMPOSE
-    MKTEMP_RUN_COMPOSE=$(mktemp) || fatal "Failed to create temporary run compose script.\nFailing command: ${F[C]}mktemp"
-    info "Downloading run compose script."
-    curl -fsSL https://raw.githubusercontent.com/linuxserver/docker-docker-compose/master/run.sh -o "${MKTEMP_RUN_COMPOSE}" > /dev/null 2>&1 || fatal "Failed to get run compose script.\nFailing command: ${F[C]}curl -fsSL https://raw.githubusercontent.com/linuxserver/docker-docker-compose/master/run.sh -o \"${MKTEMP_RUN_COMPOSE}\""
-    docker pull ghcr.io/linuxserver/docker-compose:latest || fatal "Failed to pull latest docker-compose image.\nFailing command: ${F[C]}docker pull ghcr.io/linuxserver/docker-compose:latest"
     cd "${SCRIPTPATH}/compose/" || fatal "Failed to change directory.\nFailing command: ${F[C]}cd \"${SCRIPTPATH}/compose/\""
-    eval sh "${MKTEMP_RUN_COMPOSE}" "${COMPOSECOMMAND}" || fatal "Docker Compose failed.\nFailing command: ${F[C]}eval sh \"${MKTEMP_RUN_COMPOSE}\" \"${COMPOSECOMMAND}\""
-    rm -f "${MKTEMP_RUN_COMPOSE}" || warn "Failed to remove temporary run compose script."
+    run_script 'run_compose' "${COMPOSECOMMAND}"
     cd "${SCRIPTPATH}" || fatal "Failed to change directory.\nFailing command: ${F[C]}cd \"${SCRIPTPATH}\""
 }
 
@@ -56,13 +50,7 @@ test_docker_compose() {
     cat "${SCRIPTPATH}/compose/.env"
     run_script 'yml_merge'
     cd "${SCRIPTPATH}/compose/" || fatal "Failed to change directory.\nFailing command: ${F[C]}cd \"${SCRIPTPATH}/compose/\""
-    local MKTEMP_RUN_COMPOSE
-    MKTEMP_RUN_COMPOSE=$(mktemp) || fatal "Failed to create temporary run compose script.\nFailing command: ${F[C]}mktemp"
-    info "Downloading run compose script."
-    curl -fsSL https://raw.githubusercontent.com/linuxserver/docker-docker-compose/master/run.sh -o "${MKTEMP_RUN_COMPOSE}" > /dev/null 2>&1 || fatal "Failed to get run compose script.\nFailing command: ${F[C]}curl -fsSL https://raw.githubusercontent.com/linuxserver/docker-docker-compose/master/run.sh -o \"${MKTEMP_RUN_COMPOSE}\""
-    docker pull ghcr.io/linuxserver/docker-compose:latest || fatal "Failed to pull latest docker-compose image.\nFailing command: ${F[C]}docker pull ghcr.io/linuxserver/docker-compose:latest"
-    eval sh "${MKTEMP_RUN_COMPOSE}" config || fatal "Failed to validate ${SCRIPTPATH}/compose/docker-compose.yml file.\nFailing command: ${F[C]}eval sh \"${MKTEMP_RUN_COMPOSE}\" config"
-    rm -f "${MKTEMP_RUN_COMPOSE}" || warn "Failed to remove temporary run compose script."
+    run_script 'run_compose' "config"
     cd "${SCRIPTPATH}" || fatal "Failed to change directory.\nFailing command: ${F[C]}cd \"${SCRIPTPATH}\""
     run_script 'docker_compose'
 }

--- a/.scripts/run_compose.sh
+++ b/.scripts/run_compose.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+run_compose() {
+    local COMPOSE_ARGS=${1:-}
+    local MKTEMP_RUN_COMPOSE
+    MKTEMP_RUN_COMPOSE=$(mktemp) || fatal "Failed to create temporary run compose script.\nFailing command: ${F[C]}mktemp"
+    info "Downloading run compose script."
+    curl -fsSL https://raw.githubusercontent.com/linuxserver/docker-docker-compose/master/run.sh -o "${MKTEMP_RUN_COMPOSE}" > /dev/null 2>&1 || fatal "Failed to get run compose script.\nFailing command: ${F[C]}curl -fsSL https://raw.githubusercontent.com/linuxserver/docker-docker-compose/master/run.sh -o \"${MKTEMP_RUN_COMPOSE}\""
+    docker pull ghcr.io/linuxserver/docker-compose:latest || fatal "Failed to pull latest docker-compose image.\nFailing command: ${F[C]}docker pull ghcr.io/linuxserver/docker-compose:latest"
+    eval sh "${MKTEMP_RUN_COMPOSE}" "${COMPOSE_ARGS}" || fatal "Failed run compose script.\nFailing command: ${F[C]}eval sh \"${MKTEMP_RUN_COMPOSE}\" \"${COMPOSE_ARGS}\""
+    rm -f "${MKTEMP_RUN_COMPOSE}" || warn "Failed to remove temporary run compose script."
+}
+
+test_run_compose() {
+    run_script 'run_compose'
+}

--- a/.scripts/run_yq.sh
+++ b/.scripts/run_yq.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+run_yq() {
+    local YQ_ARGS=${1:-}
+    local MKTEMP_RUN_YQ
+    MKTEMP_RUN_YQ=$(mktemp) || fatal "Failed to create temporary run yq script.\nFailing command: ${F[C]}mktemp"
+    info "Downloading run yq script."
+    curl -fsSL https://raw.githubusercontent.com/linuxserver/docker-yq/master/run-yq.sh -o "${MKTEMP_RUN_YQ}" > /dev/null 2>&1 || fatal "Failed to get run yq script.\nFailing command: ${F[C]}curl -fsSL https://raw.githubusercontent.com/linuxserver/docker-yq/master/run-yq.sh -o \"${MKTEMP_RUN_YQ}\""
+    docker pull ghcr.io/linuxserver/yq:latest || fatal "Failed to pull latest yq image.\nFailing command: ${F[C]}docker pull ghcr.io/linuxserver/yq:latest"
+    eval sh "${MKTEMP_RUN_YQ}" "${YQ_ARGS}" || fatal "Failed to run yq script.\nFailing command: ${F[C]}eval sh \"${MKTEMP_RUN_YQ}\" \"${YQ_ARGS}\""
+    rm -f "${MKTEMP_RUN_YQ}" || warn "Failed to remove temporary run yq script."
+}
+
+test_run_yq() {
+    run_script 'run_yq'
+}


### PR DESCRIPTION
# Pull request

**Purpose**
Reduce code complexity and allow simpler repetitive use of compose and yq.

As a result this also rids `yml_merge` of creating a temporary bash file to merge `docker-compose.yml` and instead appends everything to a variable and passes it as an argument to the new `run_yq` script. This should be more reliable long term, but is a fairly major change and should be properly tested.

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [x] Test `ds -u origin/run_scripts`

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
