### PR TITLE
Return the exit code from the last command after forcing update to `m…

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -388,7 +388,7 @@ switch_branch() {
         export FORCE
         PROMPT="CLI"
         run_script 'update_self' "${TargetBranch}" bash "${SCRIPTNAME}" "$@"
-        exit 0
+        exit
     fi
 }
 


### PR DESCRIPTION
…ain` branch

# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Bug Fixes:
- Replace hardcoded exit 0 with exit to return the last command’s status after a forced update to main branch.