### PR TITLE
Add LyrionMusicServer/deprecate LogitechMediaServer

### DIFF
--- a/compose/.apps/logitechmediaserver/logitechmediaserver.labels.yml
+++ b/compose/.apps/logitechmediaserver/logitechmediaserver.labels.yml
@@ -1,7 +1,7 @@
 services:
   logitechmediaserver:
     labels:
-      com.dockstarter.appinfo.deprecated: "false"
+      com.dockstarter.appinfo.deprecated: "true"
       com.dockstarter.appinfo.description: "LogitechMediaServer(SqueezeBox)"
       com.dockstarter.appinfo.nicename: "LogitechMediaServer"
       com.dockstarter.appvars.logitechmediaserver_container_name: "logitechmediaserver"

--- a/compose/.apps/lyrionmusicserver/lyrionmusicserver.aarch64.yml
+++ b/compose/.apps/lyrionmusicserver/lyrionmusicserver.aarch64.yml
@@ -1,0 +1,3 @@
+services:
+  lyrionmusicserver:
+    image: lmscommunity/lyrionmusicserver:${LYRIONMUSICSERVER_TAG}

--- a/compose/.apps/lyrionmusicserver/lyrionmusicserver.hostname.yml
+++ b/compose/.apps/lyrionmusicserver/lyrionmusicserver.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  lyrionmusicserver:
+    hostname: ${DOCKER_HOSTNAME}

--- a/compose/.apps/lyrionmusicserver/lyrionmusicserver.labels.yml
+++ b/compose/.apps/lyrionmusicserver/lyrionmusicserver.labels.yml
@@ -1,0 +1,14 @@
+services:
+  lyrionmusicserver:
+    labels:
+      com.dockstarter.appinfo.deprecated: "false"
+      com.dockstarter.appinfo.description: "Lyrion Music Server for Squeezebox radios (formerly LogitechMediaServer)"
+      com.dockstarter.appinfo.nicename: "LyrionMusicServer"
+      com.dockstarter.appvars.lyrionmusicserver_container_name: "lyrionmusicserver"
+      com.dockstarter.appvars.lyrionmusicserver_enabled: "false"
+      com.dockstarter.appvars.lyrionmusicserver_network_mode: ""
+      com.dockstarter.appvars.lyrionmusicserver_port_3483: "3483"
+      com.dockstarter.appvars.lyrionmusicserver_port_9000: "9000"
+      com.dockstarter.appvars.lyrionmusicserver_port_9090: "9090"
+      com.dockstarter.appvars.lyrionmusicserver_restart: "always"
+      com.dockstarter.appvars.lyrionmusicserver_tag: "latest"

--- a/compose/.apps/lyrionmusicserver/lyrionmusicserver.netmode.yml
+++ b/compose/.apps/lyrionmusicserver/lyrionmusicserver.netmode.yml
@@ -1,0 +1,3 @@
+services:
+  lyrionmusicserver:
+    network_mode: ${LYRIONMUSICSERVER_NETWORK_MODE}

--- a/compose/.apps/lyrionmusicserver/lyrionmusicserver.ports.yml
+++ b/compose/.apps/lyrionmusicserver/lyrionmusicserver.ports.yml
@@ -1,0 +1,7 @@
+services:
+  lyrionmusicserver:
+    ports:
+      - ${LYRIONMUSICSERVER_PORT_3483}:3483/tcp
+      - ${LYRIONMUSICSERVER_PORT_3483}:3483/udp
+      - ${LYRIONMUSICSERVER_PORT_9000}:9000/tcp
+      - ${LYRIONMUSICSERVER_PORT_9090}:9090/tcp

--- a/compose/.apps/lyrionmusicserver/lyrionmusicserver.x86_64.yml
+++ b/compose/.apps/lyrionmusicserver/lyrionmusicserver.x86_64.yml
@@ -1,0 +1,3 @@
+services:
+  lyrionmusicserver:
+    image: lmscommunity/lyrionmusicserver:${LYRIONMUSICSERVER_TAG}

--- a/compose/.apps/lyrionmusicserver/lyrionmusicserver.yml
+++ b/compose/.apps/lyrionmusicserver/lyrionmusicserver.yml
@@ -1,0 +1,12 @@
+services:
+  lyrionmusicserver:
+    container_name: ${LYRIONMUSICSERVER_CONTAINER_NAME}
+    environment:
+      - PGID=${PGID}
+      - PUID=${PUID}
+      - TZ=${TZ}
+    restart: ${LYRIONMUSICSERVER_RESTART}
+    volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - ${DOCKER_VOLUME_CONFIG}/lyrionmusicserver:/config:rw
+      - ${DOCKER_VOLUME_STORAGE}:/storage:ro

--- a/docs/apps/lyrionmusicserver.md
+++ b/docs/apps/lyrionmusicserver.md
@@ -1,0 +1,19 @@
+# Logitech Media Server
+
+[![Docker Pulls](https://img.shields.io/docker/pulls/lmscommunity/lyrionmusicserver)](https://hub.docker.com/r/lmscommunity/lyrionmusicserver)
+[![GitHub Repo stars](https://img.shields.io/github/stars/LMS-Community/slimserver)](https://github.com/lms-community/slimserver)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/lyrionmusicserver)
+
+## Description
+
+[Lyrion Music Server](https://github.com/lms-community/slimserver) Lyrion
+Music Server (formerly Logitech Media Server) is open-source server software
+which controls a wide range of Squeezebox audio players. Lyrion can stream
+your local music collection, internet radio stations, and content from many
+streaming services (with and without subscriptions).
+
+## Install/Setup
+
+This application does not have any specific setup instructions documented. If
+you need assistance setting up this application please visit our
+[support page](https://dockstarter.com/basics/support/).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -187,6 +187,7 @@ nav:
       - apps/limnoria.md
       - apps/logarr.md
       - apps/logitechmediaserver.md
+      - apps/lyrionmusicserver.md
       - apps/makemkv.md
       - apps/mariadb.md
       - apps/medusa.md


### PR DESCRIPTION
# Pull request

**Purpose**
Logitech Media Server has been discontinued and has been taken up by the community. They have renamed it as Lyrion Music Server. Dockstarter now has the wrong docker name and it is pulling form the wrong source. Issue: https://github.com/GhostWriters/DockSTARTer/issues/1830

**Approach**
This adds a new app called LyrionMusicServer, along with documentation. It leaves LogitechMediaServer in place, but changes the deprecated flag to "true" in logitechmediaserver.labels.yml

**Open Questions and Pre-Merge TODOs**


**Learning**
Logitech servers shut down about a year ago and the community released new docker images under the original name. Recently they have rebranded to Lyrion. This changed the name of the project, the website, and docker hub container. The github page is still the same name: https://github.com/LMS-Community/slimserver . More information is found here: https://lyrion.org/reference/lyrion-music-server/ As of version 9, the name and container have changed.

**Requirements**
Check all boxes as they are completed

- [ x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [ x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
