### PR TITLE
Fix "Unable to find labels for UPTIME KUMA" error on creating Uptime Kuma

### DIFF
--- a/compose/.apps/uptimekuma/uptimekuma.labels.yml
+++ b/compose/.apps/uptimekuma/uptimekuma.labels.yml
@@ -3,7 +3,7 @@ services:
     labels:
       com.dockstarter.appinfo.deprecated: "false"
       com.dockstarter.appinfo.description: A self-hosted monitoring tool like Uptime Robot
-      com.dockstarter.appinfo.nicename: Uptime Kuma
+      com.dockstarter.appinfo.nicename: UptimeKuma
       com.dockstarter.appvars.uptimekuma_enabled: "false"
       com.dockstarter.appvars.uptimekuma_network_mode: ""
       com.dockstarter.appvars.uptimekuma_port_3001: "3001"


### PR DESCRIPTION
# Pull request

**Purpose**
Fixes an issue where installing UptimeKuma doesn't work because the nicename has a space in it:

```
$ sudo ds
[sudo] password for ds:
2022-08-30 04:42:40 [NOTICE]   Preparing app menu. Please be patient, this can take a while.
grep: /home/ds/.docker/compose/.apps/uptime kuma/uptime kuma.labels.yml: No such file or directory
2022-08-30 04:43:42 [ERROR ]   Unable to find labels for UPTIME KUMA
2022-08-30 04:43:42 [FATAL ]   Failed to find UPTIME KUMA_ENABLED in /home/ds/.docker/compose/.env
Failing command: grep --color=never -P "^UPTIME KUMA_ENABLED=" "/home/ds/.docker/compose/.env"
DockSTARTer did not finish running successfully.
```

**Approach**
Removing the space fixes this as the variables in the `.env` file become `UPTIMEKUMA_*`

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [x] n/a

**Learning**
`ds` threw a good error that helped with troubleshooting. It might be desirable to validate for this (i.e. no spaces in `com.dockstarter.appinfo.nicename`) on future PRs.

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
