### PR TITLE
Use `app_is_added` and `enable_app` in `appvars_create`

### DIFF
--- a/.scripts/appvars_create.sh
+++ b/.scripts/appvars_create.sh
@@ -25,8 +25,8 @@ appvars_create() {
             if ! run_script 'env_var_exists' "${APPNAME}_ENABLED"; then
                 run_script 'env_migrate' "${APPNAME}_ENABLED" "${APPNAME}__ENABLED"
             fi
-            if ! run_script 'env_var_exists' "${APPNAME}__ENABLED"; then
-                run_script 'env_set' "${APPNAME}__ENABLED" true
+            if ! run_script 'app_is_added' "${APPNAME}"; then
+                run_script 'enable_app' "${APPNAME}"
             fi
 
             run_script 'appvars_migrate' "${APPNAME}"


### PR DESCRIPTION
Use the helper functions `app_is_added` and `enable_app` instead of checking for and setting `APPNAME__ENABLED` directly in `appvars_create`.

# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Refactor appvars_create to delegate enabled-state checks and updates to app_is_added and enable_app helpers instead of direct environment variable manipulation

Enhancements:
- Use app_is_added to verify if an app is already added
- Use enable_app to set the app enabled flag instead of env_var_exists and env_set