### PR TITLE
Fix prometheus app data and config volumes

### DIFF
--- a/compose/.apps/prometheus/prometheus.yml
+++ b/compose/.apps/prometheus/prometheus.yml
@@ -13,5 +13,6 @@ services:
     restart: ${PROMETHEUS_RESTART}
     volumes:
       - /etc/localtime:/etc/localtime:ro
-      - ${DOCKERCONFDIR}/prometheus:/config
+      - ${DOCKERCONFDIR}/prometheus/etc:/etc/prometheus
+      - ${DOCKERCONFDIR}/prometheus/data:/prometheus
       - ${DOCKERSTORAGEDIR}:/storage


### PR DESCRIPTION
# Pull request

**Purpose**
Propose a fix for properly mounting volumes for data and config in the prometheus app ([issue 1777](https://github.com/GhostWriters/DockSTARTer/issues/1777))

**Approach**
Mount configuration to a prometheus folder in `DOCKERCONFDIR`. Data is mounted in a prometheus folder in `DOCKERSTORAGEDIR`.

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
