### PR TITLE
Removed unnecessary port label from Gluetun

### DIFF
--- a/compose/.apps/gluetun/gluetun.labels.yml
+++ b/compose/.apps/gluetun/gluetun.labels.yml
@@ -6,5 +6,4 @@ services:
       com.dockstarter.appinfo.nicename: Gluetun
       com.dockstarter.appvars.gluetun_enabled: "false"
       com.dockstarter.appvars.gluetun_network_mode: ""
-      com.dockstarter.appvars.gluetun_port_9117: "9117"
       com.dockstarter.appvars.gluetun_restart: unless-stopped


### PR DESCRIPTION
# Pull request

**Purpose**
In [this pull request](https://github.com/GhostWriters/DockSTARTer/pull/1545) I left in a label for port 9117. This isn't required or used for Gluetun it's actually the port for Jackett that I must've left over from testing. I don't mean to spam this repository so sorry for that.

**Requirements**

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
