### PR TITLE
Change version `info` to a version `notice` if an update is available.

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -840,9 +840,11 @@ main() {
     # Create Symlink
     run_script 'symlink_ds'
     # Apply the GUI theme
-    info "${APPLICATION_NAME} [${APPLICATION_VERSION}]"
     if ds_update_available; then
+        notice "${APPLICATION_NAME} [${APPLICATION_VERSION}]"
         notice "An update to ${APPLICATION_NAME} is available. Run 'ds -u' to update."
+    else
+        info "${APPLICATION_NAME} [${APPLICATION_VERSION}]"
     fi
     run_script 'apply_theme'
     # Execute CLI Argument Functions


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Display the application version with notice severity when an update is available and revert to info when it isn’t.

Enhancements:
- Switch version display to use notice instead of info when an update is available.
- Ensure version info falls back to info logging when no updates are found.