### PR TITLE
fix: :mute: remove reqs to fix version warning

### DIFF
--- a/.scripts/yml_merge.sh
+++ b/.scripts/yml_merge.sh
@@ -5,10 +5,8 @@ IFS=$'\n\t'
 yml_merge() {
     run_script 'appvars_create_all'
     run_script 'env_update'
-    info "Compiling enabled templates to merge docker-compose.yml file."
     local COMPOSE_FILE=""
-    info "Required files included."
-    notice "Adding compose configurations for enabled apps. Please be patient, this can take a while."
+    notice "Adding enabled app templates to merge docker-compose.yml. Please be patient, this can take a while."
     while IFS= read -r line; do
         local APPNAME=${line%%_ENABLED=*}
         local FILENAME=${APPNAME,,}
@@ -60,7 +58,7 @@ yml_merge() {
         fatal "No enabled apps found."
     fi
     info "Running compose config to create docker-compose.yml file from enabled templates."
-    export COMPOSE_FILE="${COMPOSE_FILE}"
+    export COMPOSE_FILE="${COMPOSE_FILE#:}"
     eval "docker compose --project-directory ${SCRIPTPATH}/compose/ config > ${SCRIPTPATH}/compose/docker-compose.yml" || fatal "Failed to output compose config.\nFailing command: ${F[C]}docker compose --project-directory ${SCRIPTPATH}/compose/ config > \"${SCRIPTPATH}/compose/docker-compose.yml\""
     info "Merging docker-compose.yml complete."
 }

--- a/.scripts/yml_merge.sh
+++ b/.scripts/yml_merge.sh
@@ -6,9 +6,7 @@ yml_merge() {
     run_script 'appvars_create_all'
     run_script 'env_update'
     info "Compiling enabled templates to merge docker-compose.yml file."
-    local COMPOSE_FILE
-    COMPOSE_FILE="${SCRIPTPATH}/compose/.reqs/r1.yml"
-    COMPOSE_FILE="${COMPOSE_FILE}:${SCRIPTPATH}/compose/.reqs/r2.yml"
+    local COMPOSE_FILE=""
     info "Required files included."
     notice "Adding compose configurations for enabled apps. Please be patient, this can take a while."
     while IFS= read -r line; do
@@ -58,6 +56,9 @@ yml_merge() {
             error "${APPTEMPLATES}/ does not exist."
         fi
     done < <(grep --color=never -P '_ENABLED='"'"'?true'"'"'?$' "${COMPOSE_ENV}")
+    if [[ -z ${COMPOSE_FILE} ]]; then
+        fatal "No enabled apps found."
+    fi
     info "Running compose config to create docker-compose.yml file from enabled templates."
     export COMPOSE_FILE="${COMPOSE_FILE}"
     eval "docker compose --project-directory ${SCRIPTPATH}/compose/ config > ${SCRIPTPATH}/compose/docker-compose.yml" || fatal "Failed to output compose config.\nFailing command: ${F[C]}docker compose --project-directory ${SCRIPTPATH}/compose/ config > \"${SCRIPTPATH}/compose/docker-compose.yml\""

--- a/compose/.reqs/r1.yml
+++ b/compose/.reqs/r1.yml
@@ -1,1 +1,0 @@
-version: "https://github.com/compose-spec/compose-spec/blob/master/spec.md"

--- a/compose/.reqs/r2.yml
+++ b/compose/.reqs/r2.yml
@@ -1,1 +1,0 @@
-version: "https://github.com/compose-spec/compose-spec/blob/master/spec.md"

--- a/compose/README.md
+++ b/compose/README.md
@@ -5,7 +5,6 @@
 These should not be modified! `ds -u` will reset these files.
 
 - `.apps` folder contains yml files that are used as templates for DockSTARTer to piece together your main `docker-compose.yml` file
-- `.reqs` folder contains dummy yml files merged to prevent errors
 - `.env.example` file contains the default variables and values for new installs
 
 ## Files generated for your system


### PR DESCRIPTION
# Pull request

**Purpose**
Fix:

> WARN[0000] ~/.docker/compose/.reqs/r2.yml: the attribute version is obsolete, it will be ignored, please remove it to avoid potential confusion

**Approach**
Completely remove the two files in the `.reqs` folder and add an `if` statement to check if no apps were selected. The original intention with those files was just to hand something (anything) to `compose` (and in the past `jq`) so it is able to construct the `docker-compose.yml` file when a user does not have any apps selected to be enabled. Instead this just throws a `fatal`, which would also preserve any pre-existing `docker-compose.yml` file they may have had from a previous run (ex: maybe they just messed up their `.env`, which would probably mean they are not in a working state anyway, so exiting with `fatal` seems appropriate).

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
