### PR TITLE
Add Homer

### DIFF
--- a/compose/.apps/homer/homer.aarch64.yml
+++ b/compose/.apps/homer/homer.aarch64.yml
@@ -1,0 +1,3 @@
+services:
+  homer:
+    image: b4bz/homer

--- a/compose/.apps/homer/homer.armv7l.yml
+++ b/compose/.apps/homer/homer.armv7l.yml
@@ -1,0 +1,3 @@
+services:
+  homer:
+    image: b4bz/homer

--- a/compose/.apps/homer/homer.hostname.yml
+++ b/compose/.apps/homer/homer.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  homer:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/homer/homer.labels.yml
+++ b/compose/.apps/homer/homer.labels.yml
@@ -1,0 +1,12 @@
+services:
+  homer:
+    labels:
+      com.dockstarter.appinfo.deprecated: "false"
+      com.dockstarter.appinfo.description: A dead simple static HOMepage for your servER
+      com.dockstarter.appinfo.nicename: Homer
+      com.dockstarter.appvars.homer_enabled: "false"
+      com.dockstarter.appvars.homer_assets: ""
+      com.dockstarter.appvars.homer_init_assets: "1"
+      com.dockstarter.appvars.homer_network_mode: ""
+      com.dockstarter.appvars.homer_port_http: "8080"
+      com.dockstarter.appvars.homer_restart: always

--- a/compose/.apps/homer/homer.labels.yml
+++ b/compose/.apps/homer/homer.labels.yml
@@ -9,5 +9,5 @@ services:
       com.dockstarter.appvars.homer_init_assets: "1"
       com.dockstarter.appvars.homer_network_mode: ""
       com.dockstarter.appvars.homer_port_http: "8080"
-      com.dockstarter.appvars.homer_restart: always
+      com.dockstarter.appvars.homer_restart: unless-stopped
       com.dockstarter.appvars.homer_subfolder: ""

--- a/compose/.apps/homer/homer.labels.yml
+++ b/compose/.apps/homer/homer.labels.yml
@@ -5,7 +5,6 @@ services:
       com.dockstarter.appinfo.description: A dead simple static HOMepage for your servER
       com.dockstarter.appinfo.nicename: Homer
       com.dockstarter.appvars.homer_enabled: "false"
-      com.dockstarter.appvars.homer_assets: ""
       com.dockstarter.appvars.homer_init_assets: "1"
       com.dockstarter.appvars.homer_network_mode: ""
       com.dockstarter.appvars.homer_port_http: "8080"

--- a/compose/.apps/homer/homer.labels.yml
+++ b/compose/.apps/homer/homer.labels.yml
@@ -10,3 +10,4 @@ services:
       com.dockstarter.appvars.homer_network_mode: ""
       com.dockstarter.appvars.homer_port_http: "8080"
       com.dockstarter.appvars.homer_restart: always
+      com.dockstarter.appvars.homer_subfolder: ""

--- a/compose/.apps/homer/homer.labels.yml
+++ b/compose/.apps/homer/homer.labels.yml
@@ -7,6 +7,6 @@ services:
       com.dockstarter.appvars.homer_enabled: "false"
       com.dockstarter.appvars.homer_init_assets: "1"
       com.dockstarter.appvars.homer_network_mode: ""
-      com.dockstarter.appvars.homer_port_http: "8080"
+      com.dockstarter.appvars.homer_port_8080: "8080"
       com.dockstarter.appvars.homer_restart: unless-stopped
       com.dockstarter.appvars.homer_subfolder: ""

--- a/compose/.apps/homer/homer.netmode.yml
+++ b/compose/.apps/homer/homer.netmode.yml
@@ -1,0 +1,3 @@
+services:
+  homer:
+    network_mode: ${HOMER_NETWORK_MODE}

--- a/compose/.apps/homer/homer.ports.yml
+++ b/compose/.apps/homer/homer.ports.yml
@@ -1,4 +1,4 @@
 services:
   homer:
     ports:
-      - ${HOMER_PORT_HTTP}:8080
+      - ${HOMER_PORT_8080}:8080

--- a/compose/.apps/homer/homer.ports.yml
+++ b/compose/.apps/homer/homer.ports.yml
@@ -1,0 +1,4 @@
+services:
+  homer:
+    ports:
+      - ${HOMER_PORT_HTTP}:8080

--- a/compose/.apps/homer/homer.x86_64.yml
+++ b/compose/.apps/homer/homer.x86_64.yml
@@ -1,0 +1,3 @@
+services:
+  homer:
+    image: b4bz/homer

--- a/compose/.apps/homer/homer.yml
+++ b/compose/.apps/homer/homer.yml
@@ -14,4 +14,6 @@ services:
         max-size: ${DOCKERLOGGING_MAXSIZE}
     restart: ${HOMER_RESTART}
     volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - ${DOCKERSTORAGEDIR}:/storage
       - ${HOMER_ASSETS}:/www/assets

--- a/compose/.apps/homer/homer.yml
+++ b/compose/.apps/homer/homer.yml
@@ -16,4 +16,4 @@ services:
     volumes:
       - /etc/localtime:/etc/localtime:ro
       - ${DOCKERSTORAGEDIR}:/storage
-      - ${HOMER_ASSETS}:/www/assets
+      - ${DOCKERCONFDIR}/homer:/www/assets

--- a/compose/.apps/homer/homer.yml
+++ b/compose/.apps/homer/homer.yml
@@ -5,6 +5,7 @@ services:
       - INIT_ASSETS=${HOMER_INIT_ASSETS}
       - PGID=${PGID}
       - PUID=${PUID}
+      - SUBFOLDER=${HOMER_SUBFOLDER}
       - TZ=${TZ}
     logging:
       driver: json-file

--- a/compose/.apps/homer/homer.yml
+++ b/compose/.apps/homer/homer.yml
@@ -1,0 +1,16 @@
+services:
+  homer:
+    container_name: homer
+    environment:
+      - INIT_ASSETS=${HOMER_INIT_ASSETS}
+      - PGID=${PGID}
+      - PUID=${PUID}
+      - TZ=${TZ}
+    logging:
+      driver: json-file
+      options:
+        max-file: ${DOCKERLOGGING_MAXFILE}
+        max-size: ${DOCKERLOGGING_MAXSIZE}
+    restart: ${HOMER_RESTART}
+    volumes:
+      - ${HOMER_ASSETS}:/www/assets

--- a/docs/apps/homer.md
+++ b/docs/apps/homer.md
@@ -10,6 +10,16 @@
 
 ## Install/Setup
 
-This application does not have any specific setup instructions documented. If
-you need assistance setting up this application please visit our
-[support page](https://dockstarter.com/basics/support/).
+Be sure to read the [app specific documentation](https://github.com/bastienwirtz/homer) on github as the environment variables below are an extension of those explained in the documentation.
+
+### Environment Variables
+
+#### HOMER_ASSETS
+
+Path to homer assets. If `HOMER_INIT_ASSETS="1"` then this may be an empty directory and the assets will be downloaded. If you already have assets here you should set `HOMER_INIT_ASSETS="0"`
+
+#### HOMER_INIT_ASSETS
+
+`1` (default) Install example configuration file & assets (favicons, ...) to help you get started.
+
+`0` Don't install assets. Use existing files. This is the suggested value after you first launch homer and assets are installed.

--- a/docs/apps/homer.md
+++ b/docs/apps/homer.md
@@ -12,13 +12,11 @@
 
 Be sure to read the [app specific documentation](https://github.com/bastienwirtz/homer) on github as the environment variables below are an extension of those explained in the documentation.
 
+Note that your configuration files and homer assets are located in `${DOCKERCONFDIR}/homer`
+
 ### Environment Variables
 
-#### HOMER_ASSETS
-
-Path to homer assets. If `HOMER_INIT_ASSETS="1"` then this may be an empty directory and the assets will be downloaded. If you already have assets here you should set `HOMER_INIT_ASSETS="0"`
-
-#### HOMER_INIT_ASSETS
+#### HOMER\_INIT_ASSETS
 
 `1` (default) Install example configuration file & assets (favicons, ...) to help you get started.
 

--- a/docs/apps/homer.md
+++ b/docs/apps/homer.md
@@ -23,3 +23,7 @@ Path to homer assets. If `HOMER_INIT_ASSETS="1"` then this may be an empty direc
 `1` (default) Install example configuration file & assets (favicons, ...) to help you get started.
 
 `0` Don't install assets. Use existing files. This is the suggested value after you first launch homer and assets are installed.
+
+#### HOMER_SUBFOLDER
+
+(default: `''`) If you would like to host Homer in a subfolder, (ex: http://my-domain/homer), set this to the subfolder path (ex /homer).

--- a/docs/apps/homer.md
+++ b/docs/apps/homer.md
@@ -1,0 +1,15 @@
+# Homer
+
+[![Docker Pulls](https://img.shields.io/docker/pulls/b4bz/homer?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/b4bz/homer)
+[![GitHub Stars](https://img.shields.io/github/stars/bastienwirtz/homer?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/bastienwirtz/homer)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/homer)
+
+## Description
+
+[Homer](https://github.com/bastienwirtz/homer) is a dead simple static HOMepage for your servER to keep your services on hand, from a simple yaml configuration file.
+
+## Install/Setup
+
+This application does not have any specific setup instructions documented. If
+you need assistance setting up this application please visit our
+[support page](https://dockstarter.com/basics/support/).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -127,6 +127,7 @@ nav:
       - apps/headphones.md
       - apps/heimdall.md
       - apps/homeassistant.md
+      - apps/homer.md
       - apps/htpcmanager.md
       - apps/httpserver.md
       - apps/huginn.md


### PR DESCRIPTION
# Pull request

**Purpose**
Adding Homer as a new application
https://github.com/bastienwirtz/homer

**Approach/Testing**
1. After installing DockSTARTer on my x86_64 system I cloned my fork of the DockSTARTer repo and created the following symlinks. These links allowed me to use "ds -c" in the CLI and the ds GUI to test like a production user
`~/.docker/docs -> <my_repo>/docs`
`~/.docker/compose/.apps -> <my_repo>/compose/.apps`

1. Used https://markdownlivepreview.com/ to preview my homer.md doc.
2. Verified in the GUI that Homer shows up with value of com.dockstarter.appinfo.description
3. Used `ds -a homer` and `ds -r homer` with `ds -c` for remaining testing
4. Verified that HOMER_INIT_ASSETS can be toggled to 1 and 0 and behavior as expected by inspecting container logs.
5. Verified that HOMER_PORT_HTTP can be set and homepage served on this port
6. Verified that HOMER_SUBFOLDER can be set and homepage served on this subfolder path

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [x] I want to double check that the best practice in DockSTARTer is use of `${DOCKERCONFDIR}/homer:/www/assets` as config/assets volume  instead of `${HOMER_ASSETS}:/www/assets` which was my first instinct and felt more natural to me

**Learning**
Read docs:
1. https://hub.docker.com/r/b4bz/homer 
7. https://github.com/bastienwirtz/homer

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
