### PR TITLE
Return an error notice for `ds --u` if the branch does not exist

### DIFF
--- a/.scripts/update_self.sh
+++ b/.scripts/update_self.sh
@@ -50,16 +50,28 @@ update_self() {
         fi
         return
     fi
+
+    BRANCH="${BRANCH:-"${CurrentBranch}"}"
+    if ! ds_branch_exists "${BRANCH}"; then
+        local ErrorMessage="${APPLICATION_NAME} branch ${BRANCH} does not exists."
+        if use_dialog_box; then
+            error "${ErrorMessage}" |&
+                dialog_pipe "${DC[TitleError]}${Title}" "${ErrorMessage}\n${DC[CommandLine]} ds --update $*"
+        else
+            error "${ErrorMessage}"
+        fi
+        return 1
+    fi
+
     if ! run_script 'question_prompt' Y "${Question}" "${Title}" "${FORCE:+Y}"; then
         if use_dialog_box; then
             notice "${NoNotice}" |& dialog_pipe "${DC[TitleError]}${Title}" "${NoNotice}"
         else
             notice "${NoNotice}"
         fi
-        return
+        return 1
     fi
 
-    BRANCH="${BRANCH:-"${CurrentBranch}"}"
     if use_dialog_box; then
         commands_update_self "${BRANCH}" "${YesNotice}" |&
             dialog_pipe "${DC[TitleSuccess]}${Title}" "${YesNotice}\n${DC[CommandLine]} ds --update $*"


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Enhance the update_self script to verify the specified branch exists, provide an appropriate error message through dialog or CLI on failure, and ensure the function returns a non-zero exit code when encountering errors or user cancellation.

Enhancements:
- Validate the target branch exists before attempting to update and show an error notice if it does not
- Return a non-zero exit code when the branch check fails or the update prompt is canceled