### PR TITLE
Show `[<branch> Unknown Version]` as the version in the GUI  and `ds …

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -225,6 +225,9 @@ _dialog_() {
         fi
         local CurrentVersion
         CurrentVersion="$(ds_version)"
+        if [[ -z ${CurrentVersion} ]]; then
+            CurrentVersion="$(ds_branch) Unknown Version"
+        fi
         CleanRightBackTitle+="[${CurrentVersion}]"
         RightBackTitle+="${DC[ApplicationVersionBrackets]}[${DC[ApplicationVersion]}${CurrentVersion}${DC[ApplicationVersionBrackets]}]${DC[NC]}"
     fi
@@ -395,6 +398,9 @@ switch_branch() {
 
 declare -x APPLICATION_VERSION
 APPLICATION_VERSION="$(ds_version)"
+if [[ -z ${APPLICATION_VERSION} ]]; then
+    APPLICATION_VERSION="$(ds_branch) Unknown Version"
+fi
 readonly APPLICATION_VERSION
 
 # Check for supported CPU architecture
@@ -1261,7 +1267,7 @@ main() {
         exit
     fi
     if [[ -v VERSION ]]; then
-        local Version
+        local VersionString
         VersionString="$(ds_version "${VERSION}")"
         if [[ -n ${VersionString} ]]; then
             echo "${APPLICATION_NAME} [${VersionString}]"


### PR DESCRIPTION
…--help` if the remote branch doesn't exist

# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Add fallback version string using the current branch and "Unknown Version" when the remote branch is missing, and rename a variable for clarity.

New Features:
- Show "[<branch> Unknown Version]" as the application version in GUI title bars when ds_version returns empty
- Display "<branch> Unknown Version" in the --help output when the remote branch doesn't exist

Enhancements:
- Rename local variable 'Version' to 'VersionString' to avoid naming conflicts