### PR TITLE
Adding contributing.md link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,11 @@ Click the chat badge to join us on Discord for support!
 
 Additional information can be found on our [Support Page](https://dockstarter.com/basics/support/).
 
-## Contributors
+## Contributing
+
+Want to help develop DockSTARTer? Check out our [contributing documentation](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
+
+### Contributors
 
 [![GitHub contributors](https://img.shields.io/github/contributors/GhostWriters/DockSTARTer.svg?style=flat-square&color=607D8B)](https://github.com/GhostWriters/DockSTARTer/graphs/contributors)
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Additional information can be found on our [Support Page](https://dockstarter.co
 
 ## Contributing
 
-Want to help develop DockSTARTer? Check out our [contributing documentation](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
+Want to help develop DockSTARTer? Check out our [contributing guidelines](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md) and [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
 
 ### Contributors
 


### PR DESCRIPTION
# Pull request

**Purpose**
It's typical for the README on Github to directly have a link to CONTRIBUTING.md. As a new contributor myself I had trouble finding this and so I thought it makes sense to follow this pattern of directly linking to CONTRIBUTING from the README. 

**Testing**
Rendered README on https://markdownlivepreview.com/ and reviewed there

**Open Questions and Pre-Merge TODOs**
None

**Learning**
I pulled a lot of this text directly from [Docker Compose](https://github.com/docker/compose#contributing)

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
