### PR TITLE
audiobookshelf: Set default metadata location

### DIFF
--- a/compose/.apps/audiobookshelf/audiobookshelf.yml
+++ b/compose/.apps/audiobookshelf/audiobookshelf.yml
@@ -5,7 +5,7 @@ services:
       - CONFIG_PATH=/config
       - HOME=/config/.home
       - LOG_LEVEL=info
-      - METADATA_PATH=${AUDIOBOOKSHELF_METADATA_PATH}
+      - METADATA_PATH=${AUDIOBOOKSHELF_METADATA_PATH:-/config/.metadata}
       - TZ=${TZ}
     logging:
       driver: json-file


### PR DESCRIPTION
# Pull request

**Purpose**
Use the default location for metadata if variable is not set

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
