### PR TITLE
Fix filebrowser healthcheck

### DIFF
--- a/compose/.apps/filebrowser/filebrowser.yml
+++ b/compose/.apps/filebrowser/filebrowser.yml
@@ -9,7 +9,7 @@ services:
     healthcheck:
       test:
         - CMD-SHELL
-        - curl -fs http://localhost:${FILEBROWSER_PORT_80}/health || exit 1
+        - curl -fs http://localhost:80/health || exit 1
     restart: ${FILEBROWSER_RESTART}
     user: ${PUID}:${PGID}
     volumes:


### PR DESCRIPTION
# Pull request

**Purpose**
File browser healthchecks were always failing due to using the incorrect port.
This was caused by a change where the `FB_PORT` env variable is no longer set.

**Approach**
As the FB_PORT env variable is no longer set, internally, within the container, port 80 is now always used.
So, as health checks run inside the container, the internal port needs to be used and not the host port.

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
