### PR TITLE
Update menu_config_vars.sh

### DIFF
--- a/.scripts/menu_config_vars.sh
+++ b/.scripts/menu_config_vars.sh
@@ -129,7 +129,7 @@ menu_config_vars() {
         if [[ -z ${LastLineChoice-} ]]; then
             # Set the default line to the first line with a variable on it
             LastLineChoice="$(printf "%0${PadSize}d" "${FirstVarLine}")"
-        elif [[ ${LastLineChoice} -gt ${TotalLines} ]]; then
+        elif [[ $((10#${LastLineChoice})) -gt ${TotalLines} ]]; then
             LastLineChoice=${TotalLines}
         fi
         while true; do


### PR DESCRIPTION
Fix LastLineChoice being interpreted at octal if it has a leading 0.

# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
