### PR TITLE
Fix links in `crossseed` docs

### DIFF
--- a/docs/apps/crossseed.md
+++ b/docs/apps/crossseed.md
@@ -1,12 +1,11 @@
 # crossseed
 
-[![Docker Pulls](https://img.shields.io/docker/pulls/cross-seed/cross-seed?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/cross-seed/cross-seed)
 [![GitHub Stars](https://img.shields.io/github/stars/cross-seed/cross-seed?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/cross-seed/cross-seed)
 [![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/crossseed)
 
 ## Description
 
-[cross-seed](https://www.navidrome.org/) can inject the torrents it finds directly into your torrent client.
+[cross-seed](https://www.cross-seed.org/) can inject the torrents it finds directly into your torrent client.
 Currently, the supported clients are
 
 - rTorrent


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Fix documentation links in the crossseed app docs by removing an outdated badge and correcting the project URL.

Documentation:
- Remove the Docker Pulls badge from the crossseed documentation
- Update the cross-seed project link to the official cross-seed.org URL