### PR TITLE
Always get the current version for the GUI display, instead of using …

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -673,8 +673,10 @@ _dialog_() {
             CleanRightBackTitle+=" "
             RightBackTitle+="${DC[ApplicationVersionSpace]} "
         fi
-        CleanRightBackTitle+="[${APPLICATION_VERSION}]"
-        RightBackTitle+="${DC[ApplicationVersionBrackets]}[${DC[ApplicationVersion]}${APPLICATION_VERSION}${DC[ApplicationVersionBrackets]}]${DC[NC]}"
+        local CurrentVersion
+        CurrentVersion="$(ds_version)"
+        CleanRightBackTitle+="[${CurrentVersion}]"
+        RightBackTitle+="${DC[ApplicationVersionBrackets]}[${DC[ApplicationVersion]}${CurrentVersion}${DC[ApplicationVersionBrackets]}]${DC[NC]}"
     fi
 
     local -i IndentLength


### PR DESCRIPTION
…the variable.

# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Bug Fixes:
- Fix the GUI showing outdated version by always fetching the current version via ds_version instead of using the static APPLICATION_VERSION variable.