### PR TITLE
Make DockStarter work with CoreOS (immutable filesystem, no traditional package manager)

### DIFF
--- a/.scripts/package_manager_run.sh
+++ b/.scripts/package_manager_run.sh
@@ -26,6 +26,11 @@ package_manager_run() {
             fi
         done
 
+        if [[ "$(docker compose 2>&1)" == *"docker: 'compose' is not a docker command."* ]]; then
+            fatal "The 'docker compose' command is not functional. Follow the directions at https://docs.docker.com/compose/install/linux/ to install compose."
+        fi
+
+
     fi
 }
 

--- a/.scripts/package_manager_run.sh
+++ b/.scripts/package_manager_run.sh
@@ -12,7 +12,7 @@ package_manager_run() {
         run_script "pm_pacman_${ACTION}"
     elif [[ -n "$(command -v yum)" ]]; then
         run_script "pm_yum_${ACTION}"
-    elif [[ "${ACTION}" == "install" ]]; then
+    elif [[ ${ACTION} == "install" ]]; then
         # We might not need a supported package manager at all if the dependencies are there already. Let's validate that.
 
         # Define an array of commands

--- a/.scripts/package_manager_run.sh
+++ b/.scripts/package_manager_run.sh
@@ -14,7 +14,7 @@ package_manager_run() {
         run_script "pm_yum_${ACTION}"
     else
         # We might not need a supported package manager at all if the dependencies are there already. Let's validate that.
-        echo "Supported package manager not detected. Checking for dependencies ..."
+
         # Define an array of commands
         commands=("curl" "docker" "docker-compose" "git" "grep" "sed" "whiptail")
 
@@ -26,7 +26,6 @@ package_manager_run() {
             fi
         done
 
-        echo "All commands are available."
     fi
 }
 

--- a/.scripts/package_manager_run.sh
+++ b/.scripts/package_manager_run.sh
@@ -16,7 +16,7 @@ package_manager_run() {
         # We might not need a supported package manager at all if the dependencies are there already. Let's validate that.
 
         # Define an array of commands
-        commands=("curl" "docker" "git" "grep" "sed" "whiptail")
+        commands=("curl" "git" "grep" "sed" "whiptail")
 
         # Iterate over each command in the array
         for cmd in "${commands[@]}"; do
@@ -25,7 +25,13 @@ package_manager_run() {
                 fatal "Error: '$cmd' is not available. Exiting..."
             fi
         done
+    elif [[ ${ACTION} == "install_docker" ]]; then
+        # Check for the presence of the docker command
+        if ! command -v "docker" &> /dev/null; then
+            fatal "Error: 'docker' is not available. Exiting..."
+        fi
 
+        # If docker warns that compose is not a docker command when we call it, we alert the user they need to take action.
         if [[ "$(docker compose 2>&1)" == *"docker: 'compose' is not a docker command."* ]]; then
             fatal "The 'docker compose' command is not functional. Follow the directions at https://docs.docker.com/compose/install/linux/ to install compose."
         fi

--- a/.scripts/package_manager_run.sh
+++ b/.scripts/package_manager_run.sh
@@ -32,7 +32,7 @@ package_manager_run() {
         fi
 
         # If docker warns that compose is not a docker command when we call it, we alert the user they need to take action.
-        if [[ "$(docker compose 2>&1)" == *"docker: 'compose' is not a docker command."* ]]; then
+        if ! docker compose version > /dev/null 2>&1; then
             fatal "The 'docker compose' command is not functional. Follow the directions at https://docs.docker.com/compose/install/linux/ to install compose."
         fi
     fi

--- a/.scripts/package_manager_run.sh
+++ b/.scripts/package_manager_run.sh
@@ -13,7 +13,20 @@ package_manager_run() {
     elif [[ -n "$(command -v yum)" ]]; then
         run_script "pm_yum_${ACTION}"
     else
-        fatal "Supported package manager not detected!"
+        # We might not need a supported package manager at all if the dependencies are there already. Let's validate that.
+        echo "Supported package manager not detected. Checking for dependencies ..."
+        # Define an array of commands
+        commands=("curl" "docker" "docker-compose" "git" "grep" "sed" "whiptail")
+        
+        # Iterate over each command in the array
+        for cmd in "${commands[@]}"; do
+            # Check if the command is available in the system
+            if ! command -v "$cmd" &> /dev/null; then
+                fatal "Error: '$cmd' is not available. Exiting..."
+            fi
+        done
+        
+        echo "All commands are available."
     fi
 }
 

--- a/.scripts/package_manager_run.sh
+++ b/.scripts/package_manager_run.sh
@@ -29,8 +29,6 @@ package_manager_run() {
         if [[ "$(docker compose 2>&1)" == *"docker: 'compose' is not a docker command."* ]]; then
             fatal "The 'docker compose' command is not functional. Follow the directions at https://docs.docker.com/compose/install/linux/ to install compose."
         fi
-
-
     fi
 }
 

--- a/.scripts/package_manager_run.sh
+++ b/.scripts/package_manager_run.sh
@@ -17,7 +17,7 @@ package_manager_run() {
         echo "Supported package manager not detected. Checking for dependencies ..."
         # Define an array of commands
         commands=("curl" "docker" "docker-compose" "git" "grep" "sed" "whiptail")
-        
+
         # Iterate over each command in the array
         for cmd in "${commands[@]}"; do
             # Check if the command is available in the system
@@ -25,7 +25,7 @@ package_manager_run() {
                 fatal "Error: '$cmd' is not available. Exiting..."
             fi
         done
-        
+
         echo "All commands are available."
     fi
 }

--- a/.scripts/package_manager_run.sh
+++ b/.scripts/package_manager_run.sh
@@ -12,11 +12,11 @@ package_manager_run() {
         run_script "pm_pacman_${ACTION}"
     elif [[ -n "$(command -v yum)" ]]; then
         run_script "pm_yum_${ACTION}"
-    else
+    elif [[ "${ACTION}" == "install" ]]; then
         # We might not need a supported package manager at all if the dependencies are there already. Let's validate that.
 
         # Define an array of commands
-        commands=("curl" "docker" "docker-compose" "git" "grep" "sed" "whiptail")
+        commands=("curl" "docker" "git" "grep" "sed" "whiptail")
 
         # Iterate over each command in the array
         for cmd in "${commands[@]}"; do

--- a/.scripts/symlink_ds.sh
+++ b/.scripts/symlink_ds.sh
@@ -16,7 +16,7 @@ symlink_ds() {
     fi
 
     for DS_SYMLINK_TARGET in "${DS_SYMLINK_TARGETS[@]}"; do
-        if [[ -L ${DS_SYMLINK_TARGET} ]] && [[ ${SCRIPTNAME} != "$(readlink -f "${target}")" ]]; then
+        if [[ -L ${DS_SYMLINK_TARGET} ]] && [[ ${SCRIPTNAME} != "$(readlink -f "${DS_SYMLINK_TARGET}")" ]]; then
             info "Attempting to remove ${DS_SYMLINK_TARGET} symlink."
             sudo rm -f "${DS_SYMLINK_TARGET}" || fatal "Failed to remove file.\nFailing command: ${F[C]}sudo rm -f \"${DS_SYMLINK_TARGET}\""
         fi

--- a/.scripts/symlink_ds.sh
+++ b/.scripts/symlink_ds.sh
@@ -10,19 +10,19 @@ symlink_ds() {
             warn "Read only /usr filesystem detected. Symlinks will be created in $HOME/bin. You will need to add this to your path."
         fi
         mkdir -p "$HOME/bin" # Make sure the path exists.
-        ds_symlink_targets=("HOME/bin")
+        DS_SYMLINK_TARGETS=("HOME/bin")
     else
-        ds_symlink_targets=("/usr/bin/ds" "/usr/local/bin/ds")
+        DS_SYMLINK_TARGETS=("/usr/bin/ds" "/usr/local/bin/ds")
     fi
 
-    for target in "${ds_symlink_targets[@]}"; do
-        if [[ -L ${target} ]] && [[ ${SCRIPTNAME} != "$(readlink -f "${target}")" ]]; then
-            info "Attempting to remove ${target} symlink."
-            sudo rm -f "${target}" || fatal "Failed to remove file. Failing command: sudo rm -f \"${target}\""
+    for DS_SYMLINK_TARGET in "${DS_SYMLINK_TARGETS[@]}"; do
+        if [[ -L ${DS_SYMLINK_TARGET} ]] && [[ ${SCRIPTNAME} != "$(readlink -f "${target}")" ]]; then
+            info "Attempting to remove ${DS_SYMLINK_TARGET} symlink."
+            sudo rm -f "${target}" || fatal "Failed to remove file.\nFailing command: ${F[C]}sudo rm -f \"${target}\""
         fi
         if [[ ! -L ${target} ]]; then
             info "Creating ${target} symbolic link for DockSTARTer."
-            sudo ln -s -T "${SCRIPTNAME}" "${target}" || fatal "Failed to create symlink. Failing command: sudo ln -s -T \"${SCRIPTNAME}\" \"${target}\""
+            sudo ln -s -T "${SCRIPTNAME}" "${target}" || fatal "Failed to create symlink.\nFailing command: ${F[C]}sudo ln -s -T \"${SCRIPTNAME}\" \"${target}\""
         fi
     done
 }

--- a/.scripts/symlink_ds.sh
+++ b/.scripts/symlink_ds.sh
@@ -18,11 +18,11 @@ symlink_ds() {
     for DS_SYMLINK_TARGET in "${DS_SYMLINK_TARGETS[@]}"; do
         if [[ -L ${DS_SYMLINK_TARGET} ]] && [[ ${SCRIPTNAME} != "$(readlink -f "${target}")" ]]; then
             info "Attempting to remove ${DS_SYMLINK_TARGET} symlink."
-            sudo rm -f "${target}" || fatal "Failed to remove file.\nFailing command: ${F[C]}sudo rm -f \"${target}\""
+            sudo rm -f "${DS_SYMLINK_TARGET}" || fatal "Failed to remove file.\nFailing command: ${F[C]}sudo rm -f \"${DS_SYMLINK_TARGET}\""
         fi
-        if [[ ! -L ${target} ]]; then
-            info "Creating ${target} symbolic link for DockSTARTer."
-            sudo ln -s -T "${SCRIPTNAME}" "${target}" || fatal "Failed to create symlink.\nFailing command: ${F[C]}sudo ln -s -T \"${SCRIPTNAME}\" \"${target}\""
+        if [[ ! -L ${DS_SYMLINK_TARGET} ]]; then
+            info "Creating ${DS_SYMLINK_TARGET} symbolic link for DockSTARTer."
+            sudo ln -s -T "${SCRIPTNAME}" "${DS_SYMLINK_TARGET}" || fatal "Failed to create symlink.\nFailing command: ${F[C]}sudo ln -s -T \"${SCRIPTNAME}\" \"${DS_SYMLINK_TARGET}\""
         fi
     done
 }

--- a/.scripts/symlink_ds.sh
+++ b/.scripts/symlink_ds.sh
@@ -6,8 +6,9 @@ symlink_ds() {
     run_script 'set_permissions' "${SCRIPTNAME}"
 
     if findmnt -n /usr | grep "ro"; then
-        echo "Read only /usr filesystem detected. Symlinks will be created in $HOME/bin instead."
-         # $HOME/bin/ds
+        echo "Read only /usr filesystem detected. Symlinks will be created in $HOME/bin instead. You will need to add this to your path."
+        mkdir -p $HOME/bin # Make sure the path exists.
+        # $HOME/bin/ds
         if [[ -L "$HOME/bin/ds" ]] && [[ ${SCRIPTNAME} != "$(readlink -f $HOME/bin/ds)" ]]; then
             info "Attempting to remove $HOME/bin/ds symlink."
             sudo rm -f "$HOME/bin/ds" || fatal "Failed to remove file.\nFailing command: ${F[C]}sudo rm -f \"$HOME/bin/ds\""

--- a/.scripts/symlink_ds.sh
+++ b/.scripts/symlink_ds.sh
@@ -10,7 +10,7 @@ symlink_ds() {
             warn "Read only /usr filesystem detected. Symlinks will be created in $HOME/bin. You will need to add this to your path."
         fi
         mkdir -p "$HOME/bin" # Make sure the path exists.
-        DS_SYMLINK_TARGETS=("HOME/bin")
+        DS_SYMLINK_TARGETS=("$HOME/bin")
     else
         DS_SYMLINK_TARGETS=("/usr/bin/ds" "/usr/local/bin/ds")
     fi

--- a/.scripts/symlink_ds.sh
+++ b/.scripts/symlink_ds.sh
@@ -5,25 +5,39 @@ IFS=$'\n\t'
 symlink_ds() {
     run_script 'set_permissions' "${SCRIPTNAME}"
 
-    # /usr/bin/ds
-    if [[ -L "/usr/bin/ds" ]] && [[ ${SCRIPTNAME} != "$(readlink -f /usr/bin/ds)" ]]; then
-        info "Attempting to remove /usr/bin/ds symlink."
-        sudo rm -f "/usr/bin/ds" || fatal "Failed to remove file.\nFailing command: ${F[C]}sudo rm -f \"/usr/bin/ds\""
-    fi
-    if [[ ! -L "/usr/bin/ds" ]]; then
-        info "Creating /usr/bin/ds symbolic link for DockSTARTer."
-        sudo ln -s -T "${SCRIPTNAME}" /usr/bin/ds || fatal "Failed to create symlink.\nFailing command: ${F[C]}sudo ln -s -T \"${SCRIPTNAME}\" /usr/bin/ds"
+    if findmnt -n /usr | egrep "^ro,|,ro,|,ro$"; then
+        echo "Read only /usr filesystem detected. Symlinks will be created in $HOME/bin instead."
+         # $HOME/bin/ds
+        if [[ -L "$HOME/bin/ds" ]] && [[ ${SCRIPTNAME} != "$(readlink -f $HOME/bin/ds)" ]]; then
+            info "Attempting to remove $HOME/bin/ds symlink."
+            sudo rm -f "$HOME/bin/ds" || fatal "Failed to remove file.\nFailing command: ${F[C]}sudo rm -f \"$HOME/bin/ds\""
+        fi
+        if [[ ! -L "$HOME/bin/ds" ]]; then
+            info "Creating $HOME/bin/ds symbolic link for DockSTARTer."
+            sudo ln -s -T "${SCRIPTNAME}" /usr/bin/ds || fatal "Failed to create symlink.\nFailing command: ${F[C]}sudo ln -s -T \"${SCRIPTNAME}\" $HOME/bin/ds"
+        fi
+    else
+        # /usr/bin/ds
+        if [[ -L "/usr/bin/ds" ]] && [[ ${SCRIPTNAME} != "$(readlink -f /usr/bin/ds)" ]]; then
+            info "Attempting to remove /usr/bin/ds symlink."
+            sudo rm -f "/usr/bin/ds" || fatal "Failed to remove file.\nFailing command: ${F[C]}sudo rm -f \"/usr/bin/ds\""
+        fi
+        if [[ ! -L "/usr/bin/ds" ]]; then
+            info "Creating /usr/bin/ds symbolic link for DockSTARTer."
+            sudo ln -s -T "${SCRIPTNAME}" /usr/bin/ds || fatal "Failed to create symlink.\nFailing command: ${F[C]}sudo ln -s -T \"${SCRIPTNAME}\" /usr/bin/ds"
+        fi
+    
+        # /usr/local/bin/ds
+        if [[ -L "/usr/local/bin/ds" ]] && [[ ${SCRIPTNAME} != "$(readlink -f /usr/local/bin/ds)" ]]; then
+            info "Attempting to remove /usr/local/bin/ds symlink."
+            sudo rm -f "/usr/local/bin/ds" || fatal "Failed to remove file.\nFailing command: ${F[C]}sudo rm -f \"/usr/local/bin/ds\""
+        fi
+        if [[ ! -L "/usr/local/bin/ds" ]]; then
+            info "Creating /usr/local/bin/ds symbolic link for DockSTARTer."
+            sudo ln -s -T "${SCRIPTNAME}" /usr/local/bin/ds || fatal "Failed to create symlink.\nFailing command: ${F[C]}sudo ln -s -T \"${SCRIPTNAME}\" /usr/local/bin/ds"
+        fi
     fi
 
-    # /usr/local/bin/ds
-    if [[ -L "/usr/local/bin/ds" ]] && [[ ${SCRIPTNAME} != "$(readlink -f /usr/local/bin/ds)" ]]; then
-        info "Attempting to remove /usr/local/bin/ds symlink."
-        sudo rm -f "/usr/local/bin/ds" || fatal "Failed to remove file.\nFailing command: ${F[C]}sudo rm -f \"/usr/local/bin/ds\""
-    fi
-    if [[ ! -L "/usr/local/bin/ds" ]]; then
-        info "Creating /usr/local/bin/ds symbolic link for DockSTARTer."
-        sudo ln -s -T "${SCRIPTNAME}" /usr/local/bin/ds || fatal "Failed to create symlink.\nFailing command: ${F[C]}sudo ln -s -T \"${SCRIPTNAME}\" /usr/local/bin/ds"
-    fi
 }
 
 test_symlink_ds() {

--- a/.scripts/symlink_ds.sh
+++ b/.scripts/symlink_ds.sh
@@ -27,7 +27,7 @@ symlink_ds() {
             info "Creating /usr/bin/ds symbolic link for DockSTARTer."
             sudo ln -s -T "${SCRIPTNAME}" /usr/bin/ds || fatal "Failed to create symlink.\nFailing command: ${F[C]}sudo ln -s -T \"${SCRIPTNAME}\" /usr/bin/ds"
         fi
-    
+
         # /usr/local/bin/ds
         if [[ -L "/usr/local/bin/ds" ]] && [[ ${SCRIPTNAME} != "$(readlink -f /usr/local/bin/ds)" ]]; then
             info "Attempting to remove /usr/local/bin/ds symlink."

--- a/.scripts/symlink_ds.sh
+++ b/.scripts/symlink_ds.sh
@@ -5,7 +5,7 @@ IFS=$'\n\t'
 symlink_ds() {
     run_script 'set_permissions' "${SCRIPTNAME}"
 
-    if findmnt -n /usr | egrep "^ro,|,ro,|,ro$"; then
+    if findmnt -n /usr | grep "ro"; then
         echo "Read only /usr filesystem detected. Symlinks will be created in $HOME/bin instead."
          # $HOME/bin/ds
         if [[ -L "$HOME/bin/ds" ]] && [[ ${SCRIPTNAME} != "$(readlink -f $HOME/bin/ds)" ]]; then
@@ -14,7 +14,7 @@ symlink_ds() {
         fi
         if [[ ! -L "$HOME/bin/ds" ]]; then
             info "Creating $HOME/bin/ds symbolic link for DockSTARTer."
-            sudo ln -s -T "${SCRIPTNAME}" /usr/bin/ds || fatal "Failed to create symlink.\nFailing command: ${F[C]}sudo ln -s -T \"${SCRIPTNAME}\" $HOME/bin/ds"
+            sudo ln -s -T "${SCRIPTNAME}" $HOME/bin/ds || fatal "Failed to create symlink.\nFailing command: ${F[C]}sudo ln -s -T \"${SCRIPTNAME}\" $HOME/bin/ds"
         fi
     else
         # /usr/bin/ds

--- a/.scripts/symlink_ds.sh
+++ b/.scripts/symlink_ds.sh
@@ -6,7 +6,7 @@ symlink_ds() {
     run_script 'set_permissions' "${SCRIPTNAME}"
 
     if findmnt -n /usr | grep "ro" > /dev/null; then
-        if [[ "$PATH" != *"$HOME/bin"* ]]; then
+        if [[ $PATH != *"$HOME/bin"* ]]; then
             warn "Read only /usr filesystem detected. Symlinks will be created in $HOME/bin. You will need to add this to your path."
         fi
         mkdir -p "$HOME/bin" # Make sure the path exists.
@@ -16,11 +16,11 @@ symlink_ds() {
     fi
 
     for target in "${ds_symlink_targets[@]}"; do
-        if [[ -L "${target}" ]] && [[ "${SCRIPTNAME}" != "$(readlink -f "${target}")" ]]; then
+        if [[ -L ${target} ]] && [[ ${SCRIPTNAME} != "$(readlink -f "${target}")" ]]; then
             info "Attempting to remove ${target} symlink."
             sudo rm -f "${target}" || fatal "Failed to remove file. Failing command: sudo rm -f \"${target}\""
         fi
-        if [[ ! -L "${target}" ]]; then
+        if [[ ! -L ${target} ]]; then
             info "Creating ${target} symbolic link for DockSTARTer."
             sudo ln -s -T "${SCRIPTNAME}" "${target}" || fatal "Failed to create symlink. Failing command: sudo ln -s -T \"${SCRIPTNAME}\" \"${target}\""
         fi

--- a/.scripts/symlink_ds.sh
+++ b/.scripts/symlink_ds.sh
@@ -5,7 +5,7 @@ IFS=$'\n\t'
 symlink_ds() {
     run_script 'set_permissions' "${SCRIPTNAME}"
 
-    if findmnt -n /usr | grep "ro" > /dev/null; 
+    if findmnt -n /usr | grep "ro" > /dev/null; then
         if [[ "$PATH" != *"$HOME/bin"* ]]; then
             warn "Read only /usr filesystem detected. Symlinks will be created in $HOME/bin. You will need to add this to your path."
         fi

--- a/.scripts/symlink_ds.sh
+++ b/.scripts/symlink_ds.sh
@@ -7,15 +7,15 @@ symlink_ds() {
 
     if findmnt -n /usr | grep "ro"; then
         echo "Read only /usr filesystem detected. Symlinks will be created in $HOME/bin instead. You will need to add this to your path."
-        mkdir -p $HOME/bin # Make sure the path exists.
+        mkdir -p "$HOME/bin" # Make sure the path exists.
         # $HOME/bin/ds
-        if [[ -L "$HOME/bin/ds" ]] && [[ ${SCRIPTNAME} != "$(readlink -f $HOME/bin/ds)" ]]; then
+        if [[ -L "$HOME/bin/ds" ]] && [[ ${SCRIPTNAME} != "$(readlink -f "$HOME"/bin/ds)" ]]; then
             info "Attempting to remove $HOME/bin/ds symlink."
             sudo rm -f "$HOME/bin/ds" || fatal "Failed to remove file.\nFailing command: ${F[C]}sudo rm -f \"$HOME/bin/ds\""
         fi
         if [[ ! -L "$HOME/bin/ds" ]]; then
             info "Creating $HOME/bin/ds symbolic link for DockSTARTer."
-            sudo ln -s -T "${SCRIPTNAME}" $HOME/bin/ds || fatal "Failed to create symlink.\nFailing command: ${F[C]}sudo ln -s -T \"${SCRIPTNAME}\" $HOME/bin/ds"
+            sudo ln -s -T "${SCRIPTNAME}" "$HOME/bin/ds" || fatal "Failed to create symlink.\nFailing command: ${F[C]}sudo ln -s -T \"${SCRIPTNAME}\" $HOME/bin/ds"
         fi
     else
         # /usr/bin/ds

--- a/.scripts/symlink_ds.sh
+++ b/.scripts/symlink_ds.sh
@@ -5,7 +5,7 @@ IFS=$'\n\t'
 symlink_ds() {
     run_script 'set_permissions' "${SCRIPTNAME}"
 
-    if findmnt -n /usr | grep "ro"; then
+    if findmnt -n /usr | grep "ro" > /dev/null; 
         if [[ "$PATH" != *"$HOME/bin"* ]]; then
             warn "Read only /usr filesystem detected. Symlinks will be created in $HOME/bin. You will need to add this to your path."
         fi


### PR DESCRIPTION
# Pull request

**Purpose**
Closes #1730. 

Tested on [ucore-hci from the Universal Blue project](https://github.com/ublue-os/ucore). Manual workaround needed for docker compose plugin:
```
DOCKER_CONFIG=${DOCKER_CONFIG:-$HOME/.docker}
mkdir -p $DOCKER_CONFIG/cli-plugins
curl -SL https://github.com/docker/compose/releases/download/v2.24.5/docker-compose-linux-x86_64 -o $DOCKER_CONFIG/cli-plugins/docker-compose
chmod +x $DOCKER_CONFIG/cli-plugins/docker-compose
```
I also set SELinux to permissive. After that, it worked perfectly and all my containers spun up. :-)
![image](https://github.com/GhostWriters/DockSTARTer/assets/277927/ed2b9d76-8bdd-4cc8-81fb-6344418c8774)


**Approach**
How does this change address the problem?
* Uses $HOME/bin instead of /usr for the filesystem
* Doesn't fail hard if it detects no supported package manager, instead checking if the commands we need are there.

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [x] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
