### PR TITLE
feat: 💥 Add TSDProxy

### DIFF
--- a/compose/.apps/tsdproxy/tsdproxy.aarch64.yml
+++ b/compose/.apps/tsdproxy/tsdproxy.aarch64.yml
@@ -1,0 +1,3 @@
+services:
+  tsdproxy:
+    image: almeidapaulopt/tsdproxy:${TSDPROXY_TAG}

--- a/compose/.apps/tsdproxy/tsdproxy.hostname.yml
+++ b/compose/.apps/tsdproxy/tsdproxy.hostname.yml
@@ -1,0 +1,3 @@
+services:
+  tsdproxy:
+    hostname: ${DOCKER_HOSTNAME}

--- a/compose/.apps/tsdproxy/tsdproxy.labels.yml
+++ b/compose/.apps/tsdproxy/tsdproxy.labels.yml
@@ -10,3 +10,4 @@ services:
       com.dockstarter.appvars.tsdproxy_port_8080: "8080"
       com.dockstarter.appvars.tsdproxy_restart: "unless-stopped"
       com.dockstarter.appvars.tsdproxy_tag: "latest"
+      com.dockstarter.appvars.tsdproxy_volume_docker_socket: "/var/run/docker.sock"

--- a/compose/.apps/tsdproxy/tsdproxy.labels.yml
+++ b/compose/.apps/tsdproxy/tsdproxy.labels.yml
@@ -1,0 +1,12 @@
+services:
+  tsdproxy:
+    labels:
+      com.dockstarter.appinfo.deprecated: "false"
+      com.dockstarter.appinfo.description: "Simplifies the process of securely exposing services and Docker containers to your Tailscale network."
+      com.dockstarter.appinfo.nicename: "TSDProxy"
+      com.dockstarter.appvars.tsdproxy_container_name: "tsdproxy"
+      com.dockstarter.appvars.tsdproxy_enabled: "false"
+      com.dockstarter.appvars.tsdproxy_network_mode: ""
+      com.dockstarter.appvars.tsdproxy_port_8080: "8080"
+      com.dockstarter.appvars.tsdproxy_restart: "unless-stopped"
+      com.dockstarter.appvars.tsdproxy_tag: "latest"

--- a/compose/.apps/tsdproxy/tsdproxy.netmode.yml
+++ b/compose/.apps/tsdproxy/tsdproxy.netmode.yml
@@ -1,0 +1,3 @@
+services:
+  tsdproxy:
+    network_mode: ${TSDPROXY_NETWORK_MODE}

--- a/compose/.apps/tsdproxy/tsdproxy.ports.yml
+++ b/compose/.apps/tsdproxy/tsdproxy.ports.yml
@@ -1,0 +1,4 @@
+services:
+  tsdproxy:
+    ports:
+      - ${TSDPROXY_PORT_8080}:8080

--- a/compose/.apps/tsdproxy/tsdproxy.x86_64.yml
+++ b/compose/.apps/tsdproxy/tsdproxy.x86_64.yml
@@ -1,0 +1,3 @@
+services:
+  tsdproxy:
+    image: almeidapaulopt/tsdproxy:${TSDPROXY_TAG}

--- a/compose/.apps/tsdproxy/tsdproxy.yml
+++ b/compose/.apps/tsdproxy/tsdproxy.yml
@@ -1,0 +1,11 @@
+services:
+  tsdproxy:
+    container_name: ${TSDPROXY_CONTAINER_NAME}
+    environment:
+      - TZ=${TZ}
+    restart: ${TSDPROXY_RESTART}
+    volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ${DOCKER_VOLUME_CONFIG}/tsdproxy:/data
+      - ${DOCKER_VOLUME_STORAGE}:/storage

--- a/compose/.apps/tsdproxy/tsdproxy.yml
+++ b/compose/.apps/tsdproxy/tsdproxy.yml
@@ -6,6 +6,6 @@ services:
     restart: ${TSDPROXY_RESTART}
     volumes:
       - /etc/localtime:/etc/localtime:ro
-      - /var/run/docker.sock:/var/run/docker.sock
       - ${DOCKER_VOLUME_CONFIG}/tsdproxy:/data
       - ${DOCKER_VOLUME_STORAGE}:/storage
+      - ${TSDPROXY_VOLUME_DOCKER_SOCKET}:/var/run/docker.sock

--- a/docs/apps/tsdproxy.md
+++ b/docs/apps/tsdproxy.md
@@ -1,0 +1,17 @@
+# TSDProxy
+
+[![Docker Pulls](https://img.shields.io/docker/pulls/almeidapaulopt/tsdproxy?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/almeidapaulopt/tsdproxy)
+[![GitHub Stars](https://img.shields.io/github/stars/almeidapaulopt/tsdproxy?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/almeidapaulopt/tsdproxy)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/TSDProxy)
+
+## Description
+
+[TSDProxy](https://almeidapaulopt.github.io/tsdproxy) is an application that automatically creates a proxy to virtual addresses in your Tailscale network. Easy to configure and deploy, based on Docker container labels or a simple proxy list file. It simplifies traffic redirection to services running inside Docker containers, without the need for a separate Tailscale container for each service.
+
+## Install/Setup
+
+Ensure [Tailscale](https://tailscale.com) is installed and configured on your host machine.
+
+If you need further assistance setting up this application, please visit the official
+[GitHub repository](https://github.com/almeidapaulopt/tsdproxy) or our
+[support page](https://dockstarter.com/basics/support).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -261,6 +261,7 @@ nav:
       - apps/traktarr.md
       - apps/transmission.md
       - apps/transmissionvpn.md
+      - apps/tsdproxy.md
       - apps/tvheadend.md
       - apps/ubooquity.md
       - apps/unificontroller.md


### PR DESCRIPTION
**Purpose**
This PR adds support for TSDProxy, an application that automatically creates a proxy to virtual addresses in your Tailscale network. Easy to configure and deploy, based on Docker container labels or a simple proxy list file. It simplifies traffic redirection to services running inside Docker containers, without the need for a separate Tailscale container for each service.

Closes #1855 

GitHub repository: https://github.com/almeidapaulopt/tsdproxy
Documentation: https://almeidapaulopt.github.io/tsdproxy

**Approach**
I've implemented TSDProxy support in DockSTARTer by:

- Creating the necessary YML configuration files in `/compose/.apps/tsdproxy/`
- Adding appropriate environment variables and default settings
- Creating documentation in /docs/apps/tsdproxy.md
- Adding the navigation link in mkdocs.yml

The implementation follows the DockSTARTer standards for adding new applications, with proper container configuration, environment variables, and appropriate defaults.

**Learning**
Key technical details:
- TSDProxy uses port 8080 by default
- Data persistence is through a volume at /data in the container

**Requirements**

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).