### PR TITLE
Show version info when updating

### DIFF
--- a/.scripts/update_self.sh
+++ b/.scripts/update_self.sh
@@ -16,11 +16,11 @@ update_self() {
             error "You need to specify a branch to update to."
             return 1
         fi
-        Question="Would you like to update ${APPLICATION_NAME} to branch ${CurrentBranch} now?"
+        Question="Would you like to update ${APPLICATION_NAME} to current branch ${CurrentBranch} now?"
         NoNotice="${APPLICATION_NAME} will not be updated."
         YesNotice="Updating ${APPLICATION_NAME} to branch ${CurrentBranch}."
     elif [[ ${BRANCH-} == "${CurrentBranch-}" ]]; then
-        Question="Would you like to update ${APPLICATION_NAME} to branch ${BRANCH} now?"
+        Question="Would you like to forcefully update ${APPLICATION_NAME} to current branch ${BRANCH} now?"
         NoNotice="${APPLICATION_NAME} will not be updated."
         YesNotice="Updating ${APPLICATION_NAME} to branch ${BRANCH}."
     else
@@ -55,6 +55,7 @@ commands_update_self() {
         BRANCH="$(git branch --show)"
         if ! ds_update_available; then
             notice "${APPLICATION_NAME} is already up to date on branch ${BRANCH}."
+            notice "Current version is $(ds_version)"
             return
         fi
     fi
@@ -92,6 +93,7 @@ commands_update_self() {
     git ls-tree -rt --name-only "${BRANCH}" | xargs sudo chown "${DETECTED_PUID}":"${DETECTED_PGID}" > /dev/null 2>&1 || true
     sudo chown -R "${DETECTED_PUID}":"${DETECTED_PGID}" "${SCRIPTPATH}/.git" > /dev/null 2>&1 || true
     sudo chown "${DETECTED_PUID}":"${DETECTED_PGID}" "${SCRIPTPATH}" > /dev/null 2>&1 || true
+    notice "Updated to $(ds_version)"
     popd &> /dev/null
     exec bash "${SCRIPTNAME}" -e
 }


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Improve the update_self script to provide version information before and after updates and refine user prompts for clarity.

Enhancements:
- Display the current version when checking for available updates
- Show the updated version after a successful update
- Clarify update prompts by referencing the current branch and indicating forceful updates