### PR TITLE
feat: add armvl7 arch for glances

### DIFF
--- a/compose/.apps/glances/glances.armv7l.yml
+++ b/compose/.apps/glances/glances.armv7l.yml
@@ -1,0 +1,3 @@
+services:
+  glances:
+    image: nicolargo/glances


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

Want to install glances app on raspberry pi based on armv7 architecture.

**Approach**
How does this change address the problem?

Added in required docker-compose partial file to indicate to ds that glances is installable on armv7 architecture.

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

None afaik.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

Checking the docker image repo, it has images for the armv7 architecture.

https://hub.docker.com/r/nicolargo/glances/tags

![glances-docker-repo-tags](https://user-images.githubusercontent.com/6343135/163721503-1724b11c-e9bb-4d33-bc69-b8e694fbc065.png)

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
