### PR TITLE
audiobookshelf: remove METADATA var, mount into /config

### DIFF
--- a/compose/.apps/audiobookshelf/audiobookshelf.labels.yml
+++ b/compose/.apps/audiobookshelf/audiobookshelf.labels.yml
@@ -5,7 +5,6 @@ services:
       com.dockstarter.appinfo.description: Self-hosted audiobook and podcast server
       com.dockstarter.appinfo.nicename: audiobookshelf
       com.dockstarter.appvars.audiobookshelf_enabled: "false"
-      com.dockstarter.appvars.audiobookshelf_metadata_path: "/config/.metadata"
       com.dockstarter.appvars.audiobookshelf_network_mode: ""
       com.dockstarter.appvars.audiobookshelf_port_80: "13378"
       com.dockstarter.appvars.audiobookshelf_restart: unless-stopped

--- a/compose/.apps/audiobookshelf/audiobookshelf.yml
+++ b/compose/.apps/audiobookshelf/audiobookshelf.yml
@@ -5,7 +5,7 @@ services:
       - CONFIG_PATH=/config
       - HOME=/config/.home
       - LOG_LEVEL=info
-      - METADATA_PATH=${AUDIOBOOKSHELF_METADATA_PATH:-/config/.metadata}
+      - METADATA_PATH=/metadata
       - TZ=${TZ}
     logging:
       driver: json-file
@@ -17,4 +17,5 @@ services:
     volumes:
       - /etc/localtime:/etc/localtime:ro
       - ${DOCKERCONFDIR}/audiobookshelf:/config
+      - ${DOCKERCONFDIR}/audiobookshelf/.metadata:/metadata
       - ${DOCKERSTORAGEDIR}:/storage

--- a/compose/.apps/audiobookshelf/audiobookshelf.yml
+++ b/compose/.apps/audiobookshelf/audiobookshelf.yml
@@ -5,7 +5,7 @@ services:
       - CONFIG_PATH=/config
       - HOME=/config/.home
       - LOG_LEVEL=info
-      - METADATA_PATH=${AUDIOBOOKSHELF_METADATA_PATH}
+      - METADATA_PATH=${AUDIOBOOKSHELF_METADATA_PATH:-/config/.metadata}
       - TZ=${TZ}
     logging:
       driver: json-file


### PR DESCRIPTION
# Pull request

**Purpose**
Mount the metadata folder into from `/metadata` to `/config/.metadata` instead of using `METADATA_PATH` variable.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
