### PR TITLE
Add to the invalid instance names

### DIFF
--- a/.scripts/appname_is_valid.sh
+++ b/.scripts/appname_is_valid.sh
@@ -10,10 +10,30 @@ appname_is_valid() {
         AppName="${AppName#:*}"
     fi
     if [[ ${AppName} =~ ^[a-zA-Z][a-zA-Z0-9]*(__[a-zA-Z0-9]+)?$ ]]; then
-        local InvalidInstanceNames="CONTAINER|ENABLED|ENVIRONMENT|HOSTNAME|PORT|NETWORK|RESTART|TAG"
+        local -a InvalidInstanceNames=(
+            CONTAINER
+            DEVICE
+            DEVICES
+            ENABLED
+            ENVIRONMENT
+            HOSTNAME
+            PORT
+            NETWORK
+            RESTART
+            STORAGE
+            STORAGE2
+            STORAGE3
+            STORAGE4
+            TAG
+        )
+        local InvalidInstanceNamesRegex
+        {
+            IFS='|'
+            InvalidInstanceNamesRegex="${InvalidInstanceNames[*]}"
+        }
         local InstanceName
         InstanceName="$(run_script 'appname_to_instancename' "${AppName}")"
-        [[ ! ${InstanceName^^} =~ ${InvalidInstanceNames} ]]
+        [[ ! ${InstanceName^^} =~ ${InvalidInstanceNamesRegex} ]]
         return
     fi
     false


### PR DESCRIPTION
Add `DEVICE`, `DEVICES`, `STORAGE`, `STORAGE2`, `STORAGE3`, and `STORAGE4` to the list of invalid application instance names.

# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Expand the script’s invalid application instance name checks to include additional reserved words and improve maintainability

Enhancements:
- Add DEVICE, DEVICES, STORAGE, STORAGE2, STORAGE3, and STORAGE4 to the invalid instance name list
- Refactor the invalid names definition to use an array and dynamically build the regex pattern