### PR TITLE
Fix "Updated to" notice during `ds -u`

### DIFF
--- a/.scripts/update_self.sh
+++ b/.scripts/update_self.sh
@@ -102,7 +102,7 @@ commands_update_self() {
     git ls-tree -rt --name-only "${BRANCH}" | xargs sudo chown "${DETECTED_PUID}":"${DETECTED_PGID}" > /dev/null 2>&1 || true
     sudo chown -R "${DETECTED_PUID}":"${DETECTED_PGID}" "${SCRIPTPATH}/.git" > /dev/null 2>&1 || true
     sudo chown "${DETECTED_PUID}":"${DETECTED_PGID}" "${SCRIPTPATH}" > /dev/null 2>&1 || true
-    notice "Updated to [$(ds_version)]"
+    notice "Updated ${APPLICATION_NAME} to $(ds_version)"
     popd &> /dev/null
     exec bash "${SCRIPTNAME}" -e
 }


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Bug Fixes:
- Correct the ‘Updated to’ notice in the update_self script to display “Updated <APPLICATION_NAME> to <version>” instead of a generic message