### PR TITLE
Change call to `git branch --show` to use `git symbolic-ref --short H…

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -357,7 +357,7 @@ dialog_success() {
 ds_branch() {
     pushd "${SCRIPTPATH}" &> /dev/null || fatal "Failed to change directory.\nFailing command: ${F[C]}pushd \"${SCRIPTPATH}\""
     git fetch --quiet &> /dev/null || true
-    git branch --show
+    git symbolic-ref --short HEAD 2> /dev/null || true
     popd &> /dev/null
 }
 


### PR DESCRIPTION
…EAD`

Older versions of `git` do not support the `git branch --show` command.  Switch to using `git symbolic-ref --short HEAD` instead.

# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).
