### PR TITLE
Add apprise_tag to apprise.labels.yml

### DIFF
--- a/compose/.apps/apprise/apprise.labels.yml
+++ b/compose/.apps/apprise/apprise.labels.yml
@@ -7,3 +7,4 @@ services:
       com.dockstarter.appvars.apprise_enabled: "false"
       com.dockstarter.appvars.apprise_network_mode: ""
       com.dockstarter.appvars.apprise_port_8000: "8000"
+      com.dockstarter.appvars.apprise_tag: "latest"

--- a/compose/.apps/apprise/apprise.labels.yml
+++ b/compose/.apps/apprise/apprise.labels.yml
@@ -7,4 +7,5 @@ services:
       com.dockstarter.appvars.apprise_enabled: "false"
       com.dockstarter.appvars.apprise_network_mode: ""
       com.dockstarter.appvars.apprise_port_8000: "8000"
+      com.dockstarter.appvars.apprise_restart: "unless-stopped"
       com.dockstarter.appvars.apprise_tag: "latest"

--- a/compose/.apps/apprise/apprise.yml
+++ b/compose/.apps/apprise/apprise.yml
@@ -10,7 +10,7 @@ services:
       options:
         max-file: ${DOCKERLOGGING_MAXFILE}
         max-size: ${DOCKERLOGGING_MAXSIZE}
-    restart: unless-stopped
+    restart: ${APPRISE_RESTART}
     volumes:
       - /etc/localtime:/etc/localtime:ro
       - ${DOCKERCONFDIR}/apprise:/config


### PR DESCRIPTION
# Pull request

**Purpose**
Seems to fix https://github.com/GhostWriters/DockSTARTer/issues/1679

**Approach**
How does this change address the problem?

**Learning**
I saw that [other containers had this tag](https://github.com/GhostWriters/DockSTARTer/blob/master/compose/.apps/amd/amd.labels.yml#L29C7-L29C48) but Apprise did not

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
