### PR TITLE
Remove the `filebrowser` healthcheck

### DIFF
--- a/compose/.apps/filebrowser/filebrowser.yml
+++ b/compose/.apps/filebrowser/filebrowser.yml
@@ -4,10 +4,6 @@ services:
     env_file: env_files/filebrowser<__instance>.env
     environment:
       - TZ=${TZ?}
-    healthcheck:
-      test:
-        - CMD-SHELL
-        - curl -fs http://localhost:80/health || exit 1
     restart: ${FILEBROWSER<__INSTANCE>__RESTART?}
     user: ${PUID?}:${PGID?}
     volumes:


### PR DESCRIPTION
Remove the `filebrowser` healthcheck, and instead use the healthcheck included in the container.

# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Enhancements:
- Remove custom filebrowser healthcheck from Docker Compose and rely on built-in container healthcheck