### PR TITLE
Use more consistent notices

### DIFF
--- a/.scripts/appvars_rename.sh
+++ b/.scripts/appvars_rename.sh
@@ -15,7 +15,7 @@ appvars_rename() {
         notice "Migrating vars."
         sed -i "s/^\s*${FROMAPP^^}__/${TOAPP^^}__/" "${COMPOSE_ENV}" || fatal "Failed to migrate vars from ${FROMAPP^^}__ to ${TOAPP^^}__\nFailing command: ${F[C]}sed -i \"s/^\\s*${FROMAPP^^}__/${TOAPP^^}__/\" \"${COMPOSE_ENV}\""
         run_script 'appvars_create' "${TOAPP^^}"
-        notice "Completed migrating from ${FROMAPP^^} to ${TOAPP^^}. Run ${F[C]}ds -c${NC} to create the new container."
+        notice "Completed migrating from ${FROMAPP^^} to ${TOAPP^^}. Run '${F[C]}ds -c${NC}' to create the new container."
     fi
 }
 

--- a/.scripts/update_self.sh
+++ b/.scripts/update_self.sh
@@ -7,7 +7,7 @@ update_self() {
     BRANCH=${1-}
     shift || true
     if [[ ${BRANCH-} == "${SOURCE_BRANCH}" ]] && ds_branch_exists "${TARGET_BRANCH}"; then
-        warn "Updating to branch ${TARGET_BRANCH} instead of ${SOURCE_BRANCH}."
+        warn "Updating to branch '${F[C]}${TARGET_BRANCH}${NC}' instead of '${F[C]}${SOURCE_BRANCH}${NC}'."
         BRANCH="${TARGET_BRANCH}"
     fi
 
@@ -22,31 +22,31 @@ update_self() {
             return 1
         fi
         RemoteVersion="$(ds_version "${CurrentBranch}")"
-        Question="Would you like to update ${APPLICATION_NAME} from ${CurrentVersion} to ${RemoteVersion} now?"
+        Question="Would you like to update ${APPLICATION_NAME} from ${F[C]}${CurrentVersion}${NC} to ${F[C]}${RemoteVersion}${NC} now?"
         NoNotice="${APPLICATION_NAME} will not be updated."
-        YesNotice="Updating ${APPLICATION_NAME} from ${CurrentVersion} to ${RemoteVersion}"
+        YesNotice="Updating ${APPLICATION_NAME} from ${F[C]}${CurrentVersion}${NC} to ${F[C]}${RemoteVersion}${NC}"
     elif [[ ${BRANCH-} == "${CurrentBranch-}" ]]; then
         RemoteVersion="$(ds_version "${BRANCH}")"
         if [[ ${CurrentVersion} == "${RemoteVersion}" ]]; then
-            Question="Would you like to forcefully re-apply ${APPLICATION_NAME} update ${CurrentVersion}?"
+            Question="Would you like to forcefully re-apply ${APPLICATION_NAME} update ${F[C]}${CurrentVersion}${NC}?"
             NoNotice="${APPLICATION_NAME} will not be updated."
-            YesNotice="Updating ${APPLICATION_NAME} to ${RemoteVersion}"
+            YesNotice="Updating ${APPLICATION_NAME} to ${F[C]}${RemoteVersion}${NC}"
         else
-            Question="Would you like to update ${APPLICATION_NAME} from ${CurrentVersion} to ${RemoteVersion} now?"
-            NoNotice="${APPLICATION_NAME} will not be updated from ${CurrentVersion} to ${RemoteVersion}"
-            YesNotice="Updating ${APPLICATION_NAME} from ${CurrentVersion} to ${RemoteVersion}"
+            Question="Would you like to update ${APPLICATION_NAME} from ${F[C]}${CurrentVersion}${NC} to ${F[C]}${RemoteVersion}${NC} now?"
+            NoNotice="${APPLICATION_NAME} will not be updated from ${F[C]}${CurrentVersion}${NC} to ${F[C]}${RemoteVersion}${NC}"
+            YesNotice="Updating ${APPLICATION_NAME} from ${F[C]}${CurrentVersion}${NC} to ${F[C]}${RemoteVersion}${NC}"
         fi
     else
         RemoteVersion="$(ds_version "${BRANCH}")"
-        Question="Would you like to update ${APPLICATION_NAME} from ${CurrentVersion} to ${RemoteVersion} now?"
-        NoNotice="${APPLICATION_NAME} will not be updated from ${CurrentVersion} to ${RemoteVersion}"
-        YesNotice="Updating ${APPLICATION_NAME} from ${CurrentVersion} to ${RemoteVersion}"
+        Question="Would you like to update ${APPLICATION_NAME} from ${F[C]}${CurrentVersion}${NC} to ${F[C]}${RemoteVersion}${NC} now?"
+        NoNotice="${APPLICATION_NAME} will not be updated from ${F[C]}${CurrentVersion}${NC} to ${F[C]}${RemoteVersion}${NC}"
+        YesNotice="Updating ${APPLICATION_NAME} from ${F[C]}${CurrentVersion}${NC} to ${F[C]}${RemoteVersion}${NC}"
     fi
     popd &> /dev/null
 
     if ! ds_branch_exists "${BRANCH}"; then
         BRANCH="${BRANCH:-"${CurrentBranch}"}"
-        local ErrorMessage="${APPLICATION_NAME} branch ${BRANCH} does not exists."
+        local ErrorMessage="${APPLICATION_NAME} branch ${F[C]}${BRANCH}${NC} does not exists."
         if use_dialog_box; then
             error "${ErrorMessage}" |&
                 dialog_pipe "${DC[TitleError]}${Title}" "${DC[CommandLine]} ds --update $*"
@@ -58,12 +58,12 @@ update_self() {
     if [[ -z ${BRANCH-} && ${CurrentVersion} == "${RemoteVersion}" ]]; then
         if use_dialog_box; then
             {
-                notice "${APPLICATION_NAME} is already up to date on branch ${CurrentBranch}."
-                notice "Current version is ${CurrentVersion}"
+                notice "${APPLICATION_NAME} is already up to date on branch ${F[C]}${CurrentBranch}${NC}."
+                notice "Current version is ${F[C]}${CurrentVersion}${NC}"
             } |& dialog_pipe "${DC[TitleWarning]}${Title}" "${DC[CommandLine]} ds --update $*"
         else
-            notice "${APPLICATION_NAME} is already up to date on branch ${CurrentBranch}."
-            notice "Current version is ${CurrentVersion}"
+            notice "${APPLICATION_NAME} is already up to date on branch ${F[C]}${CurrentBranch}${NC}."
+            notice "Current version is ${F[C]}${CurrentVersion}${NC}"
         fi
         return 0
     fi
@@ -122,7 +122,7 @@ commands_update_self() {
     git ls-tree -rt --name-only "${BRANCH}" | xargs sudo chown "${DETECTED_PUID}":"${DETECTED_PGID}" > /dev/null 2>&1 || true
     sudo chown -R "${DETECTED_PUID}":"${DETECTED_PGID}" "${SCRIPTPATH}/.git" > /dev/null 2>&1 || true
     sudo chown "${DETECTED_PUID}":"${DETECTED_PGID}" "${SCRIPTPATH}" > /dev/null 2>&1 || true
-    notice "Updated ${APPLICATION_NAME} to $(ds_version)"
+    notice "Updated ${APPLICATION_NAME} to ${F[C]}$(ds_version)${NC}"
     popd &> /dev/null
     if [[ -z $* ]]; then
         exec bash "${SCRIPTNAME}" -e

--- a/.scripts/yml_merge.sh
+++ b/.scripts/yml_merge.sh
@@ -24,7 +24,7 @@ commands_yml_merge() {
             if [[ -f ${main_yml} ]]; then
                 if run_script 'app_is_depreciated' "${APPNAME}"; then
                     warn "${AppName} IS DEPRECATED!"
-                    warn "Please run 'ds --status-disable ${AppName}' to disable it."
+                    warn "Please run '${F[C]}ds --status-disable ${AppName}${NC}' to disable it."
                 fi
                 local arch_yml
                 arch_yml="$(run_script 'app_instance_file' "${appname}" ".${ARCH}.yml")"

--- a/main.sh
+++ b/main.sh
@@ -912,23 +912,23 @@ main() {
     Branch="$(ds_branch)"
     if ds_branch_exists "${Branch}"; then
         if ds_update_available; then
-            notice "${APPLICATION_NAME} [${APPLICATION_VERSION}]"
+            notice "${APPLICATION_NAME} [${F[C]}${APPLICATION_VERSION}${NC}]"
             notice "An update to ${APPLICATION_NAME} is available."
-            notice "Run 'ds -u' to update to version $(ds_version "${Branch}")."
+            notice "Run '${F[C]}ds -u${NC}' to update to version ${F[C]}$(ds_version "${Branch}")${NC}."
         else
-            info "${APPLICATION_NAME} [${APPLICATION_VERSION}]"
+            info "${APPLICATION_NAME} [${F[C]}${APPLICATION_VERSION}${NC}]"
         fi
     else
         local MainBranch="${TARGET_BRANCH}"
         if ! ds_branch_exists "${MainBranch}"; then
             MainBranch="${SOURCE_BRANCH}"
         fi
-        warn "${APPLICATION_NAME} branch ${Branch} appears to no longer exist."
-        warn "${APPLICATION_NAME} is currently on version $(ds_version)."
+        warn "${APPLICATION_NAME} branch '${F[C]}${Branch}${NC}' appears to no longer exist."
+        warn "${APPLICATION_NAME} is currently on version ${F[C]}$(ds_version)${NC}."
         if ! ds_branch_exists "${MainBranch}"; then
-            error "${APPLICATION_NAME} does not appear to have a '${TARGET_BRANCH}' or '${SOURCE_BRANCH}' branch."
+            error "${APPLICATION_NAME} does not appear to have a '${F[C]}${TARGET_BRANCH}${NC}' or '${F[C]}${SOURCE_BRANCH}${NC}' branch."
         else
-            warn "Run 'ds -u ${MainBranch}' to update to the latest stable release $(ds_version "${MainBranch}")."
+            warn "Run '${F[C]}ds -u ${MainBranch}${NC}' to update to the latest stable release ${F[C]}$(ds_version "${MainBranch}")${NC}."
         fi
     fi
     # Apply the GUI theme
@@ -1307,11 +1307,11 @@ main() {
         local VersionString
         VersionString="$(ds_version "${VERSION}")"
         if [[ -n ${VersionString} ]]; then
-            echo "${APPLICATION_NAME} [${VersionString}]"
+            echo "${APPLICATION_NAME} [${F[C]}${VersionString}${NC}]"
         else
             local Branch
             Branch="${VERSION:-$(ds_branch)}"
-            error "DockSTARTer branch ${Branch} does not exist."
+            error "DockSTARTer branch '${F[C]}${Branch}${NC}' does not exist."
         fi
         exit
     fi


### PR DESCRIPTION
Be more consistent in how notices including branches, versions, and command lines are shown.

Enclose command lines in single quotes, and color command lines, branches and versions CYAN.

# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Improve consistency and readability of terminal notices by quoting and colorizing command lines, branch names, and version numbers in CYAN across various shell scripts.

Enhancements:
- Enclose command lines in single quotes and apply CYAN color codes to commands in notice, warn, and error messages
- Colorize branch names and version numbers in notices across update_self.sh, main.sh, appvars_rename.sh, and yml_merge.sh for uniform formatting