### PR TITLE
Fix command-line parsing

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -533,7 +533,7 @@ that take app names can use the form app: to refer to the same file.
     Enable the app specified
 -t --test <test_name>
     Run tests to check the program
---theme <themename>
+-T --theme <themename>
     Applies the specified theme to the GUI
 --theme-list
     Lists the available themes
@@ -588,7 +588,7 @@ trap 'cleanup' ERR EXIT SIGABRT SIGALRM SIGHUP SIGINT SIGQUIT SIGTERM
 # Command Line Arguments
 readonly ARGS=("$@")
 cmdline() {
-    while getopts ":-:a:c:efghilpr:s:t:u:vVx" OPTION; do
+    while getopts ":-:a:c:efghilpr:s:t:T:u:vV:x" OPTION; do
         # support long options: https://stackoverflow.com/a/28466267/519360
         if [ "$OPTION" = "-" ]; then # long option: reformulate OPTION and OPTARG
             OPTION="${OPTARG}"       # extract long option name
@@ -773,10 +773,10 @@ cmdline() {
                     exit 1
                 fi
                 ;;
-            theme)
+            T | theme)
                 readonly THEMEMETHOD='theme'
                 if [[ -n ${OPTARG-} ]]; then
-                    readonly THEME="${!OPTIND}"
+                    readonly THEME="${OPTARG}"
                     OPTIND=$((OPTIND + 1))
                 fi
                 ;;
@@ -812,8 +812,14 @@ cmdline() {
                     r)
                         readonly REMOVE=true
                         ;;
+                    T)
+                        readonly THEMEMETHOD='theme'
+                        ;;
                     u)
                         readonly UPDATE=true
+                        ;;
+                    V)
+                        readonly VERSION=''
                         ;;
                     *)
                         error "${OPTARG} requires an option."


### PR DESCRIPTION
Fix parsing of `ds -V branch` (short form of `ds --version branch`) to pass the optional branch name to check the version of.

Add `ds -T theme` as a short form of `ds --theme theme`, and fix parsing of the optional theme name in that as well.

# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Fix command-line parsing by properly handling optional arguments for the version and theme flags, and add -T as a short alias for --theme.

New Features:
- Introduce -T as a short option for --theme to specify a theme name.

Bug Fixes:
- Fix parsing of optional branch name with -V short form of --version.
- Fix parsing of optional theme name with -T short form of --theme.