### PR TITLE
Add other supported filebrowser architectures

### DIFF
--- a/compose/.apps/filebrowser/filebrowser.aarch64.yml
+++ b/compose/.apps/filebrowser/filebrowser.aarch64.yml
@@ -1,0 +1,3 @@
+services:
+  filebrowser:
+    image: filebrowser/filebrowser

--- a/compose/.apps/filebrowser/filebrowser.armv7l.yml
+++ b/compose/.apps/filebrowser/filebrowser.armv7l.yml
@@ -1,0 +1,3 @@
+services:
+  filebrowser:
+    image: filebrowser/filebrowser


### PR DESCRIPTION
# Pull request

**Purpose**
filebrowser docker supports arm and arm64, e.g. for running it with DockSTARTer on a Raspberry Pi

**Approach**
Adding relevant architecture-specific files

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
