### PR TITLE
Update kiwix-serve image location

### DIFF
--- a/compose/.apps/kiwixserve/kiwixserve.aarch64.yml
+++ b/compose/.apps/kiwixserve/kiwixserve.aarch64.yml
@@ -1,3 +1,3 @@
 services:
   kiwixserve:
-    image: kiwix/kiwix-serve
+    image: ghcr.io/kiwix/kiwix-serve

--- a/compose/.apps/kiwixserve/kiwixserve.armv7l.yml
+++ b/compose/.apps/kiwixserve/kiwixserve.armv7l.yml
@@ -1,3 +1,3 @@
 services:
   kiwixserve:
-    image: kiwix/kiwix-serve
+    image: ghcr.io/kiwix/kiwix-serve

--- a/compose/.apps/kiwixserve/kiwixserve.x86_64.yml
+++ b/compose/.apps/kiwixserve/kiwixserve.x86_64.yml
@@ -1,3 +1,3 @@
 services:
   kiwixserve:
-    image: kiwix/kiwix-serve
+    image: ghcr.io/kiwix/kiwix-serve


### PR DESCRIPTION
The default kiwix/kiwix-serve image location fails as it tries to pull from dockerhub rather than ghcr.io. This updates the files to pull from the correct location.

# Pull request

**Purpose**
The image location for kiwix/kiwix-serve is linking to dockerhub rather than ghcr.io where the images are actually located. This corrects that issue. As a result this also fixes the validation check that causes every PR to fail.

**Approach**
Changes the image location.

**Open Questions and Pre-Merge TODOs**

N/A

**Learning**
N/A

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
