### PR TITLE
feat: 💥 Add Maintainerr

### DIFF
--- a/compose/.apps/maintainerr/maintainerr.aarch64.yml
+++ b/compose/.apps/maintainerr/maintainerr.aarch64.yml
@@ -1,0 +1,3 @@
+services:
+  maintainerr:
+    image: ghcr.io/jorenn92/maintainerr:${MAINTAINERR_TAG}

--- a/compose/.apps/maintainerr/maintainerr.hostname.yml
+++ b/compose/.apps/maintainerr/maintainerr.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  maintainerr:
+    hostname: ${DOCKER_HOSTNAME}

--- a/compose/.apps/maintainerr/maintainerr.labels.yml
+++ b/compose/.apps/maintainerr/maintainerr.labels.yml
@@ -1,0 +1,12 @@
+services:
+  maintainerr:
+    labels:
+      com.dockstarter.appinfo.deprecated: "false"
+      com.dockstarter.appinfo.description: "Maintenance tool that automatically removes watched media based on user-defined rules to help manage server storage space."
+      com.dockstarter.appinfo.nicename: "Maintainerr"
+      com.dockstarter.appvars.maintainerr_container_name: "maintainerr"
+      com.dockstarter.appvars.maintainerr_enabled: "false"
+      com.dockstarter.appvars.maintainerr_network_mode: ""
+      com.dockstarter.appvars.maintainerr_port_6246: "6246"
+      com.dockstarter.appvars.maintainerr_restart: "unless-stopped"
+      com.dockstarter.appvars.maintainerr_tag: "latest"

--- a/compose/.apps/maintainerr/maintainerr.netmode.yml
+++ b/compose/.apps/maintainerr/maintainerr.netmode.yml
@@ -1,0 +1,3 @@
+services:
+  maintainerr:
+    network_mode: ${MAINTAINERR_NETWORK_MODE}

--- a/compose/.apps/maintainerr/maintainerr.ports.yml
+++ b/compose/.apps/maintainerr/maintainerr.ports.yml
@@ -1,0 +1,4 @@
+services:
+  maintainerr:
+    ports:
+      - ${MAINTAINERR_PORT_6246}:6246

--- a/compose/.apps/maintainerr/maintainerr.x86_64.yml
+++ b/compose/.apps/maintainerr/maintainerr.x86_64.yml
@@ -1,0 +1,3 @@
+services:
+  maintainerr:
+    image: ghcr.io/jorenn92/maintainerr:${MAINTAINERR_TAG}

--- a/compose/.apps/maintainerr/maintainerr.yml
+++ b/compose/.apps/maintainerr/maintainerr.yml
@@ -1,0 +1,11 @@
+services:
+  maintainerr:
+    container_name: ${MAINTAINERR_CONTAINER_NAME}
+    environment:
+      - TZ=${TZ}
+    restart: ${MAINTAINERR_RESTART}
+    user: ${PUID}:${PGID}
+    volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - ${DOCKER_VOLUME_CONFIG}/maintainerr:/opt/data
+      - ${DOCKER_VOLUME_STORAGE}:/storage

--- a/docs/apps/maintainerr.md
+++ b/docs/apps/maintainerr.md
@@ -10,7 +10,24 @@
 
 ## Install/Setup
 
-This application does not have any specific setup instructions documented. If
-you need assistance setting up this application, please visit the official
+When installing the Maintainerr container, it will create its data directory in `appdata` as the root user. If you see errors like:
+
+> Could not create or access (files in) the data directory. Please make sure the necessary permissions are set
+
+You will need to change the ownership of the directory to your user account. To do this, run:
+
+```bash
+sudo chown -R $USER:$USER ~/.config/appdata/Maintainerr
+```
+
+Restart your container by running:
+
+```bash
+docker restart Maintainerr
+```
+
+Setting the correct ownership will let you edit the files as needed and will help ensure the application runs properly, without permission issues.
+
+If you need further assistance setting up this application, please visit the official
 [GitHub repository](https://github.com/jorenn92/Maintainerr) or our
 [support page](https://dockstarter.com/basics/support/).

--- a/docs/apps/maintainerr.md
+++ b/docs/apps/maintainerr.md
@@ -1,0 +1,16 @@
+# Maintainerr
+
+[![Docker Pulls](https://img.shields.io/docker/pulls/jorenn92/maintainerr?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/jorenn92/maintainerr)
+[![GitHub Stars](https://img.shields.io/github/stars/jorenn92/Maintainerr?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/jorenn92/Maintainerr)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/maintainerr)
+
+## Description
+
+[Maintainerr](https://github.com/jorenn92/Maintainerr) is an automated media management tool designed to help users free up storage space on their media servers by identifying and removing unwatched or unwanted content. It integrates with platforms like Plex, Overseerr, Radarr, Sonarr, Jellyseerr, and Tautulli, allowing users to set customizable rules for detecting media that is taking up space but not being used. Maintainerr can automatically create collections of such media, display them on the Plex home screen for a specified period before deletion, and then remove or unmonitor the files from your server. The application aims to simplify server maintenance by automating the cleanup process, making it easy to reclaim disk space without manual intervention.
+
+## Install/Setup
+
+This application does not have any specific setup instructions documented. If
+you need assistance setting up this application, please visit the official
+[GitHub repository](https://github.com/jorenn92/Maintainerr) or our
+[support page](https://dockstarter.com/basics/support/).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -189,7 +189,7 @@ nav:
       - apps/logitechmediaserver.md
       - apps/lyrionmusicserver.md
       - apps/makemkv.md
-      - app/maintainerr.md
+      - apps/maintainerr.md
       - apps/mariadb.md
       - apps/medusa.md
       - apps/minecraftbedrockserver.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -189,6 +189,7 @@ nav:
       - apps/logitechmediaserver.md
       - apps/lyrionmusicserver.md
       - apps/makemkv.md
+      - app/maintainerr.md
       - apps/mariadb.md
       - apps/medusa.md
       - apps/minecraftbedrockserver.md


### PR DESCRIPTION
**Purpose**
This PR adds support for Maintainerr, a library management system that helps Plex administrators save storage by identifying and managing unwatched or unwanted media. Maintainerr creates collections based on user-defined rules and can automatically remove content after a set period, keeping media libraries optimized.

Closes #1823 

GitHub repository: https://github.com/jorenn92/Maintainerr
Documentation: https://docs.maintainerr.info/

**Approach**
I've implemented Maintainerr support in DockSTARTer by:

- Creating the necessary YML configuration files in `/compose/.apps/maintainerr/`
- Adding appropriate environment variables and default settings
- Creating documentation in /docs/apps/maintainerr.md
- Adding the navigation link in mkdocs.yml

The implementation follows the DockSTARTer standards for adding new applications, with proper container configuration, environment variables, and appropriate defaults.

**Learning**
Key technical details:
- Maintainerr uses port 6246 by default
- Data persistence is through a volume at /opt/data in the container

**Requirements**

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
