### PR TITLE
Create pre-defined colors for `notice`, `warn`, etc

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -100,10 +100,21 @@ readonly NC
 BS=$(tput cup 1000 0 2> /dev/null || true) # Bottom of screen
 readonly BS
 export BS
+
 declare -Agr C=( # Pre-defined colors
+    ["Trace"]="${F[B]}"
+    ["Debug"]="${F[B]}"
+    ["Info"]="${F[B]}"
+    ["Notice"]="${F[G]}"
+    ["Warn"]="${F[Y]}"
+    ["Error"]="${F[R]}"
+    ["Fatal"]="${B[R]}${F[W]}"
+
     ["App"]="${F[C]}"
     ["Branch"]="${F[C]}"
     ["Command"]="${F[C]}"
+    ["RunningCommand"]="${F[C]}"
+    ["UserCommand"]="${F[C]}"
     ["FailingCommand"]="${F[C]}"
     ["File"]="${F[C]}"
     ["Folder"]="${F[C]}"
@@ -181,14 +192,14 @@ log() {
     # Output the message to the log file without color
     echo -e "${STRIPPED_MESSAGE-}" >> "${MKTEMP_LOG}"
 }
-trace() { log "${TRACE-}" "${NC}$(date +"%F %T") ${F[B]}[TRACE ]${NC}   $*${NC}"; }
-debug() { log "${DEBUG-}" "${NC}$(date +"%F %T") ${F[B]}[DEBUG ]${NC}   $*${NC}"; }
-info() { log "${VERBOSE-}" "${NC}$(date +"%F %T") ${F[B]}[INFO  ]${NC}   $*${NC}"; }
-notice() { log true "${NC}$(date +"%F %T") ${F[G]}[NOTICE]${NC}   $*${NC}"; }
-warn() { log true "${NC}$(date +"%F %T") ${F[Y]}[WARN  ]${NC}   $*${NC}"; }
-error() { log true "${NC}$(date +"%F %T") ${F[R]}[ERROR ]${NC}   $*${NC}"; }
+trace() { log "${TRACE-}" "${NC}$(date +"%F %T") ${C["Trace"]}[TRACE ]${NC}   $*${NC}"; }
+debug() { log "${DEBUG-}" "${NC}$(date +"%F %T") ${C["Debug"]}[DEBUG ]${NC}   $*${NC}"; }
+info() { log "${VERBOSE-}" "${NC}$(date +"%F %T") ${C["Info"]}[INFO  ]${NC}   $*${NC}"; }
+notice() { log true "${NC}$(date +"%F %T") ${C["Notice"]}[NOTICE]${NC}   $*${NC}"; }
+warn() { log true "${NC}$(date +"%F %T") ${C["Warn"]}[WARN  ]${NC}   $*${NC}"; }
+error() { log true "${NC}$(date +"%F %T") ${C["Error"]}[ERROR ]${NC}   $*${NC}"; }
 fatal() {
-    log true "${NC}$(date +"%F %T") ${B[R]}${F[W]}[FATAL ]${NC}   $*${NC}"
+    log true "${NC}$(date +"%F %T") ${C["Fatal"]}[FATAL ]${NC}   $*${NC}"
     exit 1
 }
 


### PR DESCRIPTION
`

# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Centralize ANSI color codes in a shared map and update logging functions to use those predefined colors

Enhancements:
- Introduce an associative array C to hold common ANSI color codes for log levels and contexts
- Add predefined color entries for Trace, Debug, Info, Notice, Warn, Error, Fatal, RunningCommand, and UserCommand
- Refactor trace, debug, info, notice, warn, error, and fatal functions to reference the new color map instead of inline codes