### PR TITLE
Add quotes and color to the branch names in the notice in `switch_bra…

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -418,7 +418,7 @@ switch_branch() {
         FORCE=true
         export FORCE
         PROMPT="CLI"
-        notice "Automatically switching from ${APPLICATION_NAME} branch ${SOURCE_BRANCH} to ${TARGET_BRANCH}."
+        notice "Automatically switching from ${APPLICATION_NAME} branch '${F[C]}${SOURCE_BRANCH}${NC}' to '${F[C]}${TARGET_BRANCH}${NC}'."
         run_script 'update_self' "${TARGET_BRANCH}" bash "${SCRIPTNAME}" "$@"
         exit
     fi


### PR DESCRIPTION
…nch`

# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Enhancements:
- Quote and apply ANSI color codes to source and target branch names in the switch_branch notification