### PR TITLE
Update overseerr.md

### DIFF
--- a/docs/apps/overseerr.md
+++ b/docs/apps/overseerr.md
@@ -1,6 +1,6 @@
 # Overseerr
 
-[![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/overseerr?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](hhttps://hub.docker.com/r/linuxserver/overseerr)
+[![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/overseerr?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/overseerr)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-overseerr?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-overseerr)
 [![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/overseerr)
 


### PR DESCRIPTION
Fixes a typo in the documentation for Overseer to make the Docker Pulls link valid.

# Pull request

**Purpose**
A typo in the documentation for Overseerr made a link non-clickable

**Approach**
Fixes the typo

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

N/A

**Learning**
Describe the research stage
N/A

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
