### PR TITLE
Update airsonicadvanced.labels.yml

### DIFF
--- a/compose/.apps/airsonicadvanced/airsonicadvanced.labels.yml
+++ b/compose/.apps/airsonicadvanced/airsonicadvanced.labels.yml
@@ -3,7 +3,7 @@ services:
     labels:
       com.dockstarter.appinfo.deprecated: "false"
       com.dockstarter.appinfo.description: Web-based media streamer providing ubiquitous access to your music
-      com.dockstarter.appinfo.nicename: Airsonic
+      com.dockstarter.appinfo.nicename: Airsonic-Advanced
       com.dockstarter.appvars.airsonicadvanced_context_path: /airsonic
       com.dockstarter.appvars.airsonicadvanced_enabled: "false"
       com.dockstarter.appvars.airsonicadvanced_java_opts: ""

--- a/compose/.apps/airsonicadvanced/airsonicadvanced.labels.yml
+++ b/compose/.apps/airsonicadvanced/airsonicadvanced.labels.yml
@@ -3,7 +3,7 @@ services:
     labels:
       com.dockstarter.appinfo.deprecated: "false"
       com.dockstarter.appinfo.description: Web-based media streamer providing ubiquitous access to your music
-      com.dockstarter.appinfo.nicename: Airsonic-Advanced
+      com.dockstarter.appinfo.nicename: AirsonicAdvanced
       com.dockstarter.appvars.airsonicadvanced_context_path: /airsonic
       com.dockstarter.appvars.airsonicadvanced_enabled: "false"
       com.dockstarter.appvars.airsonicadvanced_java_opts: ""


### PR DESCRIPTION
Fixes the airsonic-advanced config to correctly list and pull the proper image rather than mixing airsonic with airsonic-advanced.

# Pull request

**Purpose**
As it stands right now, the nicename for Airsonic and Airsonic-Advanced is the same. That leads to DS incorrectly pulling the original airsonic rather than advanced.

**Approach**
Changes the nicename for AirSonic-Advanced to be different from Airsonic.

**Open Questions and Pre-Merge TODOs**
N/A

**Learning**
N/A

**Requirements**

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
