### PR TITLE
Fix handling of `DOCKER_STORAGE` and `APPNAME__STORAGE` boolean varia…

### DIFF
--- a/.scripts/yml_merge.sh
+++ b/.scripts/yml_merge.sh
@@ -68,7 +68,7 @@ commands_yml_merge() {
                 for Number in "${StorageNumbers[@]}"; do
                     local StorageOn
                     StorageOn="$(run_script 'env_get' "${APPNAME}__STORAGE${Number}")"
-                    StorageOn="${StorageOn-$(run_script 'env_get' "DOCKER_STORAGE${Number}")}"
+                    StorageOn="${StorageOn:-$(run_script 'env_get' "DOCKER_STORAGE${Number}")}"
                     if [[ -n ${StorageOn-} && ${StorageOn^^} =~ ON|TRUE|YES ]]; then
                         local StorageVolume
                         StorageVolume="$(run_script 'env_get' "DOCKER_VOLUME_STORAGE${Number}")"


### PR DESCRIPTION
…bles.

Use `${StorageOn:-$(run_script 'env_get' "DOCKER_STORAGE${Number}")` instead of `${StorageOn-$(run_script 'env_get' "DOCKER_STORAGE${Number}")`.  We are looking to see if `StorageOn `is empty, not unset.

# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
