### PR TITLE
Depreciate `bitrwarden` (renamed to `vaultwarden`)

### DIFF
--- a/compose/.apps/bitwarden/bitwarden.labels.yml
+++ b/compose/.apps/bitwarden/bitwarden.labels.yml
@@ -1,6 +1,7 @@
 services:
   bitwarden<__instance>:
     labels:
-      com.dockstarter.appinfo.deprecated: "false"
-      com.dockstarter.appinfo.description: "Free and open source password management solution"
+      com.dockstarter.appinfo.deprecated: "true"
+      com.dockstarter.appinfo.description: "(DEPRECATED) Use Vaultwarden"
       com.dockstarter.appinfo.nicename: "Bitwarden<__Instance>"
+      com.dockstarter.appinfo.migrateto: "vaultwarden"

--- a/docs/apps/bitwarden.md
+++ b/docs/apps/bitwarden.md
@@ -1,5 +1,9 @@
 # Bitwarden
 
+## DEPRECATED
+
+DEPRECATION NOTICE: This image is deprecated as of 2025-07-14.
+
 [![Docker Pulls](https://img.shields.io/docker/pulls/vaultwarden/server?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/vaultwarden/server)
 [![GitHub Stars](https://img.shields.io/github/stars/dani-garcia/vaultwarden?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/dani-garcia/vaultwarden)
 [![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps/bitwarden)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -128,7 +128,6 @@ nav:
       - apps/azuracast.md
       - apps/bazarr.md
       - apps/beets.md
-      - apps/bitwarden.md
       - apps/booksonicair.md
       - apps/bookstack.md
       - apps/calibre.md


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Deprecate the Bitwarden app in favour of Vaultwarden by marking it deprecated in configuration and updating documentation.

Enhancements:
- Mark the Bitwarden service as deprecated and add a migrateto label pointing to Vaultwarden

Documentation:
- Insert a deprecation notice in the Bitwarden documentation with an effective date

Chores:
- Remove the Bitwarden documentation entry from the MkDocs navigation