### PR TITLE
Warn that we are overriding an explicit update to `master` to use `ma…

### DIFF
--- a/.scripts/update_self.sh
+++ b/.scripts/update_self.sh
@@ -7,6 +7,7 @@ update_self() {
     BRANCH=${1-}
     shift || true
     if [[ ${BRANCH-} == 'master' ]] && ds_branch_exists 'main'; then
+        warn "Updating to branch main instead of master."
         BRANCH='main'
     fi
 


### PR DESCRIPTION
…in` instead.

# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Enhancements:
- Add a warning when explicitly updating to master but automatically switching to main