### PR TITLE
Calibre aarch64 support

### DIFF
--- a/compose/.apps/calibre/calibre.aarch64.yml
+++ b/compose/.apps/calibre/calibre.aarch64.yml
@@ -1,0 +1,3 @@
+services:
+  calibre:
+    image: lscr.io/linuxserver/calibre


### PR DESCRIPTION
Lsio has added aarch64 architechure support to their calibre container sometime in the last two years. I added the aarch64.yml file needed for DS to pull that container.

# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [x] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

https://hub.docker.com/r/linuxserver/calibre


**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
