### PR TITLE
Add update notices, and initial version display

### DIFF
--- a/.scripts/apply_theme.sh
+++ b/.scripts/apply_theme.sh
@@ -89,7 +89,7 @@ apply_theme() {
         DC["${VarName}"]="${Value}"
     done
     DC["ThemeName"]="${ThemeName}"
-    DIALOGOPTS="--colors  --cr-wrap --no-collapse --backtitle ${DC[BackTitle]}${BACKTITLE}"
+    DIALOGOPTS="--colors --cr-wrap --no-collapse"
 
     local LineCharacters Scrollbar Shadow
     LineCharacters="$(run_script 'env_get' "LineCharacters" "${MENU_INI_FILE}")"

--- a/.scripts/ds_update_available.sh
+++ b/.scripts/ds_update_available.sh
@@ -6,7 +6,8 @@ ds_update_available() {
     pushd "${SCRIPTPATH}" &> /dev/null || fatal "Failed to change directory.\nFailing command: ${F[C]}pushd \"${SCRIPTPATH}\""
     git fetch --quiet &> /dev/null
     local -i result=0
-    [[ $(git rev-parse HEAD 2> /dev/null) != $(git rev-parse @{u} 2> /dev/null) ]] || result=$?
+    # shellcheck disable=SC2319 # This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    [[ $(git rev-parse HEAD 2> /dev/null) != $(git rev-parse '@{u}' 2> /dev/null) ]] || result=$?
     popd &> /dev/null
     return ${result}
 }

--- a/.scripts/ds_update_available.sh
+++ b/.scripts/ds_update_available.sh
@@ -13,7 +13,7 @@ ds_update_available() {
 }
 
 test_ds_update_available() {
-    if run_script 'update_available'; then
+    if run_script 'ds_update_available'; then
         notice "Update available."
     else
         notice "DockSTARTer is already up to date."

--- a/.scripts/ds_update_available.sh
+++ b/.scripts/ds_update_available.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+ds_update_available() {
+    pushd "${SCRIPTPATH}" &> /dev/null || fatal "Failed to change directory.\nFailing command: ${F[C]}pushd \"${SCRIPTPATH}\""
+    git fetch --quiet &> /dev/null
+    local -i result=0
+    [[ $(git rev-parse HEAD 2> /dev/null) != $(git rev-parse @{u} 2> /dev/null) ]] || result=$?
+    popd &> /dev/null
+    return ${result}
+}
+
+test_ds_update_available() {
+    if run_script 'update_available'; then
+        notice "Update available."
+    else
+        notice "DockSTARTer is already up to date."
+    fi
+}

--- a/.scripts/ds_version.sh
+++ b/.scripts/ds_version.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+ds_version() {
+    echo ''
+}
+
+test_ds_version() {
+    notice "DockSTARTer version: $(run_script 'ds_version')"
+}

--- a/.scripts/menu_add_app.sh
+++ b/.scripts/menu_add_app.sh
@@ -33,7 +33,7 @@ menu_add_app() {
             "${ValueOptions[@]}"
         )
         local InputValueDialogButtonPressed=0
-        AppName=$(dialog "${InputValueDialog[@]}") || InputValueDialogButtonPressed=$?
+        AppName=$(_dialog_ "${InputValueDialog[@]}") || InputValueDialogButtonPressed=$?
         case ${DIALOG_BUTTONS[InputValueDialogButtonPressed]-} in
             OK)
                 # Sanitize the input
@@ -91,7 +91,7 @@ menu_add_app() {
                         "$((LINES - DC["WindowRowsAdjust"]))" "$((COLUMNS - DC["WindowColsAdjust"]))"
                     )
                     local -i YesNoDialogButtonPressed=0
-                    dialog "${YesNoDialog[@]}" || YesNoDialogButtonPressed=$?
+                    _dialog_ "${YesNoDialog[@]}" || YesNoDialogButtonPressed=$?
                     case ${DIALOG_BUTTONS[YesNoDialogButtonPressed]-} in
                         OK) # Built In
                             Heading="$(run_script 'menu_heading' "${AppNameHeading}")"

--- a/.scripts/menu_add_var.sh
+++ b/.scripts/menu_add_var.sh
@@ -177,7 +177,7 @@ menu_add_var() {
                     --title "${DC["Title"]}${Title}"
                 )
                 local -i MenuTextLines
-                MenuTextLines="$(dialog "${SelectValueDialogParams[@]}" --print-text-size "${SelectValueMenuText}" "$((LINES - DC["WindowRowsAdjust"]))" "$((COLUMNS - DC["WindowColsAdjust"]))" | cut -d ' ' -f 1)"
+                MenuTextLines="$(_dialog_ "${SelectValueDialogParams[@]}" --print-text-size "${SelectValueMenuText}" "$((LINES - DC["WindowRowsAdjust"]))" "$((COLUMNS - DC["WindowColsAdjust"]))" | cut -d ' ' -f 1)"
                 local -i SelectValueDialogButtonPressed=0
                 local -a SelectValueDialog=(
                     "${SelectValueDialogParams[@]}"
@@ -190,7 +190,7 @@ menu_add_var() {
                     "${ValueOptions[@]}"
                 )
                 SelectValueDialogButtonPressed=0
-                SelectedOption=$(dialog "${SelectValueDialog[@]}") || SelectValueDialogButtonPressed=$?
+                SelectedOption=$(_dialog_ "${SelectValueDialog[@]}") || SelectValueDialogButtonPressed=$?
                 case ${DIALOG_BUTTONS[SelectValueDialogButtonPressed]-} in
                     OK) # SELECT button
                         if [[ ${SelectedOption} == "${OptionClear}" ]]; then
@@ -303,7 +303,7 @@ menu_add_var() {
                     "${ValueOptions[@]}"
                 )
                 local InputValueDialogButtonPressed=0
-                VarName=$(dialog "${InputValueDialog[@]}") || InputValueDialogButtonPressed=$?
+                VarName=$(_dialog_ "${InputValueDialog[@]}") || InputValueDialogButtonPressed=$?
                 case ${DIALOG_BUTTONS[InputValueDialogButtonPressed]-} in
                     OK)
                         local Default

--- a/.scripts/menu_app_select.sh
+++ b/.scripts/menu_app_select.sh
@@ -64,7 +64,7 @@ menu_app_select() {
             --title "${DC["Title"]}${Title}"
         )
         local -i MenuTextLines
-        MenuTextLines="$(dialog "${SelectedAppsDialogParams[@]}" --print-text-size "${SelectAppsDialogText}" "$((LINES - DC["WindowRowsAdjust"]))" "$((COLUMNS - DC["WindowColsAdjust"]))" | cut -d ' ' -f 1)"
+        MenuTextLines="$(_dialog_ "${SelectedAppsDialogParams[@]}" --print-text-size "${SelectAppsDialogText}" "$((LINES - DC["WindowRowsAdjust"]))" "$((COLUMNS - DC["WindowColsAdjust"]))" | cut -d ' ' -f 1)"
         local -a SelectedAppsDialog=(
             "${SelectedAppsDialogParams[@]}"
             --ok-label "Done"
@@ -77,7 +77,7 @@ menu_app_select() {
             "${AppList[@]}"
         )
         SelectedAppsDialogButtonPressed=0
-        SelectedApps=$(dialog "${SelectedAppsDialog[@]}") || SelectedAppsDialogButtonPressed=$?
+        SelectedApps=$(_dialog_ "${SelectedAppsDialog[@]}") || SelectedAppsDialogButtonPressed=$?
     fi
     case ${DIALOG_BUTTONS[SelectedAppsDialogButtonPressed]-} in
         OK)

--- a/.scripts/menu_config.sh
+++ b/.scripts/menu_config.sh
@@ -41,7 +41,7 @@ menu_config() {
         )
         local ConfigChoice
         local -i ConfigDialogButtonPressed=0
-        ConfigChoice=$(dialog --default-item "${LastConfigChoice}" "${ConfigChoiceDialog[@]}") || ConfigDialogButtonPressed=$?
+        ConfigChoice=$(_dialog_ --default-item "${LastConfigChoice}" "${ConfigChoiceDialog[@]}") || ConfigDialogButtonPressed=$?
         LastConfigChoice=${ConfigChoice}
         case ${DIALOG_BUTTONS[ConfigDialogButtonPressed]-} in
             OK)

--- a/.scripts/menu_config_apps.sh
+++ b/.scripts/menu_config_apps.sh
@@ -16,7 +16,7 @@ menu_config_apps() {
         local WindowRows WindowCols WindowListRows
         local MenuTextSize MenuTextRows MenuTextCols
         #local ScreenSize
-        #ScreenSize="$(dialog --stdout --print-maxsize)"
+        #ScreenSize="$(_dialog_ --stdout --print-maxsize)"
         #ScreenRows="$(echo "${ScreenSize}" | cut -d ' ' -f 2 | cut -d ',' -f 1)"
         #ScreenCols="$(echo "${ScreenSize}" | cut -d ' ' -f 3)"
         ScreenRows="${LINES}"
@@ -29,7 +29,7 @@ menu_config_apps() {
             --stdout
         )
         local MenuTextSize
-        MenuTextSize="$(dialog "${AppChoiceParams[@]}" --print-text-size "${MenuText}" "${WindowRowsMax}" "${WindowColsMax}")"
+        MenuTextSize="$(_dialog_ "${AppChoiceParams[@]}" --print-text-size "${MenuText}" "${WindowRowsMax}" "${WindowColsMax}")"
         MenuTextRows="$(echo "${MenuTextSize}" | cut -d ' ' -f 1)"
         MenuTextCols="$(echo "${MenuTextSize}" | cut -d ' ' -f 2)"
         local ListCols=${MenuTextCols}
@@ -76,7 +76,7 @@ menu_config_apps() {
         )
         local AppChoice
         local -i AppChoiceButtonPressed=0
-        AppChoice=$(dialog --default-item "${LastAppChoice}" "${AppChoiceDialog[@]}") || AppChoiceButtonPressed=$?
+        AppChoice=$(_dialog_ --default-item "${LastAppChoice}" "${AppChoiceDialog[@]}") || AppChoiceButtonPressed=$?
         LastAppChoice=${AppChoice}
         case ${DIALOG_BUTTONS[AppChoiceButtonPressed]-} in
             OK)

--- a/.scripts/menu_config_vars.sh
+++ b/.scripts/menu_config_vars.sh
@@ -159,7 +159,7 @@ menu_config_vars() {
                 "${LineOptions[@]}"
             )
             local -i LineDialogButtonPressed=0
-            LineChoice=$(dialog "${LineDialog[@]}") || LineDialogButtonPressed=$?
+            LineChoice=$(_dialog_ "${LineDialog[@]}") || LineDialogButtonPressed=$?
             case ${DIALOG_BUTTONS[LineDialogButtonPressed]-} in
                 OK) # Select
                     LastLineChoice="${LineChoice}"

--- a/.scripts/menu_dialog_example.sh
+++ b/.scripts/menu_dialog_example.sh
@@ -47,7 +47,7 @@ menu_dialog_example() {
 
     local -i MenuTextLines
     MenuTextLines="$(
-        dialog \
+        _dialog_ \
             --stdout \
             --print-text-size \
             "${DialogText}" \

--- a/.scripts/menu_display_options.sh
+++ b/.scripts/menu_display_options.sh
@@ -27,7 +27,7 @@ menu_display_options() {
         )
         local Choice
         local -i DialogButtonPressed=0
-        Choice=$(dialog --default-item "${LastChoice}" "${ChoiceDialog[@]}") || DialogButtonPressed=$?
+        Choice=$(_dialog_ --default-item "${LastChoice}" "${ChoiceDialog[@]}") || DialogButtonPressed=$?
         LastChoice=${Choice}
         case ${DIALOG_BUTTONS[DialogButtonPressed]-} in
             OK)

--- a/.scripts/menu_display_options_general.sh
+++ b/.scripts/menu_display_options_general.sh
@@ -49,7 +49,7 @@ menu_display_options_general() {
         )
         local Choices
         local -i DialogButtonPressed=0
-        Choices=$(dialog "${ChoiceDialog[@]}") || DialogButtonPressed=$?
+        Choices=$(_dialog_ "${ChoiceDialog[@]}") || DialogButtonPressed=$?
         case ${DIALOG_BUTTONS[DialogButtonPressed]-} in
             OK)
                 local -a ChoicesArray OptionsToTurnOff OptionsToTurnOn

--- a/.scripts/menu_display_options_theme.sh
+++ b/.scripts/menu_display_options_theme.sh
@@ -46,7 +46,7 @@ menu_display_options_theme() {
         )
         local Choice
         local -i DialogButtonPressed=0
-        Choice=$(dialog --default-item "${LastChoice}" "${ChoiceDialog[@]}") || DialogButtonPressed=$?
+        Choice=$(_dialog_ --default-item "${LastChoice}" "${ChoiceDialog[@]}") || DialogButtonPressed=$?
         LastChoice=${Choice}
         case ${DIALOG_BUTTONS[DialogButtonPressed]-} in
             OK)

--- a/.scripts/menu_main.sh
+++ b/.scripts/menu_main.sh
@@ -31,7 +31,7 @@ menu_main() {
         )
         local MainChoice
         local -i MainDialogButtonPressed=0
-        MainChoice=$(dialog --default-item "${LastMainChoice}" "${MainChoiceDialog[@]}") || MainDialogButtonPressed=$?
+        MainChoice=$(_dialog_ --default-item "${LastMainChoice}" "${MainChoiceDialog[@]}") || MainDialogButtonPressed=$?
         LastMainChoice=${MainChoice}
         case ${DIALOG_BUTTONS[MainDialogButtonPressed]-} in
             OK)

--- a/.scripts/menu_value_prompt.sh
+++ b/.scripts/menu_value_prompt.sh
@@ -298,7 +298,7 @@ menu_value_prompt() {
             --item-help
         )
         local -i MenuTextLines
-        MenuTextLines="$(dialog "${SelectValueDialogParams[@]}" --print-text-size "${SelectValueMenuText}" "$((LINES - DC["WindowRowsAdjust"]))" "$((COLUMNS - DC["WindowColsAdjust"]))" | cut -d ' ' -f 1)"
+        MenuTextLines="$(_dialog_ "${SelectValueDialogParams[@]}" --print-text-size "${SelectValueMenuText}" "$((LINES - DC["WindowRowsAdjust"]))" "$((COLUMNS - DC["WindowColsAdjust"]))" | cut -d ' ' -f 1)"
         local -i SelectValueDialogButtonPressed=0
         local SelectedValue
         local -a SelectValueDialog=(
@@ -312,7 +312,7 @@ menu_value_prompt() {
             "${ValueOptions[@]}"
         )
         SelectValueDialogButtonPressed=0
-        SelectedValue=$(dialog "${SelectValueDialog[@]}") || SelectValueDialogButtonPressed=$?
+        SelectedValue=$(_dialog_ "${SelectValueDialog[@]}") || SelectValueDialogButtonPressed=$?
 
         case ${DIALOG_BUTTONS[SelectValueDialogButtonPressed]-} in
             OK) # SELECT button

--- a/.scripts/question_prompt.sh
+++ b/.scripts/question_prompt.sh
@@ -52,7 +52,7 @@ question_prompt() {
                 "$((LINES - DC["WindowRowsAdjust"]))" "$((COLUMNS - DC["WindowColsAdjust"]))"
             )
             local -i YesNoDialogButtonPressed=0
-            dialog "${YesNoDialog[@]}" || YesNoDialogButtonPressed=$?
+            _dialog_ "${YesNoDialog[@]}" || YesNoDialogButtonPressed=$?
             case ${DIALOG_BUTTONS[YesNoDialogButtonPressed]-} in
                 OK)
                     YN="Y"

--- a/.scripts/question_prompt.sh
+++ b/.scripts/question_prompt.sh
@@ -9,7 +9,7 @@ question_prompt() {
         Default=""
     fi
     local Question=${2-}
-    local Title=${3-$BACKTITLE}
+    local Title=${3-$APPLICATION_NAME}
     local Override=${4-}
     Override=${Override^^:0:1}
     local YesButton=${5-Yes}

--- a/main.sh
+++ b/main.sh
@@ -120,7 +120,6 @@ declare -rx APPLICATION_NAME='DockSTARTer'
 declare -x APPLICATION_VERSION=''
 APPLICATION_VERSION="$(run_script 'ds_version')"
 readonly APPLICATION_VERSION
-declare -x APPLICATION_UPDATE=''
 
 usage() {
     local APPLICATION_HEADING="${APPLICATION_NAME}"
@@ -627,7 +626,7 @@ highlighted_list() {
 _dialog_() {
     local BACKTITLE="${DC[BackTitle]}${APPLICATION_NAME}${DC[NC]}"
     if [[ ${APPLICATION_VERSION-} ]]; then
-        BACKTITLE+="${DC[BackTitle]} [${APPLICATION_VERSION}]${DC[NC]}"
+        BACKTITLE+=" ${DC[BackTitle]}[${APPLICATION_VERSION}]${DC[NC]}"
     fi
     if run_script 'ds_update_available'; then
         BACKTITLE+=" (Update Available)"

--- a/main.sh
+++ b/main.sh
@@ -624,30 +624,30 @@ highlighted_list() {
 }
 
 _dialog_() {
-    local LEFT_BACKTITLE RIGHT_BACKTITLE
-    local CLEAN_LEFT_BACKTITLE CLEAN_RIGHT_BACKTITLE
+    local LeftBackTitle RightBackTitle
+    local CleanLeftBackTitle CleanRightBackTitle
 
-    CLEAN_LEFT_BACKTITLE="${APPLICATION_NAME}"
-    LEFT_BACKTITLE="${DC[BackTitle]}${APPLICATION_NAME}${DC[NC]}"
+    CleanLeftBackTitle="${APPLICATION_NAME}"
+    LeftBackTitle="${DC[BackTitle]}${APPLICATION_NAME}${DC[NC]}"
 
-    CLEAN_RIGHT_BACKTITLE=''
-    RIGHT_BACKTITLE=''
+    CleanRightBackTitle=''
+    RightBackTitle=''
     if run_script 'ds_update_available'; then
-        CLEAN_RIGHT_BACKTITLE="(Update Available)"
-        RIGHT_BACKTITLE="(Update Available)"
+        CleanRightBackTitle="(Update Available)"
+        RightBackTitle="(Update Available)"
     fi
     if [[ ${APPLICATION_VERSION-} ]]; then
-        CLEAN_RIGHT_BACKTITLE+=" [${APPLICATION_VERSION}]"
-        RIGHT_BACKTITLE+=" ${DC[BackTitle]}[${APPLICATION_VERSION}]${DC[NC]}"
+        CleanRightBackTitle+=" [${APPLICATION_VERSION}]"
+        RightBackTitle+=" ${DC[BackTitle]}[${APPLICATION_VERSION}]${DC[NC]}"
     fi
 
     local -i IndentLength
-    IndentLength=$((COLUMNS - ${#CLEAN_LEFT_BACKTITLE} - ${#CLEAN_RIGHT_BACKTITLE} - 2))
-    local INDENT
-    INDENT="$(printf %${IndentLength}s '')"
-    BACKTITLE="${LEFT_BACKTITLE}${INDENT}${RIGHT_BACKTITLE}"
+    IndentLength=$((COLUMNS - ${#CleanLeftBackTitle} - ${#CleanRightBackTitle} - 2))
+    local Indent
+    Indent="$(printf %${IndentLength}s '')"
+    BackTitle="${LeftBackTitle}${Indent}${RightBackTitle}"
 
-    ${DIALOG} --backtitle "${BACKTITLE}" "$@"
+    ${DIALOG} --backtitle "${BackTitle}" "$@"
 }
 
 # Check to see if we should use a dialog box

--- a/main.sh
+++ b/main.sh
@@ -123,8 +123,16 @@ readonly APPLICATION_VERSION
 declare -x APPLICATION_UPDATE=''
 
 usage() {
+    local APPLICATION_HEADING="${APPLICATION_NAME}"
+    if [[ ${APPLICATION_VERSION-} ]]; then
+        APPLICATION_HEADING+=" ${APPLICATION_VERSION}"
+    fi
+    if run_script 'ds_update_available'; then
+        APPLICATION_HEADING+=" (Update Available)"
+    fi
     cat << EOF
 Usage: ds [OPTION]
+${APPLICATION_HEADING}
 NOTE: ds shortcut is only available after the first run of
     bash main.sh
 

--- a/main.sh
+++ b/main.sh
@@ -125,7 +125,7 @@ declare -x APPLICATION_UPDATE=''
 usage() {
     local APPLICATION_HEADING="${APPLICATION_NAME}"
     if [[ ${APPLICATION_VERSION-} ]]; then
-        APPLICATION_HEADING+=" ${APPLICATION_VERSION}"
+        APPLICATION_HEADING+=" [${APPLICATION_VERSION}]"
     fi
     if run_script 'ds_update_available'; then
         APPLICATION_HEADING+=" (Update Available)"

--- a/main.sh
+++ b/main.sh
@@ -624,13 +624,29 @@ highlighted_list() {
 }
 
 _dialog_() {
-    local BACKTITLE="${DC[BackTitle]}${APPLICATION_NAME}${DC[NC]}"
-    if [[ ${APPLICATION_VERSION-} ]]; then
-        BACKTITLE+=" ${DC[BackTitle]}[${APPLICATION_VERSION}]${DC[NC]}"
-    fi
+    local LEFT_BACKTITLE RIGHT_BACKTITLE
+    local CLEAN_LEFT_BACKTITLE CLEAN_RIGHT_BACKTITLE
+
+    CLEAN_LEFT_BACKTITLE="${APPLICATION_NAME}"
+    LEFT_BACKTITLE="${DC[BackTitle]}${APPLICATION_NAME}${DC[NC]}"
+
+    CLEAN_RIGHT_BACKTITLE=''
+    RIGHT_BACKTITLE=''
     if run_script 'ds_update_available'; then
-        BACKTITLE+=" (Update Available)"
+        CLEAN_RIGHT_BACKTITLE="(Update Available)"
+        RIGHT_BACKTITLE="(Update Available)"
     fi
+    if [[ ${APPLICATION_VERSION-} ]]; then
+        CLEAN_RIGHT_BACKTITLE+=" [${APPLICATION_VERSION}]"
+        RIGHT_BACKTITLE+=" ${DC[BackTitle]}[${APPLICATION_VERSION}]${DC[NC]}"
+    fi
+
+    local -i IndentLength
+    IndentLength=$((COLUMNS - ${#CLEAN_LEFT_BACKTITLE} - ${#CLEAN_RIGHT_BACKTITLE}))
+    local INDENT
+    INDENT="$(printf %${IndentLength}s '')"
+    BACKTITLE="${LEFT_BACKTITLE}${INDENT}${RIGHT_BACKTITLE}"
+
     ${DIALOG} --backtitle "${BACKTITLE}" "$@"
 }
 

--- a/main.sh
+++ b/main.sh
@@ -642,7 +642,7 @@ _dialog_() {
     fi
 
     local -i IndentLength
-    IndentLength=$((COLUMNS - ${#CLEAN_LEFT_BACKTITLE} - ${#CLEAN_RIGHT_BACKTITLE}))
+    IndentLength=$((COLUMNS - ${#CLEAN_LEFT_BACKTITLE} - ${#CLEAN_RIGHT_BACKTITLE} - 2))
     local INDENT
     INDENT="$(printf %${IndentLength}s '')"
     BACKTITLE="${LEFT_BACKTITLE}${INDENT}${RIGHT_BACKTITLE}"

--- a/main.sh
+++ b/main.sh
@@ -6,6 +6,122 @@ export LC_ALL=C
 export PROMPT="CLI"
 export MENU=false
 
+# Script Information
+# https://stackoverflow.com/questions/59895/get-the-source-directory-of-a-bash-script-from-within-the-script-itself/246128#246128
+get_scriptname() {
+    # https://stackoverflow.com/questions/35006457/choosing-between-0-and-bash-source/35006505#35006505
+    local SOURCE=${BASH_SOURCE[0]:-$0}
+    while [[ -L ${SOURCE} ]]; do # resolve ${SOURCE} until the file is no longer a symlink
+        local DIR
+        DIR=$(cd -P "$(dirname "${SOURCE}")" > /dev/null 2>&1 && pwd)
+        SOURCE=$(readlink "${SOURCE}")
+        [[ ${SOURCE} != /* ]] && SOURCE="${DIR}/${SOURCE}" # if ${SOURCE} was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+    done
+    echo "${SOURCE}"
+}
+
+SCRIPTPATH=$(cd -P "$(dirname "$(get_scriptname)")" > /dev/null 2>&1 && pwd)
+readonly SCRIPTPATH
+SCRIPTNAME="${SCRIPTPATH}/$(basename "$(get_scriptname)")"
+readonly SCRIPTNAME
+
+# Terminal Colors
+declare -Agr B=( # Background
+    [B]=$(tput setab 4 2> /dev/null || echo -e "\e[44m") # Blue
+    [C]=$(tput setab 6 2> /dev/null || echo -e "\e[46m") # Cyan
+    [G]=$(tput setab 2 2> /dev/null || echo -e "\e[42m") # Green
+    [K]=$(tput setab 0 2> /dev/null || echo -e "\e[40m") # Black
+    [M]=$(tput setab 5 2> /dev/null || echo -e "\e[45m") # Magenta
+    [R]=$(tput setab 1 2> /dev/null || echo -e "\e[41m") # Red
+    [W]=$(tput setab 7 2> /dev/null || echo -e "\e[47m") # White
+    [Y]=$(tput setab 3 2> /dev/null || echo -e "\e[43m") # Yellow
+)
+declare -Agr F=( # Foreground
+    [B]=$(tput setaf 4 2> /dev/null || echo -e "\e[34m") # Blue
+    [C]=$(tput setaf 6 2> /dev/null || echo -e "\e[36m") # Cyan
+    [G]=$(tput setaf 2 2> /dev/null || echo -e "\e[32m") # Green
+    [K]=$(tput setaf 0 2> /dev/null || echo -e "\e[30m") # Black
+    [M]=$(tput setaf 5 2> /dev/null || echo -e "\e[35m") # Magenta
+    [R]=$(tput setaf 1 2> /dev/null || echo -e "\e[31m") # Red
+    [W]=$(tput setaf 7 2> /dev/null || echo -e "\e[37m") # White
+    [Y]=$(tput setaf 3 2> /dev/null || echo -e "\e[33m") # Yellow
+)
+NC=$(tput sgr0 2> /dev/null || echo -e "\e[0m")
+readonly NC
+BS=$(tput cup 1000 0 2> /dev/null || true) # Bottom of screen
+readonly BS
+export BS
+
+# Log Functions
+MKTEMP_LOG=$(mktemp) || echo -e "Failed to create temporary log file.\nFailing command: ${F[C]}mktemp"
+readonly MKTEMP_LOG
+echo "DockSTARTer Log" > "${MKTEMP_LOG}"
+create_strip_log_colors_SEDSTRING() {
+    # Create the search string to strip ANSI colors
+    # String is saved after creation, so this is only done on the first call
+    local -a ANSICOLORS=("${F[@]}" "${B[@]}" "${NC}")
+    for index in "${!ANSICOLORS[@]}"; do
+        # Escape characters used by sed
+        ANSICOLORS[index]=$(printf '%s' "${ANSICOLORS[index]}" | sed -E 's/[]{}()[/{}\.''''$]/\\&/g')
+    done
+    printf '%s' "s/$(
+        IFS='|'
+        printf '%s' "${ANSICOLORS[*]}"
+    )//g"
+}
+strip_log_colors_SEDSTRING="$(create_strip_log_colors_SEDSTRING)"
+readonly strip_log_colors_SEDSTRING
+strip_log_colors() {
+    printf '%s' "$*" | sed -E "${strip_log_colors_SEDSTRING}"
+}
+log() {
+    local TOTERM=${1-}
+    local MESSAGE=${2-}
+    local STRIPPED_MESSAGE
+    STRIPPED_MESSAGE=$(strip_log_colors "${MESSAGE-}")
+    if [[ -n ${TOTERM} ]]; then
+        if [[ -t 2 ]]; then
+            # Stderr is not being redirected, output with color
+            echo -e "${MESSAGE-}" >&2
+        else
+            # Stderr is being redirected, output without colorr
+            echo -e "${STRIPPED_MESSAGE-}" >&2
+        fi
+    fi
+    # Output the message to the log file without color
+    echo -e "${STRIPPED_MESSAGE-}" >> "${MKTEMP_LOG}"
+}
+trace() { log "${TRACE-}" "${NC}$(date +"%F %T") ${F[B]}[TRACE ]${NC}   $*${NC}"; }
+debug() { log "${DEBUG-}" "${NC}$(date +"%F %T") ${F[B]}[DEBUG ]${NC}   $*${NC}"; }
+info() { log "${VERBOSE-}" "${NC}$(date +"%F %T") ${F[B]}[INFO  ]${NC}   $*${NC}"; }
+notice() { log true "${NC}$(date +"%F %T") ${F[G]}[NOTICE]${NC}   $*${NC}"; }
+warn() { log true "${NC}$(date +"%F %T") ${F[Y]}[WARN  ]${NC}   $*${NC}"; }
+error() { log true "${NC}$(date +"%F %T") ${F[R]}[ERROR ]${NC}   $*${NC}"; }
+fatal() {
+    log true "${NC}$(date +"%F %T") ${B[R]}${F[W]}[FATAL ]${NC}   $*${NC}"
+    exit 1
+}
+
+# Script Runner Function
+run_script() {
+    local SCRIPTSNAME=${1-}
+    shift
+    if [[ -f ${SCRIPTPATH}/.scripts/${SCRIPTSNAME}.sh ]]; then
+        # shellcheck source=/dev/null
+        source "${SCRIPTPATH}/.scripts/${SCRIPTSNAME}.sh"
+        ${SCRIPTSNAME} "$@"
+        return
+    else
+        fatal "${SCRIPTPATH}/.scripts/${SCRIPTSNAME}.sh not found."
+    fi
+}
+
+declare -rx APPLICATION_NAME='DockSTARTer'
+declare -x APPLICATION_VERSION=''
+APPLICATION_VERSION="$(run_script 'ds_version')"
+readonly APPLICATION_VERSION
+declare -x APPLICATION_UPDATE=''
+
 usage() {
     cat << EOF
 Usage: ds [OPTION]
@@ -122,25 +238,6 @@ that take app names can use the form app: to refer to the same file.
 EOF
 }
 
-# Script Information
-# https://stackoverflow.com/questions/59895/get-the-source-directory-of-a-bash-script-from-within-the-script-itself/246128#246128
-get_scriptname() {
-    # https://stackoverflow.com/questions/35006457/choosing-between-0-and-bash-source/35006505#35006505
-    local SOURCE=${BASH_SOURCE[0]:-$0}
-    while [[ -L ${SOURCE} ]]; do # resolve ${SOURCE} until the file is no longer a symlink
-        local DIR
-        DIR=$(cd -P "$(dirname "${SOURCE}")" > /dev/null 2>&1 && pwd)
-        SOURCE=$(readlink "${SOURCE}")
-        [[ ${SOURCE} != /* ]] && SOURCE="${DIR}/${SOURCE}" # if ${SOURCE} was a relative symlink, we need to resolve it relative to the path where the symlink file was located
-    done
-    echo "${SOURCE}"
-}
-
-SCRIPTPATH=$(cd -P "$(dirname "$(get_scriptname)")" > /dev/null 2>&1 && pwd)
-readonly SCRIPTPATH
-SCRIPTNAME="${SCRIPTPATH}/$(basename "$(get_scriptname)")"
-readonly SCRIPTNAME
-
 DIALOG=$(command -v dialog) || true
 export DIALOG
 
@@ -149,8 +246,6 @@ declare -rx MENU_INI_FILE="${SCRIPTPATH}/${MENU_INI_NAME}"
 declare -rx THEME_FILE_NAME='theme.ini'
 declare -rx DIALOGRC_NAME='.dialogrc'
 declare -rx DIALOGRC="${SCRIPTPATH}/${DIALOGRC_NAME}"
-
-declare -rx BACKTITLE="DockSTARTer"
 
 declare -rix DIALOGTIMEOUT=3
 declare -rix DIALOG_OK=0
@@ -194,83 +289,6 @@ cleanup() {
     exit ${EXIT_CODE}
 }
 trap 'cleanup' ERR EXIT SIGABRT SIGALRM SIGHUP SIGINT SIGQUIT SIGTERM
-
-# Terminal Colors
-declare -Agr B=( # Background
-    [B]=$(tput setab 4 2> /dev/null || echo -e "\e[44m") # Blue
-    [C]=$(tput setab 6 2> /dev/null || echo -e "\e[46m") # Cyan
-    [G]=$(tput setab 2 2> /dev/null || echo -e "\e[42m") # Green
-    [K]=$(tput setab 0 2> /dev/null || echo -e "\e[40m") # Black
-    [M]=$(tput setab 5 2> /dev/null || echo -e "\e[45m") # Magenta
-    [R]=$(tput setab 1 2> /dev/null || echo -e "\e[41m") # Red
-    [W]=$(tput setab 7 2> /dev/null || echo -e "\e[47m") # White
-    [Y]=$(tput setab 3 2> /dev/null || echo -e "\e[43m") # Yellow
-)
-declare -Agr F=( # Foreground
-    [B]=$(tput setaf 4 2> /dev/null || echo -e "\e[34m") # Blue
-    [C]=$(tput setaf 6 2> /dev/null || echo -e "\e[36m") # Cyan
-    [G]=$(tput setaf 2 2> /dev/null || echo -e "\e[32m") # Green
-    [K]=$(tput setaf 0 2> /dev/null || echo -e "\e[30m") # Black
-    [M]=$(tput setaf 5 2> /dev/null || echo -e "\e[35m") # Magenta
-    [R]=$(tput setaf 1 2> /dev/null || echo -e "\e[31m") # Red
-    [W]=$(tput setaf 7 2> /dev/null || echo -e "\e[37m") # White
-    [Y]=$(tput setaf 3 2> /dev/null || echo -e "\e[33m") # Yellow
-)
-NC=$(tput sgr0 2> /dev/null || echo -e "\e[0m")
-readonly NC
-BS=$(tput cup 1000 0 2> /dev/null || true) # Bottom of screen
-readonly BS
-export BS
-
-# Log Functions
-MKTEMP_LOG=$(mktemp) || echo -e "Failed to create temporary log file.\nFailing command: ${F[C]}mktemp"
-readonly MKTEMP_LOG
-echo "DockSTARTer Log" > "${MKTEMP_LOG}"
-create_strip_log_colors_SEDSTRING() {
-    # Create the search string to strip ANSI colors
-    # String is saved after creation, so this is only done on the first call
-    local -a ANSICOLORS=("${F[@]}" "${B[@]}" "${NC}")
-    for index in "${!ANSICOLORS[@]}"; do
-        # Escape characters used by sed
-        ANSICOLORS[index]=$(printf '%s' "${ANSICOLORS[index]}" | sed -E 's/[]{}()[/{}\.''''$]/\\&/g')
-    done
-    printf '%s' "s/$(
-        IFS='|'
-        printf '%s' "${ANSICOLORS[*]}"
-    )//g"
-}
-strip_log_colors_SEDSTRING="$(create_strip_log_colors_SEDSTRING)"
-readonly strip_log_colors_SEDSTRING
-strip_log_colors() {
-    printf '%s' "$*" | sed -E "${strip_log_colors_SEDSTRING}"
-}
-log() {
-    local TOTERM=${1-}
-    local MESSAGE=${2-}
-    local STRIPPED_MESSAGE
-    STRIPPED_MESSAGE=$(strip_log_colors "${MESSAGE-}")
-    if [[ -n ${TOTERM} ]]; then
-        if [[ -t 2 ]]; then
-            # Stderr is not being redirected, output with color
-            echo -e "${MESSAGE-}" >&2
-        else
-            # Stderr is being redirected, output without colorr
-            echo -e "${STRIPPED_MESSAGE-}" >&2
-        fi
-    fi
-    # Output the message to the log file without color
-    echo -e "${STRIPPED_MESSAGE-}" >> "${MKTEMP_LOG}"
-}
-trace() { log "${TRACE-}" "${NC}$(date +"%F %T") ${F[B]}[TRACE ]${NC}   $*${NC}"; }
-debug() { log "${DEBUG-}" "${NC}$(date +"%F %T") ${F[B]}[DEBUG ]${NC}   $*${NC}"; }
-info() { log "${VERBOSE-}" "${NC}$(date +"%F %T") ${F[B]}[INFO  ]${NC}   $*${NC}"; }
-notice() { log true "${NC}$(date +"%F %T") ${F[G]}[NOTICE]${NC}   $*${NC}"; }
-warn() { log true "${NC}$(date +"%F %T") ${F[Y]}[WARN  ]${NC}   $*${NC}"; }
-error() { log true "${NC}$(date +"%F %T") ${F[R]}[ERROR ]${NC}   $*${NC}"; }
-fatal() {
-    log true "${NC}$(date +"%F %T") ${B[R]}${F[W]}[FATAL ]${NC}   $*${NC}"
-    exit 1
-}
 
 # Command Line Arguments
 readonly ARGS=("$@")
@@ -589,20 +607,6 @@ check_sudo() {
     fi
 }
 
-# Script Runner Function
-run_script() {
-    local SCRIPTSNAME=${1-}
-    shift
-    if [[ -f ${SCRIPTPATH}/.scripts/${SCRIPTSNAME}.sh ]]; then
-        # shellcheck source=/dev/null
-        source "${SCRIPTPATH}/.scripts/${SCRIPTSNAME}.sh"
-        ${SCRIPTSNAME} "$@"
-        return
-    else
-        fatal "${SCRIPTPATH}/.scripts/${SCRIPTSNAME}.sh not found."
-    fi
-}
-
 # Take whitespace and newline delimited words and output a single line highlited list for dialog
 highlighted_list() {
     local List
@@ -610,6 +614,17 @@ highlighted_list() {
     if [[ -n ${List-} ]]; then
         echo "${DC["Subtitle"]}${List// /${DC[NC]} ${DC["Subtitle"]}}${DC[NC]}"
     fi
+}
+
+_dialog_() {
+    local BACKTITLE="${DC[BackTitle]}${APPLICATION_NAME}${DC[NC]}"
+    if [[ ${APPLICATION_VERSION-} ]]; then
+        BACKTITLE+="${DC[BackTitle]} [${APPLICATION_VERSION}]${DC[NC]}"
+    fi
+    if run_script 'ds_update_available'; then
+        BACKTITLE+=" (Update Available)"
+    fi
+    ${DIALOG} --backtitle "${BACKTITLE}" "$@"
 }
 
 # Check to see if we should use a dialog box
@@ -622,7 +637,7 @@ dialog_pipe() {
     local Title=${1:-}
     local SubTitle=${2:-}
     local TimeOut=${3:-0}
-    dialog \
+    _dialog_ \
         --title "${DC["Title"]}${Title}" \
         --timeout "${TimeOut}" \
         --programbox "${DC["Subtitle"]}${SubTitle}" \
@@ -669,7 +684,7 @@ dialog_message() {
     local Title=${1:-}
     local Message=${2:-}
     local TimeOut=${3:-0}
-    dialog \
+    _dialog_ \
         --title "${Title}" \
         --timeout "${TimeOut}" \
         --msgbox "${Message}" \


### PR DESCRIPTION
# Pull request

**Purpose**
Adds an `(Update Available)` notice at the top of the usage page, and at the top right of dialog boxes.
Added the code to display version info as well, once versioning is implemented.  Currently, `ds_version` returns a blank string.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
