### PR TITLE
Add option to toggle between line drawing and ascii characters.

### DIFF
--- a/.scripts/apply_theme.sh
+++ b/.scripts/apply_theme.sh
@@ -91,13 +91,19 @@ apply_theme() {
     DC["ThemeName"]="${ThemeName}"
     DIALOGOPTS="--colors --cr-wrap --no-collapse"
 
-    local LineCharacters Scrollbar Shadow
+    local Borders Scrollbar Shadow
+    Borders="$(run_script 'env_get' "Borders" "${MENU_INI_FILE}")"
     LineCharacters="$(run_script 'env_get' "LineCharacters" "${MENU_INI_FILE}")"
     Scrollbar="$(run_script 'env_get' "Scrollbar" "${MENU_INI_FILE}")"
     Shadow="$(run_script 'env_get' "Shadow" "${MENU_INI_FILE}")"
 
-    if [[ ${LineCharacters^^} =~ ON|TRUE|YES ]]; then
+    if [[ ${Borders^^} =~ ON|TRUE|YES ]]; then
         DIALOGOPTS+=" --lines"
+        if [[ ${LineCharacters^^} =~ ON|TRUE|YES ]]; then
+            DIALOGOPTS+=" --no-ascii-lines"
+        else
+            DIALOGOPTS+=" --ascii-lines"
+        fi
     else
         DIALOGOPTS+=" --no-lines"
     fi

--- a/.scripts/menu_display_options_general.sh
+++ b/.scripts/menu_display_options_general.sh
@@ -12,23 +12,26 @@ menu_display_options_general() {
     #run_script 'apply_theme'
 
     local DrawLineOption="Draw Lines"
+    local ShowBordersOption="Show Borders"
     local ShowScrollbarOption="Show Scrollbar"
     local ShowShadowOption="Show Shadow"
 
     local -A OptionDescription OptionVariable
 
-    OptionDescription["${DrawLineOption}"]="Use line drawing characters for borders"
+    OptionDescription["${DrawLineOption}"]="Use line drawing characters"
+    OptionDescription["${ShowBordersOption}"]="Show borders in dialog boxes"
     OptionDescription["${ShowScrollbarOption}"]="Show a scrollbar in dialog boxes"
     OptionDescription["${ShowShadowOption}"]="Show a shadow under the dialog boxes"
 
     OptionVariable["${DrawLineOption}"]="LineCharacters"
+    OptionVariable["${ShowBordersOption}"]="Borders"
     OptionVariable["${ShowScrollbarOption}"]="Scrollbar"
     OptionVariable["${ShowShadowOption}"]="Shadow"
 
     while true; do
         local EnabledOptions=()
         local Opts=()
-        for Option in "${DrawLineOption}" "${ShowScrollbarOption}" "${ShowShadowOption}"; do
+        for Option in "${DrawLineOption}" "${ShowBordersOption}" "${ShowScrollbarOption}" "${ShowShadowOption}"; do
             local Value
             Value="$(run_script 'env_get' "${OptionVariable["${Option}"]}" "${MENU_INI_FILE}")"
             if [[ ${Value^^} =~ ON|TRUE|YES ]]; then

--- a/.themes/menu.ini
+++ b/.themes/menu.ini
@@ -1,3 +1,4 @@
+Borders='yes'
 LineCharacters='yes'
 Scrollbar='yes'
 Shadow='yes"


### PR DESCRIPTION
Rename `LineDrawing` option to `Borders`, to turn borders on and off. Implement new `LineDrawing` option to switch between line drawing and ascii characters.

# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Separate border visibility and style into distinct settings by adding a 'Borders' toggle and a 'LineCharacters' option, and update the menu UI and theme application script to support both

New Features:
- Introduce 'Borders' option to toggle dialog borders on or off
- Add 'LineCharacters' option to switch between line drawing and ASCII characters for borders

Enhancements:
- Update menu_display_options_general to include separate 'Show Borders' and 'Use line drawing characters' options
- Modify apply_theme.sh to apply border visibility and style flags based on the new settings
- Initialize 'Borders' setting to 'yes' in the default menu.ini