### PR TITLE
Change `git branch --show` to `ds_branch` in `update_self`

### DIFF
--- a/.scripts/update_self.sh
+++ b/.scripts/update_self.sh
@@ -12,7 +12,7 @@ update_self() {
     fi
 
     pushd "${SCRIPTPATH}" &> /dev/null || fatal "Failed to change directory.\nFailing command: ${F[C]}push \"${SCRIPTPATH}\""
-    CurrentBranch="$(git branch --show)"
+    CurrentBranch="$(ds_branch)"
     CurrentVersion="$(ds_version)"
     local Title="Update ${APPLICATION_NAME}"
     local Question YesNotice NoNotice


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Enhancements:
- Use ds_branch instead of git branch --show to retrieve the current branch in update_self.sh