### PR TITLE
Add `ds -V` and `ds --version` commands to display the current versio…

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -267,6 +267,8 @@ that take app names can use the form app: to refer to the same file.
     Update ${APPLICATION_NAME} to the latest commits from the specified branch
 -v --verbose
     Verbose
+-V --version
+    Display version information
 -x --debug
     Debug
 EOF
@@ -327,7 +329,7 @@ trap 'cleanup' ERR EXIT SIGABRT SIGALRM SIGHUP SIGINT SIGQUIT SIGTERM
 # Command Line Arguments
 readonly ARGS=("$@")
 cmdline() {
-    while getopts ":-:a:c:efghilpr:s:t:u:vx" OPTION; do
+    while getopts ":-:a:c:efghilpr:s:t:u:vVx" OPTION; do
         # support long options: https://stackoverflow.com/a/28466267/519360
         if [ "$OPTION" = "-" ]; then # long option: reformulate OPTION and OPTARG
             OPTION="${OPTARG}"       # extract long option name
@@ -531,6 +533,9 @@ cmdline() {
                 ;;
             v | verbose)
                 readonly VERBOSE=1
+                ;;
+            V | version)
+                readonly VERSION=1
                 ;;
             x | debug)
                 readonly DEBUG=1
@@ -1194,6 +1199,10 @@ main() {
         else
             run_script 'update_self' "${UPDATE}"
         fi
+        exit
+    fi
+    if [[ -n ${VERSION-} ]]; then
+        echo "${APPLICATION_NAME} [${APPLICATION_VERSION}]"
         exit
     fi
     # Run Menus


### PR DESCRIPTION
…n of DockSTARTer

# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Add a version flag to the DockSTARTer CLI to display the current application version

New Features:
- Add -V and --version flags in main.sh to support version display
- Update usage text and command-line parsing to recognize and handle the version option