### PR TITLE
Add audiobookshelf

### DIFF
--- a/compose/.apps/audiobookshelf/audiobookshelf.hostname.yml
+++ b/compose/.apps/audiobookshelf/audiobookshelf.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  audiobookshelf:
+    hostname: ${DOCKERHOSTNAME}

--- a/compose/.apps/audiobookshelf/audiobookshelf.labels.yml
+++ b/compose/.apps/audiobookshelf/audiobookshelf.labels.yml
@@ -1,0 +1,11 @@
+services:
+  audiobookshelf:
+    labels:
+      com.dockstarter.appinfo.deprecated: "false"
+      com.dockstarter.appinfo.description: Self-hosted audiobook and podcast server
+      com.dockstarter.appinfo.nicename: audiobookshelf
+      com.dockstarter.appvars.audiobookshelf_enabled: "false"
+      com.dockstarter.appvars.audiobookshelf_metadata_path: "/config/.metadata"
+      com.dockstarter.appvars.audiobookshelf_network_mode: ""
+      com.dockstarter.appvars.audiobookshelf_port_80: "13378"
+      com.dockstarter.appvars.audiobookshelf_restart: unless-stopped

--- a/compose/.apps/audiobookshelf/audiobookshelf.netmode.yml
+++ b/compose/.apps/audiobookshelf/audiobookshelf.netmode.yml
@@ -1,0 +1,3 @@
+services:
+  audiobookshelf:
+    network_mode: ${AUDIOBOOKSHELF_NETWORK_MODE}

--- a/compose/.apps/audiobookshelf/audiobookshelf.ports.yml
+++ b/compose/.apps/audiobookshelf/audiobookshelf.ports.yml
@@ -1,0 +1,4 @@
+services:
+  audiobookshelf:
+    ports:
+      - ${AUDIOBOOKSHELF_PORT_80}:80

--- a/compose/.apps/audiobookshelf/audiobookshelf.x86_64.yml
+++ b/compose/.apps/audiobookshelf/audiobookshelf.x86_64.yml
@@ -1,0 +1,3 @@
+services:
+  audiobookshelf:
+    image: ghcr.io/advplyr/audiobookshelf

--- a/compose/.apps/audiobookshelf/audiobookshelf.yml
+++ b/compose/.apps/audiobookshelf/audiobookshelf.yml
@@ -1,0 +1,19 @@
+services:
+  audiobookshelf:
+    container_name: audiobookshelf
+    environment:
+      - CONFIG_PATH=/config
+      - LOG_LEVEL=info
+      - METADATA_PATH=${AUDIOBOOKSHELF_METADATA_PATH}
+      - TZ=${TZ}
+    logging:
+      driver: json-file
+      options:
+        max-file: ${DOCKERLOGGING_MAXFILE}
+        max-size: ${DOCKERLOGGING_MAXSIZE}
+    restart: ${AUDIOBOOKSHELF_RESTART}
+    user: ${PUID}:${PGID}
+    volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - ${DOCKERCONFDIR}/audiobookshelf:/config
+      - ${DOCKERSTORAGEDIR}:/storage

--- a/docs/apps/audiobookshelf.md
+++ b/docs/apps/audiobookshelf.md
@@ -1,0 +1,15 @@
+# Audiobookshelf
+
+[![Docker Pulls](https://img.shields.io/docker/pulls/advplyr/audiobookshelf?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/advplyr/audiobookshelf)
+[![GitHub Stars](https://img.shields.io/github/stars/advplyr/audiobookshelf?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/advplyr/audiobookshelf)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/audiobookshelf)
+
+## Description
+
+[Audiobookshelf](https://github.com/advplyr/audiobookshelf) is a self-hosted audiobook and podcast server.
+
+## Install/Setup
+
+This application does not have any specific setup instructions documented. If
+you need assistance setting up this application please visit our
+[support page](https://dockstarter.com/basics/support/).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,6 +92,7 @@ nav:
       - apps/amd.md
       - apps/apcupsd.md
       - apps/apprise.md
+      - apps/audiobookshelf.md
       - apps/azuracast.md
       - apps/bazarr.md
       - apps/beets.md


### PR DESCRIPTION
# Pull request

**Purpose**
Add audiobookshelf (audiobook and podcast server)

**Approach**
Audiobooksehlf has both a `config` and a `metadata` folder.  Since we only have a `config`, I placed the metadata folder in `/config/.metadata` using the `METADATA_PATH` variable.  He also no longer uses "UID/GID" variables, but using `user: ${PUID}:${PGID}` has been working for me instead to get the permissions right.

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
