### PR TITLE
Deprecate armhf

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -79,7 +79,6 @@ Look at the **App Specifics** list in the **nav** section and add a new line for
   - `<appname>.ports.yml` contains the ports used by the app. This file can be excluded if the app does not require ports
   - At least one of the following files must be included:
     - `<appname>.aarch64.yml` defines the aarch64 or arm64 image, should include an image tag (default is `latest`)
-    - `<appname>.armv7l.yml` defines the armv7l or armhf image, should include an image tag (default is `latest`)
     - `<appname>.x86_64.yml` defines the x86_64 image, should include an image tag (default is `latest`)
 
 ## .env.example file

--- a/compose/.apps/adguard/adguard.armv7l.yml
+++ b/compose/.apps/adguard/adguard.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  adguard:
-    image: adguard/adguardhome:latest

--- a/compose/.apps/adminer/adminer.armv7l.yml
+++ b/compose/.apps/adminer/adminer.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  adminer:
-    image: adminer:latest

--- a/compose/.apps/airsonic/airsonic.armv7l.yml
+++ b/compose/.apps/airsonic/airsonic.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  airsonic:
-    image: lscr.io/linuxserver/airsonic:latest

--- a/compose/.apps/airsonicadvanced/airsonicadvanced.armv7l.yml
+++ b/compose/.apps/airsonicadvanced/airsonicadvanced.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  airsonicadvanced:
-    image: lscr.io/linuxserver/airsonic-advanced:latest

--- a/compose/.apps/amd/amd.armv7l.yml
+++ b/compose/.apps/amd/amd.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  amd:
-    image: halianelf/amd:latest

--- a/compose/.apps/apprise/apprise.armv7l.yml
+++ b/compose/.apps/apprise/apprise.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  apprise:
-    image: lscr.io/linuxserver/apprise-api:latest

--- a/compose/.apps/autobrr/autobrr.armv7l.yml
+++ b/compose/.apps/autobrr/autobrr.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  autobrr:
-    image: ghcr.io/autobrr/autobrr:latest

--- a/compose/.apps/bazarr/bazarr.armv7l.yml
+++ b/compose/.apps/bazarr/bazarr.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  bazarr:
-    image: lscr.io/linuxserver/bazarr:latest

--- a/compose/.apps/beets/beets.armv7l.yml
+++ b/compose/.apps/beets/beets.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  beets:
-    image: lscr.io/linuxserver/beets:latest

--- a/compose/.apps/bitwarden/bitwarden.armv7l.yml
+++ b/compose/.apps/bitwarden/bitwarden.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  bitwarden:
-    image: vaultwarden/server:latest

--- a/compose/.apps/booksonic/booksonic.armv7l.yml
+++ b/compose/.apps/booksonic/booksonic.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  booksonic:
-    image: lscr.io/linuxserver/booksonic:latest

--- a/compose/.apps/booksonicair/booksonicair.armv7l.yml
+++ b/compose/.apps/booksonicair/booksonicair.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  booksonicair:
-    image: lscr.io/linuxserver/booksonic-air:latest

--- a/compose/.apps/bookstack/bookstack.armv7l.yml
+++ b/compose/.apps/bookstack/bookstack.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  bookstack:
-    image: lscr.io/linuxserver/bookstack:latest

--- a/compose/.apps/calibreweb/calibreweb.armv7l.yml
+++ b/compose/.apps/calibreweb/calibreweb.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  calibreweb:
-    image: lscr.io/linuxserver/calibre-web:latest

--- a/compose/.apps/cloudflareddns/cloudflareddns.armv7l.yml
+++ b/compose/.apps/cloudflareddns/cloudflareddns.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  cloudflareddns:
-    image: cr.hotio.dev/hotio/cloudflareddns:latest

--- a/compose/.apps/codeserver/codeserver.armv7l.yml
+++ b/compose/.apps/codeserver/codeserver.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  codeserver:
-    image: lscr.io/linuxserver/code-server:latest

--- a/compose/.apps/couchpotato/couchpotato.armv7l.yml
+++ b/compose/.apps/couchpotato/couchpotato.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  couchpotato:
-    image: lscr.io/linuxserver/couchpotato:latest

--- a/compose/.apps/dasshio/dasshio.armv7l.yml
+++ b/compose/.apps/dasshio/dasshio.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  dasshio:
-    image: danimtb/armv7-dasshio:latest

--- a/compose/.apps/ddclient/ddclient.armv7l.yml
+++ b/compose/.apps/ddclient/ddclient.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  ddclient:
-    image: lscr.io/linuxserver/ddclient:latest

--- a/compose/.apps/deemix/deemix.armv7l.yml
+++ b/compose/.apps/deemix/deemix.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  deemix:
-    image: registry.gitlab.com/bockiii/deemix-docker:latest

--- a/compose/.apps/deluge/deluge.armv7l.yml
+++ b/compose/.apps/deluge/deluge.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  deluge:
-    image: lscr.io/linuxserver/deluge:latest

--- a/compose/.apps/dozzle/dozzle.armv7l.yml
+++ b/compose/.apps/dozzle/dozzle.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  dozzle:
-    image: amir20/dozzle:latest

--- a/compose/.apps/duckdns/duckdns.armv7l.yml
+++ b/compose/.apps/duckdns/duckdns.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  duckdns:
-    image: lscr.io/linuxserver/duckdns:latest

--- a/compose/.apps/duplicacy/duplicacy.armv7l.yml
+++ b/compose/.apps/duplicacy/duplicacy.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  duplicacy:
-    image: cr.hotio.dev/hotio/duplicacy:latest

--- a/compose/.apps/duplicati/duplicati.armv7l.yml
+++ b/compose/.apps/duplicati/duplicati.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  duplicati:
-    image: lscr.io/linuxserver/duplicati:latest

--- a/compose/.apps/emby/emby.armv7l.yml
+++ b/compose/.apps/emby/emby.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  emby:
-    image: lscr.io/linuxserver/emby:latest

--- a/compose/.apps/fail2ban/fail2ban.armv7l.yml
+++ b/compose/.apps/fail2ban/fail2ban.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  fail2ban:
-    image: lscr.io/linuxserver/fail2ban:latest

--- a/compose/.apps/filebrowser/filebrowser.armv7l.yml
+++ b/compose/.apps/filebrowser/filebrowser.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  filebrowser:
-    image: filebrowser/filebrowser:latest

--- a/compose/.apps/flame/flame.armv7l.yml
+++ b/compose/.apps/flame/flame.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  flame:
-    image: pawelmalak/flame:multiarch

--- a/compose/.apps/flaresolverr/flaresolverr.armv7l.yml
+++ b/compose/.apps/flaresolverr/flaresolverr.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  flaresolverr:
-    image: ghcr.io/flaresolverr/flaresolverr:latest

--- a/compose/.apps/freshrss/freshrss.armv7l.yml
+++ b/compose/.apps/freshrss/freshrss.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  freshrss:
-    image: lscr.io/linuxserver/freshrss:latest

--- a/compose/.apps/gitea/gitea.armv7l.yml
+++ b/compose/.apps/gitea/gitea.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  gitea:
-    image: gitea/gitea:latest

--- a/compose/.apps/glances/glances.armv7l.yml
+++ b/compose/.apps/glances/glances.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  glances:
-    image: nicolargo/glances:latest

--- a/compose/.apps/gluetun/gluetun.armv7l.yml
+++ b/compose/.apps/gluetun/gluetun.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  gluetun:
-    image: qmcgaw/gluetun:latest

--- a/compose/.apps/grafana/grafana.armv7l.yml
+++ b/compose/.apps/grafana/grafana.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  grafana:
-    image: grafana/grafana:latest

--- a/compose/.apps/grocy/grocy.armv7l.yml
+++ b/compose/.apps/grocy/grocy.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  grocy:
-    image: lscr.io/linuxserver/grocy:latest

--- a/compose/.apps/guacamole/guacamole.armv7l.yml
+++ b/compose/.apps/guacamole/guacamole.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  guacamole:
-    image: oznu/guacamole:armhf

--- a/compose/.apps/headphones/headphones.armv7l.yml
+++ b/compose/.apps/headphones/headphones.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  headphones:
-    image: lscr.io/linuxserver/headphones:latest

--- a/compose/.apps/heimdall/heimdall.armv7l.yml
+++ b/compose/.apps/heimdall/heimdall.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  heimdall:
-    image: lscr.io/linuxserver/heimdall:latest

--- a/compose/.apps/homeassistant/homeassistant.armv7l.yml
+++ b/compose/.apps/homeassistant/homeassistant.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  homeassistant:
-    image: homeassistant/home-assistant:latest

--- a/compose/.apps/homebridge/homebridge.armv7l.yml
+++ b/compose/.apps/homebridge/homebridge.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  homebridge:
-    image: oznu/homebridge:ubuntu

--- a/compose/.apps/homer/homer.armv7l.yml
+++ b/compose/.apps/homer/homer.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  homer:
-    image: b4bz/homer:latest

--- a/compose/.apps/htpcmanager/htpcmanager.armv7l.yml
+++ b/compose/.apps/htpcmanager/htpcmanager.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  htpcmanager:
-    image: lscr.io/linuxserver/htpcmanager:latest

--- a/compose/.apps/hydra2/hydra2.armv7l.yml
+++ b/compose/.apps/hydra2/hydra2.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  hydra2:
-    image: lscr.io/linuxserver/hydra2:latest

--- a/compose/.apps/influxdb/influxdb.armv7l.yml
+++ b/compose/.apps/influxdb/influxdb.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  influxdb:
-    image: influxdb:1.8

--- a/compose/.apps/jackett/jackett.armv7l.yml
+++ b/compose/.apps/jackett/jackett.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  jackett:
-    image: lscr.io/linuxserver/jackett:latest

--- a/compose/.apps/jellyfin/jellyfin.armv7l.yml
+++ b/compose/.apps/jellyfin/jellyfin.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  jellyfin:
-    image: lscr.io/linuxserver/jellyfin:latest

--- a/compose/.apps/jfago/jfago.armv7l.yml
+++ b/compose/.apps/jfago/jfago.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  jfago:
-    image: hrfee/jfa-go:latest

--- a/compose/.apps/kanboard/kanboard.armv7l.yml
+++ b/compose/.apps/kanboard/kanboard.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  kanboard:
-    image: webhippie/kanboard:latest

--- a/compose/.apps/kiwixserve/kiwixserve.armv7l.yml
+++ b/compose/.apps/kiwixserve/kiwixserve.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  kiwixserve:
-    image: ghcr.io/kiwix/kiwix-serve:latest

--- a/compose/.apps/komga/komga.armv7l.yml
+++ b/compose/.apps/komga/komga.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  komga:
-    image: gotson/komga:latest

--- a/compose/.apps/lazylibrarian/lazylibrarian.armv7l.yml
+++ b/compose/.apps/lazylibrarian/lazylibrarian.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  lazylibrarian:
-    image: lscr.io/linuxserver/lazylibrarian:latest

--- a/compose/.apps/ldapauth/ldapauth.armv7l.yml
+++ b/compose/.apps/ldapauth/ldapauth.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  ldapauth:
-    image: lscr.io/linuxserver/ldap-auth:latest

--- a/compose/.apps/letsencrypt/letsencrypt.armv7l.yml
+++ b/compose/.apps/letsencrypt/letsencrypt.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  letsencrypt:
-    image: lscr.io/linuxserver/letsencrypt:latest

--- a/compose/.apps/librespeed/librespeed.armv7l.yml
+++ b/compose/.apps/librespeed/librespeed.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  librespeed:
-    image: lscr.io/linuxserver/librespeed:latest

--- a/compose/.apps/lidarr/lidarr.armv7l.yml
+++ b/compose/.apps/lidarr/lidarr.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  lidarr:
-    image: lscr.io/linuxserver/lidarr:latest

--- a/compose/.apps/limnoria/limnoria.armv7l.yml
+++ b/compose/.apps/limnoria/limnoria.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  limnoria:
-    image: lscr.io/linuxserver/limnoria:latest

--- a/compose/.apps/logitechmediaserver/logitechmediaserver.armv7l.yml
+++ b/compose/.apps/logitechmediaserver/logitechmediaserver.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  logitechmediaserver:
-    image: doliana/logitech-media-server:${LOGITECHMEDIASERVER_TAG}

--- a/compose/.apps/mariadb/mariadb.armv7l.yml
+++ b/compose/.apps/mariadb/mariadb.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  mariadb:
-    image: lscr.io/linuxserver/mariadb:latest

--- a/compose/.apps/medusa/medusa.armv7l.yml
+++ b/compose/.apps/medusa/medusa.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  medusa:
-    image: lscr.io/linuxserver/medusa:latest

--- a/compose/.apps/minecraft_server/minecraft_server.armv7l.yml
+++ b/compose/.apps/minecraft_server/minecraft_server.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  minecraft_server:
-    image: itzg/minecraft-server:latest

--- a/compose/.apps/mosquitto/mosquitto.armv7l.yml
+++ b/compose/.apps/mosquitto/mosquitto.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  mosquitto:
-    image: eclipse-mosquitto:latest

--- a/compose/.apps/moviematch/moviematch.armv7l.yml
+++ b/compose/.apps/moviematch/moviematch.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  moviematch:
-    image: lukechannings/moviematch:latest

--- a/compose/.apps/muximux/muximux.armv7l.yml
+++ b/compose/.apps/muximux/muximux.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  muximux:
-    image: lscr.io/linuxserver/muximux:latest

--- a/compose/.apps/mylar/mylar.armv7l.yml
+++ b/compose/.apps/mylar/mylar.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  mylar:
-    image: lscr.io/linuxserver/mylar:latest

--- a/compose/.apps/mylar3/mylar3.armv7l.yml
+++ b/compose/.apps/mylar3/mylar3.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  mylar3:
-    image: lscr.io/linuxserver/mylar3:latest

--- a/compose/.apps/netdata/netdata.armv7l.yml
+++ b/compose/.apps/netdata/netdata.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  netdata:
-    image: netdata/netdata:latest

--- a/compose/.apps/nextcloud/nextcloud.armv7l.yml
+++ b/compose/.apps/nextcloud/nextcloud.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  nextcloud:
-    image: lscr.io/linuxserver/nextcloud:latest

--- a/compose/.apps/nodered/nodered.armv7l.yml
+++ b/compose/.apps/nodered/nodered.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  nodered:
-    image: nodered/node-red:latest

--- a/compose/.apps/nzbget/nzbget.armv7l.yml
+++ b/compose/.apps/nzbget/nzbget.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  nzbget:
-    image: lscr.io/linuxserver/nzbget:latest

--- a/compose/.apps/nzbhydra2/nzbhydra2.armv7l.yml
+++ b/compose/.apps/nzbhydra2/nzbhydra2.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  nzbhydra2:
-    image: lscr.io/linuxserver/nzbhydra2:latest

--- a/compose/.apps/omadacontroller/omadacontroller.armv7l.yml
+++ b/compose/.apps/omadacontroller/omadacontroller.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  omadacontroller:
-    image: mbentley/omada-controller:latest

--- a/compose/.apps/ombi/ombi.armv7l.yml
+++ b/compose/.apps/ombi/ombi.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  ombi:
-    image: lscr.io/linuxserver/ombi:latest

--- a/compose/.apps/openldap/openldap.armv7l.yml
+++ b/compose/.apps/openldap/openldap.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  openldap:
-    image: osixia/openldap:latest

--- a/compose/.apps/openspeedtest/openspeedtest.armv7l.yml
+++ b/compose/.apps/openspeedtest/openspeedtest.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  openspeedtest:
-    image: openspeedtest/latest:latest

--- a/compose/.apps/organizr/organizr.armv7l.yml
+++ b/compose/.apps/organizr/organizr.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  organizr:
-    image: ghcr.io/organizr/organizr:latest

--- a/compose/.apps/ouroboros/ouroboros.armv7l.yml
+++ b/compose/.apps/ouroboros/ouroboros.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  ouroboros:
-    image: pyouroboros/ouroboros:latest

--- a/compose/.apps/photoshow/photoshow.armv7l.yml
+++ b/compose/.apps/photoshow/photoshow.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  photoshow:
-    image: lscr.io/linuxserver/photoshow:latest

--- a/compose/.apps/phpmyadmin/phpmyadmin.armv7l.yml
+++ b/compose/.apps/phpmyadmin/phpmyadmin.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  phpmyadmin:
-    image: phpmyadmin:latest

--- a/compose/.apps/pihole/pihole.armv7l.yml
+++ b/compose/.apps/pihole/pihole.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  pihole:
-    image: pihole/pihole:latest

--- a/compose/.apps/piwigo/piwigo.armv7l.yml
+++ b/compose/.apps/piwigo/piwigo.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  piwigo:
-    image: lscr.io/linuxserver/piwigo:latest

--- a/compose/.apps/plex/plex.armv7l.yml
+++ b/compose/.apps/plex/plex.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  plex:
-    image: lscr.io/linuxserver/plex:latest

--- a/compose/.apps/plexanisync/plexanisync.armv7l.yml
+++ b/compose/.apps/plexanisync/plexanisync.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  plexanisync:
-    image: rickdb/plexanisync:latest

--- a/compose/.apps/portainer/portainer.armv7l.yml
+++ b/compose/.apps/portainer/portainer.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  portainer:
-    image: portainer/portainer-ce:latest

--- a/compose/.apps/portaineragent/portaineragent.armv7l.yml
+++ b/compose/.apps/portaineragent/portaineragent.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  portaineragent:
-    image: portainer/agent:latest

--- a/compose/.apps/prometheus/prometheus.armv7l.yml
+++ b/compose/.apps/prometheus/prometheus.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  prometheus:
-    image: prom/prometheus:latest

--- a/compose/.apps/prowlarr/prowlarr.armv7l.yml
+++ b/compose/.apps/prowlarr/prowlarr.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  prowlarr:
-    image: lscr.io/linuxserver/prowlarr:latest

--- a/compose/.apps/pyload/pyload.armv7l.yml
+++ b/compose/.apps/pyload/pyload.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  pyload:
-    image: lscr.io/linuxserver/pyload-ng:latest

--- a/compose/.apps/qbittorrent/qbittorrent.armv7l.yml
+++ b/compose/.apps/qbittorrent/qbittorrent.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  qbittorrent:
-    image: lscr.io/linuxserver/qbittorrent:latest

--- a/compose/.apps/quasselcore/quasselcore.armv7l.yml
+++ b/compose/.apps/quasselcore/quasselcore.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  quasselcore:
-    image: lscr.io/linuxserver/quassel-core:latest

--- a/compose/.apps/quasselweb/quasselweb.armv7l.yml
+++ b/compose/.apps/quasselweb/quasselweb.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  quasselweb:
-    image: lscr.io/linuxserver/quassel-web:latest

--- a/compose/.apps/radarr/radarr.armv7l.yml
+++ b/compose/.apps/radarr/radarr.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  radarr:
-    image: lscr.io/linuxserver/radarr:latest

--- a/compose/.apps/readarr/readarr.armv7l.yml
+++ b/compose/.apps/readarr/readarr.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  readarr:
-    image: lscr.io/linuxserver/readarr:develop

--- a/compose/.apps/recyclarr/recyclarr.armv7l.yml
+++ b/compose/.apps/recyclarr/recyclarr.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  recyclarr:
-    image: ghcr.io/recyclarr/recyclarr:latest

--- a/compose/.apps/requestrr/requestrr.armv7l.yml
+++ b/compose/.apps/requestrr/requestrr.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  requestrr:
-    image: lscr.io/linuxserver/requestrr:latest

--- a/compose/.apps/resiliosync/resiliosync.armv7l.yml
+++ b/compose/.apps/resiliosync/resiliosync.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  resiliosync:
-    image: lscr.io/linuxserver/resilio-sync:latest

--- a/compose/.apps/rsnapshot/rsnapshot.armv7l.yml
+++ b/compose/.apps/rsnapshot/rsnapshot.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  rsnapshot:
-    image: lscr.io/linuxserver/rsnapshot:latest

--- a/compose/.apps/rustdesk/rustdesk.armv7l.yml
+++ b/compose/.apps/rustdesk/rustdesk.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  rustdesk:
-    image: rustdesk/rustdesk-server-s6:latest

--- a/compose/.apps/rutorrent/rutorrent.armv7l.yml
+++ b/compose/.apps/rutorrent/rutorrent.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  rutorrent:
-    image: lscr.io/linuxserver/rutorrent:latest

--- a/compose/.apps/sabnzbd/sabnzbd.armv7l.yml
+++ b/compose/.apps/sabnzbd/sabnzbd.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  sabnzbd:
-    image: lscr.io/linuxserver/sabnzbd:latest

--- a/compose/.apps/samba/samba.armv7l.yml
+++ b/compose/.apps/samba/samba.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  samba:
-    image: dperson/samba:armhf

--- a/compose/.apps/sickchill/sickchill.armv7l.yml
+++ b/compose/.apps/sickchill/sickchill.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  sickchill:
-    image: lscr.io/linuxserver/sickchill:latest

--- a/compose/.apps/smokeping/smokeping.armv7l.yml
+++ b/compose/.apps/smokeping/smokeping.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  smokeping:
-    image: lscr.io/linuxserver/smokeping:latest

--- a/compose/.apps/sonarr/sonarr.armv7l.yml
+++ b/compose/.apps/sonarr/sonarr.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  sonarr:
-    image: lscr.io/linuxserver/sonarr:latest

--- a/compose/.apps/speedtest/speedtest.armv7l.yml
+++ b/compose/.apps/speedtest/speedtest.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  speedtest:
-    image: henrywhitaker3/speedtest-tracker:latest-arm

--- a/compose/.apps/swag/swag.armv7l.yml
+++ b/compose/.apps/swag/swag.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  swag:
-    image: lscr.io/linuxserver/swag:latest

--- a/compose/.apps/synclounge/synclounge.armv7l.yml
+++ b/compose/.apps/synclounge/synclounge.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  synclounge:
-    image: lscr.io/linuxserver/synclounge:latest

--- a/compose/.apps/syncthing/syncthing.armv7l.yml
+++ b/compose/.apps/syncthing/syncthing.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  syncthing:
-    image: lscr.io/linuxserver/syncthing:latest

--- a/compose/.apps/tautulli/tautulli.armv7l.yml
+++ b/compose/.apps/tautulli/tautulli.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  tautulli:
-    image: lscr.io/linuxserver/tautulli:latest

--- a/compose/.apps/telegraf/telegraf.armv7l.yml
+++ b/compose/.apps/telegraf/telegraf.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  telegraf:
-    image: telegraf:latest

--- a/compose/.apps/thelounge/thelounge.armv7l.yml
+++ b/compose/.apps/thelounge/thelounge.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  thelounge:
-    image: lscr.io/linuxserver/thelounge:latest

--- a/compose/.apps/timemachine/timemachine.armv7l.yml
+++ b/compose/.apps/timemachine/timemachine.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  timemachine:
-    image: mbentley/timemachine:latest

--- a/compose/.apps/traktarr/traktarr.armv7l.yml
+++ b/compose/.apps/traktarr/traktarr.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  traktarr:
-    image: eafxx/traktarr:latest

--- a/compose/.apps/transmission/transmission.armv7l.yml
+++ b/compose/.apps/transmission/transmission.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  transmission:
-    image: lscr.io/linuxserver/transmission:latest

--- a/compose/.apps/transmissionvpn/transmissionvpn.armv7l.yml
+++ b/compose/.apps/transmissionvpn/transmissionvpn.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  transmissionvpn:
-    image: haugene/transmission-openvpn:latest

--- a/compose/.apps/tvheadend/tvheadend.armv7l.yml
+++ b/compose/.apps/tvheadend/tvheadend.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  tvheadend:
-    image: lscr.io/linuxserver/tvheadend:latest

--- a/compose/.apps/ubooquity/ubooquity.armv7l.yml
+++ b/compose/.apps/ubooquity/ubooquity.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  ubooquity:
-    image: lscr.io/linuxserver/ubooquity:latest

--- a/compose/.apps/unifi/unifi.armv7l.yml
+++ b/compose/.apps/unifi/unifi.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  unifi:
-    image: lscr.io/linuxserver/unifi-controller:latest

--- a/compose/.apps/unificontroller/unificontroller.armv7l.yml
+++ b/compose/.apps/unificontroller/unificontroller.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  unificontroller:
-    image: lscr.io/linuxserver/unifi-controller:latest

--- a/compose/.apps/unpackerr/unpackerr.armv7l.yml
+++ b/compose/.apps/unpackerr/unpackerr.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  unpackerr:
-    image: cr.hotio.dev/hotio/unpackerr:latest

--- a/compose/.apps/uptimekuma/uptimekuma.armv7l.yml
+++ b/compose/.apps/uptimekuma/uptimekuma.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  uptimekuma:
-    image: louislam/uptime-kuma:latest

--- a/compose/.apps/varken/varken.armv7l.yml
+++ b/compose/.apps/varken/varken.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  varken:
-    image: boerderij/varken:latest

--- a/compose/.apps/watchtower/watchtower.aarch64.yml
+++ b/compose/.apps/watchtower/watchtower.aarch64.yml
@@ -1,3 +1,3 @@
 services:
   watchtower:
-    image: ghcr.io/containrrr/watchtower:arm64v8-latest
+    image: ghcr.io/containrrr/watchtower:latest

--- a/compose/.apps/watchtower/watchtower.armv7l.yml
+++ b/compose/.apps/watchtower/watchtower.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  watchtower:
-    image: ghcr.io/containrrr/watchtower:armhf-latest

--- a/compose/.apps/wireguard/wireguard.armv7l.yml
+++ b/compose/.apps/wireguard/wireguard.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  wireguard:
-    image: lscr.io/linuxserver/wireguard:latest

--- a/compose/.apps/xbackbone/xbackbone.armv7l.yml
+++ b/compose/.apps/xbackbone/xbackbone.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  xbackbone:
-    image: ghcr.io/linuxserver/xbackbone:latest

--- a/compose/.apps/yacht/yacht.armv7l.yml
+++ b/compose/.apps/yacht/yacht.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  yacht:
-    image: selfhostedpro/yacht:latest

--- a/compose/.apps/znc/znc.armv7l.yml
+++ b/compose/.apps/znc/znc.armv7l.yml
@@ -1,3 +1,0 @@
-services:
-  znc:
-    image: lscr.io/linuxserver/znc:latest

--- a/docs/basics/available-apps.md
+++ b/docs/basics/available-apps.md
@@ -2,6 +2,6 @@
 
 Please browse the repo here to see which apps are available: [https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps)
 
-If an app folder exists then it is available for x86_64. Inside the folder will be files for ARMHF and AARCH64 if they are supported.
+If an app folder exists then it is available for x86_64. Inside the folder will be files for aarch64 if supported.
 
 You can see descriptions of each app in the GUI or in the labels yml file for each app in the repository.

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -30,7 +30,7 @@ Any operating system based on one of the above (ex: Raspbian) should also work a
 
 ### Supported Hardware
 
-Any `x86_64`, `armv7l`, or `aarch64` system should be able to run one of the supported operating systems listed above. ARM CPUs may have a limited selection of supported containers.
+Any `x86_64` or `aarch64` system should be able to run one of the supported operating systems listed above. ARM CPUs may have a limited selection of supported containers.
 
 ### Windows Support
 

--- a/main.sh
+++ b/main.sh
@@ -298,7 +298,7 @@ export DETECTED_HOMEDIR
 
 # Check for supported CPU architecture
 check_arch() {
-    if [[ ${ARCH} != "aarch64" ]] && [[ ${ARCH} != "armv7l" ]] && [[ ${ARCH} != "x86_64" ]]; then
+    if [[ ${ARCH} != "aarch64" ]] && [[ ${ARCH} != "x86_64" ]]; then
         fatal "Unsupported architecture."
     fi
 }


### PR DESCRIPTION
Signed-off-by: Eric Nemchik <eric@nemchik.com>

# Pull request

**Purpose**
LSIO has deprecated armhf. LSIO makes up the majority of the images in DS.

**Approach**
Remove armhf yaml files and adjust bash arch check to only support x86_64 and aarch64

**Learning**
https://www.linuxserver.io/blog/a-farewell-to-arm-hf

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
