### PR TITLE
Add Traefik App

### DIFF
--- a/compose/.apps/traefik/traefik.aarch64.yml
+++ b/compose/.apps/traefik/traefik.aarch64.yml
@@ -1,0 +1,3 @@
+services:
+  traefik:
+    image: traefik

--- a/compose/.apps/traefik/traefik.hostname.yml
+++ b/compose/.apps/traefik/traefik.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  traefik:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/traefik/traefik.labels.yml
+++ b/compose/.apps/traefik/traefik.labels.yml
@@ -1,0 +1,12 @@
+services:
+  traefik:
+    labels:
+      com.dockstarter.appinfo.deprecated: "false"
+      com.dockstarter.appinfo.description: A modern HTTP reverse proxy and load balancer that makes deploying microservices easy
+      com.dockstarter.appinfo.nicename: Traefik
+      com.dockstarter.appvars.traefik_enabled: "false"
+      com.dockstarter.appvars.traefik_network_mode: ""
+      com.dockstarter.appvars.traefik_port_443: "443"
+      com.dockstarter.appvars.traefik_port_80: "80"
+      com.dockstarter.appvars.traefik_port_8080: "8080"
+      com.dockstarter.appvars.traefik_restart: unless-stopped

--- a/compose/.apps/traefik/traefik.netmode.yml
+++ b/compose/.apps/traefik/traefik.netmode.yml
@@ -1,0 +1,3 @@
+services:
+  traefik:
+    network_mode: ${TRAEFIK_NETWORK_MODE}

--- a/compose/.apps/traefik/traefik.ports.yml
+++ b/compose/.apps/traefik/traefik.ports.yml
@@ -1,0 +1,6 @@
+services:
+  traefik:
+    ports:
+    - ${TRAEFIK_PORT_443}:443
+    - ${TRAEFIK_PORT_8080}:8080
+    - ${TRAEFIK_PORT_80}:80

--- a/compose/.apps/traefik/traefik.ports.yml
+++ b/compose/.apps/traefik/traefik.ports.yml
@@ -1,6 +1,6 @@
 services:
   traefik:
     ports:
-    - ${TRAEFIK_PORT_443}:443
-    - ${TRAEFIK_PORT_8080}:8080
-    - ${TRAEFIK_PORT_80}:80
+      - ${TRAEFIK_PORT_443}:443
+      - ${TRAEFIK_PORT_8080}:8080
+      - ${TRAEFIK_PORT_80}:80

--- a/compose/.apps/traefik/traefik.x86_64.yml
+++ b/compose/.apps/traefik/traefik.x86_64.yml
@@ -1,0 +1,3 @@
+services:
+  traefik:
+    image: traefik

--- a/compose/.apps/traefik/traefik.yml
+++ b/compose/.apps/traefik/traefik.yml
@@ -2,9 +2,9 @@ services:
   traefik:
     container_name: traefik
     environment:
-    - PGID=${PGID}
-    - PUID=${PUID}
-    - TZ=${TZ}
+      - PGID=${PGID}
+      - PUID=${PUID}
+      - TZ=${TZ}
     logging:
       driver: json-file
       options:
@@ -12,7 +12,7 @@ services:
         max-size: ${DOCKERLOGGING_MAXSIZE}
     restart: ${TRAEFIK_RESTART}
     volumes:
-    - ${DOCKERCONFDIR}/traefik/traefik.yml:/etc/traefik/traefik.yml
-    - ${DOCKERSTORAGEDIR}:/storage
-    - /etc/localtime:/etc/localtime:ro
-    - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ${DOCKERCONFDIR}/traefik/traefik.yml:/etc/traefik/traefik.yml
+      - ${DOCKERSTORAGEDIR}:/storage
+      - /etc/localtime:/etc/localtime:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro

--- a/compose/.apps/traefik/traefik.yml
+++ b/compose/.apps/traefik/traefik.yml
@@ -12,7 +12,7 @@ services:
         max-size: ${DOCKERLOGGING_MAXSIZE}
     restart: ${TRAEFIK_RESTART}
     volumes:
-      - ${DOCKERCONFDIR}/traefik/traefik.yml:/etc/traefik/traefik.yml
+      - ${DOCKERCONFDIR}/traefik:/etc/traefik
       - ${DOCKERSTORAGEDIR}:/storage
       - /etc/localtime:/etc/localtime:ro
       - /var/run/docker.sock:/var/run/docker.sock:ro

--- a/compose/.apps/traefik/traefik.yml
+++ b/compose/.apps/traefik/traefik.yml
@@ -1,0 +1,17 @@
+services:
+  traefik:
+    container_name: traefik
+    environment:
+    - PGID=${PGID}
+    - PUID=${PUID}
+    - TZ=${TZ}
+    logging:
+      driver: json-file
+      options:
+        max-file: ${DOCKERLOGGING_MAXFILE}
+        max-size: ${DOCKERLOGGING_MAXSIZE}
+    restart: ${TRAEFIK_RESTART}
+    volumes:
+    - ${DOCKERSTORAGEDIR}:/storage
+    - /etc/localtime:/etc/localtime:ro
+    - /var/run/docker.sock:/var/run/docker.sock:ro

--- a/compose/.apps/traefik/traefik.yml
+++ b/compose/.apps/traefik/traefik.yml
@@ -12,6 +12,7 @@ services:
         max-size: ${DOCKERLOGGING_MAXSIZE}
     restart: ${TRAEFIK_RESTART}
     volumes:
+    - ${DOCKERCONFDIR}/traefik/traefik.yml:/etc/traefik/traefik.yml
     - ${DOCKERSTORAGEDIR}:/storage
     - /etc/localtime:/etc/localtime:ro
     - /var/run/docker.sock:/var/run/docker.sock:ro

--- a/docs/apps/traefik.md
+++ b/docs/apps/traefik.md
@@ -10,7 +10,7 @@
 
 ## Install/Setup
 
-This container itself is quite simple but note that lots of customization will be needed for the client apps you will be routing with Traefik. You'll need to use [DockSTARTer overrides](https://dockstarter.com/overrides/introduction/), more specifically editing `docker-compose.override.yml` to add labels, etc, to your client apps to configure Traefik routing. 
+This container itself is quite simple but note that lots of customization will be needed for the client apps you will be routing with Traefik. You'll need to use [DockSTARTer overrides](https://dockstarter.com/overrides/introduction/), more specifically editing `docker-compose.override.yml` to add labels, etc, to your client apps to configure Traefik routing.
 
 ### traefik.yml
 

--- a/docs/apps/traefik.md
+++ b/docs/apps/traefik.md
@@ -1,0 +1,18 @@
+# Traefik
+
+[![Docker Pulls](https://img.shields.io/docker/pulls/_/traefik?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/_/traefik)
+[![GitHub Stars](https://img.shields.io/github/stars/traefik/traefik-library-image?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/traefik/traefik-library-image)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/traefik)
+
+## Description
+
+[Traefik](https://doc.traefik.io/traefik/) is a modern HTTP reverse proxy and load balancer that makes deploying microservices easy.
+
+## Install/Setup
+
+This container itself is quite simple but note that lots of customization will be needed for the client apps you will be routing with Traefik. You'll need to use [DockSTARTer overrides](https://dockstarter.com/overrides/introduction/), more specifically editing `docker-compose.override.yml` to add labels, etc, to your client apps to configure Traefik routing. 
+
+## Suggested Reading
+
+[Traefik Documentation](https://doc.traefik.io/traefik/)
+[Docker Hub Documentation of Traefik](https://hub.docker.com/_/traefik)

--- a/docs/apps/traefik.md
+++ b/docs/apps/traefik.md
@@ -14,7 +14,7 @@ This container itself is quite simple but note that lots of customization will b
 
 ### traefik.yml
 
-You can configure Traefik itself with a `traefik.yml` file. You should create this at `${DOCKERCONFDIR}/traefik/traefik.yml` which is by default volume mapped to `/etc/traefik/traefik.yml` inside the container.
+You can configure Traefik itself with a `traefik.yml` file. You should create this at `${DOCKERCONFDIR}/traefik` which is by default volume mapped to `/etc/traefik` inside the container.
 
 ## Suggested Reading
 

--- a/docs/apps/traefik.md
+++ b/docs/apps/traefik.md
@@ -12,6 +12,10 @@
 
 This container itself is quite simple but note that lots of customization will be needed for the client apps you will be routing with Traefik. You'll need to use [DockSTARTer overrides](https://dockstarter.com/overrides/introduction/), more specifically editing `docker-compose.override.yml` to add labels, etc, to your client apps to configure Traefik routing. 
 
+### traefik.yml
+
+You can configure Traefik itself with a `traefik.yml` file. You should create this at `${DOCKERCONFDIR}/traefik/traefik.yml` which is by default volume mapped to `/etc/traefik/traefik.yml` inside the container.
+
 ## Suggested Reading
 
 [Traefik Documentation](https://doc.traefik.io/traefik/)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -207,6 +207,7 @@ nav:
       - apps/thelounge.md
       - apps/timemachine.md
       - apps/traktarr.md
+      - apps/traefik.md
       - apps/transmission.md
       - apps/transmissionvpn.md
       - apps/tvheadend.md


### PR DESCRIPTION
# Pull request

**Purpose**
Adding support for [Traefik](https://hub.docker.com/_/traefik)

**Approach**
Followed contributing.md for adding new app

**Open Questions and Pre-Merge TODOs**
- [x] I'm open to suggestions on the volume mapping `${DOCKERCONFDIR}/traefik/traefik.yml:/etc/traefik/traefik.yml` VS using  an environment variable to locate this traefik.yml file

**Testing**
1. ds -a traefik
2. Created traefik.yml with basic contents
```
## traefik.yml

# Docker configuration backend
providers:
  docker:
    defaultRule: "Host(`{{ trimPrefix `/` .Name }}.docker.localhost`)"

# API and dashboard configuration
api:
  insecure: true
```
3. Visited <host>:8080 and to ensure I can see the Traefik dashboard

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
