### PR TITLE
Added some info for the docs on how to access WebUI

### DIFF
--- a/docs/apps/qbittorrent.md
+++ b/docs/apps/qbittorrent.md
@@ -20,9 +20,9 @@ you need assistance setting up this application please visit our
 
 qBittorrent randomly generates a password for the WebUI login at startup until
 one has been set by the user. This means when you first setup the container you
-wont be able to access WebUI until you find out the randomly generated password
+wont be able to access WebUI until you find out the randomly generated password.
 The simplest way to see this password is to read the output of the startup 
-message. To do this, you will need two shells, suchas two SSH sessions or if you
+message. To do this, you will need two shells, such as two SSH sessions or if you
 are accessing the machine directly a multiplexer such as ``tmux`` would work.
 
 In the first shell, run ``sudo docker attach qbittorrent``. This is will print
@@ -31,7 +31,7 @@ any output of the container to this shell.
 In the second shell, run ``sudo docker exec -it qbittorrent sh``. This will open
 a shell inside the container, allowing you to run commands directly inside the
 container. Run ``pgrep qbittorrent-nox`` which will print the process id for
-qBittorrent running in the container and then ``kill <PID>`` where <PID> is the
+qBittorrent running in the container and then ``kill <PID>`` where \<PID> is the
 number returned by ``pgrep``. Dont worry about having to restart qBittorrent,
 as Docker will automatically restart the process as soon as you kill it. 
 

--- a/docs/apps/qbittorrent.md
+++ b/docs/apps/qbittorrent.md
@@ -15,3 +15,28 @@ toolkit and libtorrent-rasterbar library.
 This application does not have any specific setup instructions documented. If
 you need assistance setting up this application please visit our
 [support page](https://dockstarter.com/basics/support/).
+
+## Accessing WebUI
+
+qBittorrent randomly generates a password for the WebUI login at startup until
+one has been set by the user. This means when you first setup the container you
+wont be able to access WebUI until you find out the randomly generated password
+The simplest way to see this password is to read the output of the startup 
+message. To do this, you will need two shells, suchas two SSH sessions or if you
+are accessing the machine directly a multiplexer such as ``tmux`` would work.
+
+In the first shell, run ``sudo docker attach qbittorrent``. This is will print
+any output of the container to this shell.
+
+In the second shell, run ``sudo docker exec -it qbittorrent sh``. This will open
+a shell inside the container, allowing you to run commands directly inside the
+container. Run ``pgrep qbittorrent-nox`` which will print the process id for
+qBittorrent running in the container and then ``kill <PID>`` where <PID> is the
+number returned by ``pgrep``. Dont worry about having to restart qBittorrent,
+as Docker will automatically restart the process as soon as you kill it. 
+
+Now in the first shell you should see the startup output printed out. In that
+output will be the username and password you can use to access WebUI. Once you
+have successfully logged in you can set your own username and password in the
+settings menu.
+


### PR DESCRIPTION
# Pull request

**Purpose**
qBittorrent randomly generates a password for WebUI which is only printed to stdout upon startup. This may pose an impediment to some users.

**Approach**
Added documentation to guide users on how to successfully access WebUI

**Learning**
Own research

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
