### PR TITLE
Fix default value of quasselweb https

### DIFF
--- a/compose/.apps/quasselweb/quasselweb.labels.yml
+++ b/compose/.apps/quasselweb/quasselweb.labels.yml
@@ -9,7 +9,7 @@ services:
       com.dockstarter.appvars.quasselweb_port_64080: "64080"
       com.dockstarter.appvars.quasselweb_port_64443: "64443"
       com.dockstarter.appvars.quasselweb_quassel_core: "quasselcore"
-      com.dockstarter.appvars.quasselweb_quassel_https: "false"
+      com.dockstarter.appvars.quasselweb_quassel_https: ""
       com.dockstarter.appvars.quasselweb_quassel_port: "4242"
       com.dockstarter.appvars.quasselweb_restart: "unless-stopped"
       com.dockstarter.appvars.quasselweb_tag: "latest"


### PR DESCRIPTION
# Pull request

**Purpose**
LSIO quassel-web container checks that `QUASSEL_HTTPS` env
var has non-zero length, not explicit `true` or `false` values. The default
value of this env var was incorrectly set to `false` when adding support
for it to DockSTARTer.

**Approach**
Change the default value to an empty string.

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [x] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
