### PR TITLE
Fix SC2317

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -48,7 +48,6 @@ For regular usage you can run without providing any options.
 -x --debug
     debug
 EOF
-    exit
 }
 
 # Script Information
@@ -74,6 +73,7 @@ export COMPOSE_ENV
 # Cleanup Function
 cleanup() {
     local -ri EXIT_CODE=$?
+    trap - ERR EXIT SIGABRT SIGALRM SIGHUP SIGINT SIGQUIT SIGTERM
     sudo sh -c "cat ${MKTEMP_LOG:-/dev/null} >> ${SCRIPTPATH}/dockstarter.log" || true
     sudo rm -f "${MKTEMP_LOG}" || true
     sudo sh -c "echo \"$(tail -1000 "${SCRIPTPATH}/dockstarter.log")\" > ${SCRIPTPATH}/dockstarter.log" || true
@@ -88,7 +88,6 @@ cleanup() {
     fi
 
     exit ${EXIT_CODE}
-    trap - ERR EXIT SIGABRT SIGALRM SIGHUP SIGINT SIGQUIT SIGTERM
 }
 trap 'cleanup' ERR EXIT SIGABRT SIGALRM SIGHUP SIGINT SIGQUIT SIGTERM
 


### PR DESCRIPTION
# Pull request

**Purpose**
SC2317 triggers when a script has code that is unreachable due to an `exit` happening before the code in question. These changes remove duplicate `exit` commands and reorder the `trap` to the top of the `cleanup`.

**Learning**
https://www.shellcheck.net/wiki/SC2317

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
