### PR TITLE
Make `'update_self' master` switch to `'update_self' main` if `main` branch exists

### DIFF
--- a/.scripts/update_self.sh
+++ b/.scripts/update_self.sh
@@ -6,11 +6,13 @@ update_self() {
     local BRANCH CurrentBranch CurrentVersion RemoteVersion
     BRANCH=${1-}
     shift || true
+    if [[ ${BRANCH-} == 'master' ]] && ds_branch_exists 'main'; then
+        BRANCH='main'
+    fi
 
     pushd "${SCRIPTPATH}" &> /dev/null || fatal "Failed to change directory.\nFailing command: ${F[C]}push \"${SCRIPTPATH}\""
     CurrentBranch="$(git branch --show)"
     CurrentVersion="$(ds_version)"
-
     local Title="Update ${APPLICATION_NAME}"
     local Question YesNotice NoNotice
     if [[ -z ${BRANCH-} ]]; then

--- a/.scripts/update_self.sh
+++ b/.scripts/update_self.sh
@@ -131,5 +131,6 @@ commands_update_self() {
 }
 
 test_update_self() {
-    run_script 'update_self' "${COMMIT_SHA-}"
+    warn "CI does not test update_self."
+    #@run_script 'update_self' "${COMMIT_SHA-}"
 }


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Switch the default branch for update_self from master to main when a main branch exists and adjust the CI test for update_self to emit a warning instead of executing the script

New Features:
- Automatically redirect update_self calls targeting master to main if the main branch is present

Tests:
- Replace the CI test for update_self with a warning message instead of running the script