### PR TITLE
PiHole additions for v6

### DIFF
--- a/compose/.apps/pihole/pihole.labels.yml
+++ b/compose/.apps/pihole/pihole.labels.yml
@@ -17,3 +17,4 @@ services:
       com.dockstarter.appvars.pihole_port_80: "8008"
       com.dockstarter.appvars.pihole_restart: "unless-stopped"
       com.dockstarter.appvars.pihole_tag: "latest"
+      com.dockstarter.appvars.pihole_environment_ftlconf_misc_etc_dnsmasq_d: "true"

--- a/compose/.apps/pihole/pihole.ports.yml
+++ b/compose/.apps/pihole/pihole.ports.yml
@@ -3,6 +3,6 @@ services:
     ports:
       - ${PIHOLE_PORT_443}:443
       - ${PIHOLE_PORT_80}:80
-      - ${PIHOLE_ENVIRONMENT_SERVERIP}:${PIHOLE_PORT_53}:53
-      - ${PIHOLE_ENVIRONMENT_SERVERIP}:${PIHOLE_PORT_53}:53/udp
-      - ${PIHOLE_ENVIRONMENT_SERVERIP}:${PIHOLE_PORT_67}:67/udp
+      - ${PIHOLE_PORT_53}:53
+      - ${PIHOLE_PORT_53}:53/udp
+      - ${PIHOLE_PORT_67}:67/udp

--- a/compose/.apps/pihole/pihole.yml
+++ b/compose/.apps/pihole/pihole.yml
@@ -3,16 +3,15 @@ services:
     cap_add:
       - NET_ADMIN
     container_name: ${PIHOLE_CONTAINER_NAME}
-    dns:
-      - 127.0.0.1
-      - ${PIHOLE_ENVIRONMENT_DNS1}
-      - ${PIHOLE_ENVIRONMENT_DNS2}
     environment:
       - DNS1=${PIHOLE_ENVIRONMENT_DNS1}
       - DNS2=${PIHOLE_ENVIRONMENT_DNS2}
+      - FTLCONF_dns_upstreams=127.0.0.1;${PIHOLE_ENVIRONMENT_DNS1};${PIHOLE_ENVIRONMENT_DNS2}
       - ServerIP=${PIHOLE_ENVIRONMENT_SERVERIP}
       - TZ=${TZ}
       - WEBPASSWORD=${PIHOLE_ENVIRONMENT_WEBPASSWORD}
+      - FTLCONF_webserver_api_password=${PIHOLE_ENVIRONMENT_WEBPASSWORD}
+      - FTLCONF_misc_etc_dnsmasq_d=${PIHOLE_ENVIRONMENT_FTLCONF_MISC_ETC_DNSMASQ_D}
     restart: ${PIHOLE_RESTART}
     volumes:
       - /etc/localtime:/etc/localtime:ro


### PR DESCRIPTION
# Pull request

**Purpose**
PiHole released version 6 which had significant changes to the environment variables causing the existing DS compose to not work on the new version. 

**Approach**
CLHatch and I discussed this at length on Discord and they wanted DS to be backward compatible for users still on PiHole v5. This approach leaves in variables that are still in use by v5, but also adds new variables needed for v6. Each version uses the variables it needs, and ignores the other variables, allowing this compose to work for both versions.

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- This has been tested by removing the `~/.config/appdata/pihole` directory every time to ensure a clean test. It was tested with 'host' mode, and default (bridge) mode. Tested on versions 5 and 6. Tested as a working DNS server to verify it was handling requests properly. 

**Learning**
PiHole documentation describes the upgrade process for docker from v5 to v6: https://docs.pi-hole.net/docker/upgrading/v5-v6/ All the changes in environment variables are described here, and these are the variables that were used to make the v6 sections work properly.

**Requirements**
Check all boxes as they are completed

- [ x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [ x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
