### PR TITLE
Switch prowlarr to latest

### DIFF
--- a/compose/.apps/prowlarr/prowlarr.aarch64.yml
+++ b/compose/.apps/prowlarr/prowlarr.aarch64.yml
@@ -1,3 +1,3 @@
 services:
   prowlarr:
-    image: lscr.io/linuxserver/prowlarr:develop
+    image: lscr.io/linuxserver/prowlarr

--- a/compose/.apps/prowlarr/prowlarr.armv7l.yml
+++ b/compose/.apps/prowlarr/prowlarr.armv7l.yml
@@ -1,3 +1,3 @@
 services:
   prowlarr:
-    image: lscr.io/linuxserver/prowlarr:develop
+    image: lscr.io/linuxserver/prowlarr

--- a/compose/.apps/prowlarr/prowlarr.x86_64.yml
+++ b/compose/.apps/prowlarr/prowlarr.x86_64.yml
@@ -1,3 +1,3 @@
 services:
   prowlarr:
-    image: lscr.io/linuxserver/prowlarr:develop
+    image: lscr.io/linuxserver/prowlarr


### PR DESCRIPTION
# Pull request

**Purpose**
Prowlarr's `latest` tag via lsio image has been released. Switching from `develop` to `latest` to provide the most stable option by default.

**Learning**
https://github.com/linuxserver/docker-prowlarr

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
