### PR TITLE
🐛 fix(autobrr): correct PUID:PGID order in environment variable

### DIFF
--- a/compose/.apps/autobrr/autobrr.yml
+++ b/compose/.apps/autobrr/autobrr.yml
@@ -4,7 +4,7 @@ services:
     environment:
       - TZ=${TZ}
     restart: ${AUTOBRR_RESTART}
-    user: ${PGID}:${PUID}
+    user: ${PUID}:${PGID}
     volumes:
       - /etc/localtime:/etc/localtime:ro
       - ${DOCKER_VOLUME_CONFIG}/autobrr:/config


### PR DESCRIPTION
# Pull request

**Purpose**
This pull request includes a small fix in the `compose/.apps/autobrr/autobrr.yml` file. The change corrects the order of the `user` environment variable values, swapping `${PGID}:${PUID}` to `${PUID}:${PGID}` to align with the expected format.

**Learning**
The change aligns with Docker's standardised user format which follows the Linux convention of `user:group` (UID). As specified in Docker's official documentation for the --user flag (https://docs.docker.com/engine/reference/run/#user), the format should be `"user:group"` which translates to `${PUID}:${PGID}` in our environment variables.

**Requirements**
- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).