### PR TITLE
Adjust notices when applying themes

### DIFF
--- a/.scripts/apply_theme.sh
+++ b/.scripts/apply_theme.sh
@@ -28,7 +28,7 @@ apply_theme() {
     fi
 
     if ! run_script 'theme_exists' "${ThemeName}"; then
-        error "Theme ${ThemeName} does not exist."
+        error "${APPLICATION_NAME} theme '${F[C]}${ThemeName}${NC}' does not exist."
         return
     fi
 

--- a/main.sh
+++ b/main.sh
@@ -1218,14 +1218,16 @@ main() {
     if [[ -n ${THEMEMETHOD-} ]]; then
         case "${THEMEMETHOD}" in
             theme)
+                local NoticeText
                 local CommandLine
                 if [[ -n ${THEME-} ]]; then
-                    notice "Applying theme ${THEME}"
+                    NoticeText="Applying ${APPLICATION_NAME} theme ${F[C]}${THEME}${NC}"
                     CommandLine="ds --theme \"${THEME}\""
                 else
-                    notice "Applying theme $(run_script 'theme_name')"
+                    NoticeText="Applying ${APPLICATION_NAME} theme ${F[C]}$(run_script 'theme_name')${NC}"
                     CommandLine="ds --theme"
                 fi
+                notice "${NoticeText}"
                 run_script 'apply_theme' "${THEME-}"
                 if use_dialog_box; then
                     run_script 'menu_dialog_example' "" "${CommandLine}"


### PR DESCRIPTION
Add the application name to notices when applying themes.  Add CYAN color to the theme names in notices, and add single quotes around theme names in error messages, to match notices and errors in branch names.

# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Improve theme application feedback by adding the application name, applying cyan color to theme names, and quoting theme names in error messages for consistency

Enhancements:
- Prepend the application name to theme application notices
- Colorize theme names in notices and errors using cyan formatting
- Enclose theme names in single quotes in error messages for consistency