### PR TITLE
Use `Run 'ds` instead of `Do 'ds` in notices.

### DIFF
--- a/.scripts/yml_merge.sh
+++ b/.scripts/yml_merge.sh
@@ -24,7 +24,7 @@ commands_yml_merge() {
             if [[ -f ${main_yml} ]]; then
                 if run_script 'app_is_depreciated' "${APPNAME}"; then
                     warn "${AppName} IS DEPRECATED!"
-                    warn "Please do 'ds --status-disable ${AppName}' to disable it."
+                    warn "Please run 'ds --status-disable ${AppName}' to disable it."
                 fi
                 local arch_yml
                 arch_yml="$(run_script 'app_instance_file' "${appname}" ".${ARCH}.yml")"

--- a/main.sh
+++ b/main.sh
@@ -928,7 +928,7 @@ main() {
         if ! ds_branch_exists "${MainBranch}"; then
             error "${APPLICATION_NAME} does not appear to have a '${TARGET_BRANCH}' or '${SOURCE_BRANCH}' branch."
         else
-            warn "Do 'ds -u ${MainBranch}' to update to the latest stable release $(ds_version "${MainBranch}")."
+            warn "Run 'ds -u ${MainBranch}' to update to the latest stable release $(ds_version "${MainBranch}")."
         fi
     fi
     # Apply the GUI theme


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Update user warning messages to use 'Run' instead of 'Do' before ds commands for consistency.

Enhancements:
- Change deprecation warning in yml_merge.sh to use "Run 'ds --status-disable ...'"
- Update update warning in main.sh to use "Run 'ds -u ...'"