### PR TITLE
Don't use ANSI colors in the output of `ds --version`

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -1307,7 +1307,7 @@ main() {
         local VersionString
         VersionString="$(ds_version "${VERSION}")"
         if [[ -n ${VersionString} ]]; then
-            echo "${APPLICATION_NAME} [${F[C]}${VersionString}${NC}]"
+            echo "${APPLICATION_NAME} [${VersionString}]"
         else
             local Branch
             Branch="${VERSION:-$(ds_branch)}"


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Enhancements:
- Stop wrapping the version string in ANSI color codes in the main version display