### PR TITLE
Update minimum docker and libseccomp2 versions

### DIFF
--- a/.scripts/install_docker.sh
+++ b/.scripts/install_docker.sh
@@ -3,8 +3,9 @@ set -Eeuo pipefail
 IFS=$'\n\t'
 
 install_docker() {
-    local MINIMUM_DOCKER="19.03.0"
+    local MINIMUM_DOCKER="20.10.0"
     # Find minimum compatible version at https://docs.docker.com/engine/release-notes/
+    # Note compatibility from https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.14.0
     run_script 'remove_snap_docker'
     local INSTALLED_DOCKER
     if [[ ${FORCE:-} == true ]] && [[ -n ${INSTALL:-} ]]; then

--- a/.scripts/pm_apt_repos.sh
+++ b/.scripts/pm_apt_repos.sh
@@ -3,7 +3,8 @@ set -Eeuo pipefail
 IFS=$'\n\t'
 
 pm_apt_repos() {
-    local MINIMUM_LIBSECCOMP2="2.4"
+    local MINIMUM_LIBSECCOMP2="2.4.4"
+    # Note compatibility from https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.14.0
     local INSTALLED_LIBSECCOMP2
     INSTALLED_LIBSECCOMP2=$(apt-cache policy libseccomp2 | grep -Po 'Installed: \K.*')
     if vergt "${MINIMUM_LIBSECCOMP2}" "${INSTALLED_LIBSECCOMP2}"; then


### PR DESCRIPTION
# Pull request

**Purpose**
The minimum versions in DS were not matching the minimum recommended versions from https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.14.0
**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
