### PR TITLE
Always return a version if a branch name is not passed to `ds_version`

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -389,18 +389,18 @@ ds_version() {
     fi
 
     pushd "${SCRIPTPATH}" &> /dev/null || fatal "Failed to change directory.\nFailing command: ${F[C]}pushd \"${SCRIPTPATH}\""
-    if ds_branch_exists "${Branch}"; then
+    if [[ -z ${CheckBranch-} ]] || ds_branch_exists "${Branch}"; then
         # Get the current tag. If no tag, use the commit instead.
-        local Version
-        Version="$(git describe --tags --exact-match "${commitish}" 2> /dev/null || true)"
-        if [[ -z ${Version-} ]]; then
-            Version="commit $(git rev-parse --short "${commitish}" 2> /dev/null || true)"
+        local VersionString
+        VersionString="$(git describe --tags --exact-match "${commitish}" 2> /dev/null || true)"
+        if [[ -z ${VersionString-} ]]; then
+            VersionString="commit $(git rev-parse --short "${commitish}" 2> /dev/null || true)"
         fi
-        Version="${Branch} ${Version}"
+        VersionString="${Branch} ${VersionString}"
     else
-        Version=''
+        VersionString=''
     fi
-    echo "${Version}"
+    echo "${VersionString}"
     popd &> /dev/null
 }
 ds_update_available() {


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Simplify the ds_version function to always produce a version string when no branch check is requested and improve variable naming for clarity

Enhancements:
- Skip branch-existence check in ds_version when the CheckBranch flag is unset to always return a version
- Rename the local Version variable to VersionString for clearer intent