### PR TITLE
Replace the rest of the hard-coded CYAN colors with pre-defined varia…

### DIFF
--- a/.scripts/app_env_file.sh
+++ b/.scripts/app_env_file.sh
@@ -6,7 +6,7 @@ app_env_file() {
     local AppName=${1:-}
 
     if [[ ! -d ${APP_ENV_FOLDER} ]]; then
-        warn "Folder ${F[C]}${APP_ENV_FOLDER}${NC} not found. Creating it."
+        warn "Folder ${C["Folder"]}${APP_ENV_FOLDER}${NC} not found. Creating it."
         mkdir -p "${APP_ENV_FOLDER}" ||
             fatal "Failed to create folder.\nFailing command: ${C["FailingCommand"]}mkdir -p \"${APP_ENV_FOLDER}\""
     fi

--- a/.scripts/app_instance_file.sh
+++ b/.scripts/app_instance_file.sh
@@ -15,7 +15,7 @@ app_instance_file() {
 
     if [[ ! -d ${INSTANCES_FOLDER} ]]; then
         mkdir -p "${INSTANCES_FOLDER}" ||
-            fatal "Failed to create folder ${F[C]}${INSTANCES_FOLDER}${NC}. ${F[C]}Failing command: mkdir -p \"${INSTANCES_FOLDER}\""
+            fatal "Failed to create folder ${C["Folder"]}${INSTANCES_FOLDER}${NC}. Failing command: mkdir -p \"${INSTANCES_FOLDER}\""
         run_script 'set_permissions' "${INSTANCES_FOLDER}"
     fi
 
@@ -23,7 +23,7 @@ app_instance_file() {
     InstanceFolder="${INSTANCES_FOLDER}/${appname}"
     if [[ ! -d ${InstanceFolder} ]]; then
         mkdir -p "${InstanceFolder}" ||
-            fatal "Failed to create folder ${F[C]}${InstanceFolder}${NC}. ${F[C]}Failing command: mkdir -p \"${InstanceFolder}\""
+            fatal "Failed to create folder ${C["Folder"]}${InstanceFolder}${NC}. Failing command: ${C["FailingCommand"]}mkdir -p \"${InstanceFolder}\""
         run_script 'set_permissions' "${InstanceFolder}"
     fi
 

--- a/.scripts/app_instance_folder.sh
+++ b/.scripts/app_instance_folder.sh
@@ -20,12 +20,12 @@ app_instance_folder() {
     echo "${InstanceFolder}"
     if [[ ! -d ${InstanceFolder} ]]; then
         if [[ ! -d ${TemplateFolder} ]]; then
-            warn "Folder ${F[C]}${TemplateFolder}${NC} does not exist."
+            warn "Folder ${C["Folder"]}${TemplateFolder}${NC} does not exist."
             return
         fi
         if [[ ! -d ${InstanceFolder} ]]; then
             mkdir -p "${InstanceFolder}" ||
-                fatal "Failed to create folder ${F[C]}${InstanceFolder}${NC}. ${F[C]}Failing command: mkdir -p \"${InstanceFolder}\""
+                fatal "Failed to create folder ${C["Folder"]}${InstanceFolder}${NC}. Failing command: ${C["FailingCommand"]}mkdir -p \"${InstanceFolder}\""
             run_script 'set_permissions' "${InstanceFolder}"
         fi
     fi

--- a/.scripts/appfolders_create.sh
+++ b/.scripts/appfolders_create.sh
@@ -28,8 +28,8 @@ appfolders_create() {
             if [[ -n ${FOLDERS_ARRAY[*]-} ]]; then
                 notice "Creating config folders for ${C["App"]}${AppName}${NC}."
                 for FOLDER in "${FOLDERS_ARRAY[@]-}"; do
-                    notice "Creating folder ${F[C]}${FOLDER}${NC}"
-                    mkdir -p "${FOLDER}" || warn "Could not create folder ${F[C]}${FOLDER}${NC}"
+                    notice "Creating folder ${C["Folder"]}${FOLDER}${NC}"
+                    mkdir -p "${FOLDER}" || warn "Could not create folder ${C["Folder"]}${FOLDER}${NC}"
                     if [[ -d ${FOLDER} ]]; then
                         run_script 'set_permissions' "${FOLDER}"
                     fi

--- a/.scripts/apply_theme.sh
+++ b/.scripts/apply_theme.sh
@@ -28,7 +28,7 @@ apply_theme() {
     fi
 
     if ! run_script 'theme_exists' "${ThemeName}"; then
-        error "${APPLICATION_NAME} theme '${F[C]}${ThemeName}${NC}' does not exist."
+        error "${APPLICATION_NAME} theme '${C["Theme"]}${ThemeName}${NC}' does not exist."
         return
     fi
 

--- a/.scripts/appvars_create_all.sh
+++ b/.scripts/appvars_create_all.sh
@@ -11,7 +11,7 @@ appvars_create_all() {
         notice "Creating environment variables for added apps. Please be patient, this can take a while."
         run_script 'appvars_create' "${AddedApps}"
     else
-        notice "${F[C]}${COMPOSE_ENV}${NC} does not contain any added apps."
+        notice "${C["File"]}${COMPOSE_ENV}${NC} does not contain any added apps."
     fi
     run_script 'env_update'
 }

--- a/.scripts/appvars_purge.sh
+++ b/.scripts/appvars_purge.sh
@@ -76,18 +76,18 @@ EOF
 
             if [[ -n ${GlobalVarsToRemove[*]-} ]]; then
                 # Remove variables from global .env file
-                notice "Removing variables from ${F[C]}${COMPOSE_ENV}${NC}:"
+                notice "Removing variables from ${C["File"]}${COMPOSE_ENV}${NC}:"
                 for line in "${GlobalLinesToRemoveArray[@]}"; do
-                    notice "   ${F[C]}$line${NC}"
+                    notice "   ${C["Var"]}$line${NC}"
                 done
                 sed -i -E "/^\s*(${GlobalVarsRegex})\s*=/d" "${COMPOSE_ENV}" ||
                     fatal "Failed to purge ${C["App"]}${AppName}${NC} variables.\nFailing command: ${C["FailingCommand"]}sed -i -E \"/^\\\*(${GlobalVarsRegex})\\\*/d\" \"${COMPOSE_ENV}\""
             fi
             if [[ -n ${AppEnvVarsToRemove[*]-} ]]; then
                 # Remove variables from file
-                notice "Removing variables from ${F[C]}${AppEnvFile}${NC}:"
+                notice "Removing variables from ${C["File"]}${AppEnvFile}${NC}:"
                 for line in "${AppEnvLinesToRemoveArray[@]}"; do
-                    notice "   ${F[C]}$line${NC}"
+                    notice "   ${C["Var"]}$line${NC}"
                 done
                 sed -i -E "/^\s*(${AppEnvVarsRegex})\s*=/d" "${AppEnvFile}" ||
                     fatal "Failed to purge ${C["App"]}${AppName}${NC} variables.\nFailing command: ${C["FailingCommand"]}sed -i -E \"/^\\\*(${AppEnvVarsRegex})\\\*/d\" \"${AppEnvFile}\""

--- a/.scripts/appvars_purge_all.sh
+++ b/.scripts/appvars_purge_all.sh
@@ -14,7 +14,7 @@ appvars_purge_all() {
             done
         fi
     else
-        notice "${F[C]}${COMPOSE_ENV}${NC} does not contain any disabled apps."
+        notice "${C["File"]}${COMPOSE_ENV}${NC} does not contain any disabled apps."
     fi
 }
 

--- a/.scripts/appvars_rename.sh
+++ b/.scripts/appvars_rename.sh
@@ -6,16 +6,16 @@ appvars_rename() {
     local FROMAPP=${1-}
     local TOAPP=${2-}
     if run_script 'app_is_enabled' "${FROMAPP}" && ! run_script 'app_is_enabled' "${TOAPP}"; then
-        notice "Migrating from ${F[C]}${FROMAPP^^}${NC} to ${F[C]}${TOAPP^^}${NC}."
-        docker stop "${FROMAPP,,}" || warn "Failed to stop ${F[C]}${FROMAPP,,}${NC} container.\nFailing command: ${C["FailingCommand"]}docker stop ${FROMAPP,,}"
+        notice "Migrating from ${C["App"]}${FROMAPP^^}${NC} to ${C["App"]}${TOAPP^^}${NC}."
+        docker stop "${FROMAPP,,}" || warn "Failed to stop ${C["App"]}${FROMAPP,,}${NC} container.\nFailing command: ${C["FailingCommand"]}docker stop ${FROMAPP,,}"
         notice "Moving config folder."
         local DOCKER_VOLUME_CONFIG
         DOCKER_VOLUME_CONFIG="$(run_script 'env_get' DOCKER_VOLUME_CONFIG)"
         mv "${DOCKER_VOLUME_CONFIG}/${FROMAPP,,}" "${DOCKER_VOLUME_CONFIG}/${TOAPP,,}" || warn "Failed to move folder.\nFailing command: ${C["FailingCommand"]}mv \"${DOCKER_VOLUME_CONFIG}/${FROMAPP,,}\" \"${DOCKER_VOLUME_CONFIG}/${TOAPP,,}\""
         notice "Migrating vars."
-        sed -i "s/^\s*${FROMAPP^^}__/${TOAPP^^}__/" "${COMPOSE_ENV}" || fatal "Failed to migrate vars from ${F[C]}${FROMAPP^^}__${NC} to ${F[C]}${TOAPP^^}__${NC}\nFailing command: ${C["FailingCommand"]}sed -i \"s/^\\s*${FROMAPP^^}__/${TOAPP^^}__/\" \"${COMPOSE_ENV}\""
+        sed -i "s/^\s*${FROMAPP^^}__/${TOAPP^^}__/" "${COMPOSE_ENV}" || fatal "Failed to migrate vars from ${C["App"]}${FROMAPP^^}__${NC} to ${C["App"]}${TOAPP^^}__${NC}\nFailing command: ${C["FailingCommand"]}sed -i \"s/^\\s*${FROMAPP^^}__/${TOAPP^^}__/\" \"${COMPOSE_ENV}\""
         run_script 'appvars_create' "${TOAPP^^}"
-        notice "Completed migrating from ${F[C]}${FROMAPP^^}${NC} to ${F[C]}${TOAPP^^}${NC}. Run '${F[C]}ds -c${NC}' to create the new container."
+        notice "Completed migrating from ${C["App"]}${FROMAPP^^}${NC} to ${C["App"]}${TOAPP^^}${NC}. Run '${C["UserCommand"]}ds -c${NC}' to create the new container."
     fi
 }
 

--- a/.scripts/disable_app.sh
+++ b/.scripts/disable_app.sh
@@ -10,8 +10,8 @@ disable_app() {
         if run_script 'app_is_builtin' "${AppName}"; then
             EnabledVar="${AppName^^}__ENABLED"
             info "Disabling application ${C["App"]}${AppName^^}${NC}"
-            notice "Setting variable in ${F[C]}${COMPOSE_ENV}${NC}:"
-            notice "   ${F[C]}${EnabledVar}='false'${NC}"
+            notice "Setting variable in ${C["File"]}${COMPOSE_ENV}${NC}:"
+            notice "   ${C["Var"]}${EnabledVar}='false'${NC}"
             run_script 'env_set' "${EnabledVar}" false
         else
             warn "Application ${C["App"]}${AppName^^}${NC} does not exist."

--- a/.scripts/docker_compose.sh
+++ b/.scripts/docker_compose.sh
@@ -111,7 +111,7 @@ docker_compose() {
                 run_script 'yml_merge'
                 for index in "${!ComposeCommand[@]}"; do
                     local Command="docker compose --project-directory ${COMPOSE_FOLDER}/ ${ComposeCommand[index]}"
-                    notice "Running: ${F[C]}${Command}${NC}"
+                    notice "Running: ${C["RunningCommand"]}${Command}${NC}"
                     eval "${Command}" ||
                         fatal "Failed to run compose.\nFailing command: ${C["FailingCommand"]}${Command}"
                 done
@@ -122,7 +122,7 @@ docker_compose() {
             run_script 'yml_merge'
             for index in "${!ComposeCommand[@]}"; do
                 local Command="docker compose --project-directory ${COMPOSE_FOLDER}/ ${ComposeCommand[index]}"
-                notice "Running: ${F[C]}${Command}${NC}"
+                notice "Running: ${C["RunningCommand"]}${Command}${NC}"
                 eval "${Command}" ||
                     fatal "Failed to run compose.\nFailing command: ${C["FailingCommand"]}${Command}"
             done

--- a/.scripts/docker_prune.sh
+++ b/.scripts/docker_prune.sh
@@ -13,12 +13,12 @@ docker_prune() {
         if use_dialog_box; then
             {
                 notice "${YesNotice}"
-                notice "Running: ${F[C]}${Command}${NC}"
+                notice "Running: ${C["RunningCommand"]}${Command}${NC}"
                 eval "${Command}" || error "Failed to remove unused docker resources.\nFailing command: ${C["FailingCommand"]}${Command}"
             } |& dialog_pipe "${DC[TitleSuccess]}${Title}" "${YesNotice}${DC[NC]}\n${DC[CommandLine]} ${Command}"
         else
             notice "${YesNotice}"
-            notice "Running: ${F[C]}${Command}${NC}"
+            notice "Running: ${C["RunningCommand"]}${Command}${NC}"
             eval "${Command}" || error "Failed to remove unused docker resources.\nFailing command: ${C["FailingCommand"]}${Command}"
         fi
     else

--- a/.scripts/enable_app.sh
+++ b/.scripts/enable_app.sh
@@ -10,8 +10,8 @@ enable_app() {
         if run_script 'app_is_builtin' "${AppName}"; then
             EnabledVar="${AppName^^}__ENABLED"
             info "Enabling application ${C["App"]}${AppName^^}${NC}"
-            notice "Setting variable in ${F[C]}${COMPOSE_ENV}${NC}:"
-            notice "   ${F[C]}${EnabledVar}='true'${NC}"
+            notice "Setting variable in ${C["File"]}${COMPOSE_ENV}${NC}:"
+            notice "   ${C["Var"]}${EnabledVar}='true'${NC}"
             run_script 'env_set' "${EnabledVar}" true
         else
             warn "Application ${C["App"]}${AppName^^}${NC} does not exist."

--- a/.scripts/env_backup.sh
+++ b/.scripts/env_backup.sh
@@ -18,14 +18,14 @@ env_backup() {
         DOCKER_VOLUME_CONFIG="$(run_script 'env_get' DOCKER_VOLUME_CONFIG)"
     fi
     if [[ -z ${DOCKER_VOLUME_CONFIG-} ]]; then
-        fatal "Variable ${F[C]}DOCKER_VOLUME_CONFIG${NC} is not set in the .env file"
+        fatal "Variable ${C["Var"]}DOCKER_VOLUME_CONFIG${NC} is not set in the ${C["File"]}.env${NC} file"
     fi
     if [[ ${DOCKER_VOLUME_CONFIG-} == *~* ]]; then
         # Value contains a "~", repace it with the user's home directory
         DOCKER_VOLUME_CONFIG="${DOCKER_VOLUME_CONFIG//\~/"${DETECTED_HOMEDIR}"}"
     fi
 
-    info "Taking ownership of ${F[C]}${DOCKER_VOLUME_CONFIG}${NC} (non-recursive)."
+    info "Taking ownership of ${C["Folder"]}${DOCKER_VOLUME_CONFIG}${NC} (non-recursive)."
     sudo chown "${DETECTED_PUID}":"${DETECTED_PGID}" "${DOCKER_VOLUME_CONFIG}" > /dev/null 2>&1 || true
 
     local COMPOSE_BACKUPS_FOLDER="${DOCKER_VOLUME_CONFIG}/.compose.backups"
@@ -33,18 +33,18 @@ env_backup() {
     BACKUPTIME="$(date +"%Y%m%d.%H.%M.%S")"
     local BACKUP_FOLDER="${COMPOSE_BACKUPS_FOLDER}/${COMPOSE_FOLDER_NAME}.${BACKUPTIME}"
 
-    info "Copying ${F[C]}.env${NC} file to ${F[C]}${BACKUP_FOLDER}/.env${NC}"
+    info "Copying ${C["File"]}.env${NC} file to ${C["Folder"]}${BACKUP_FOLDER}/.env${NC}"
     mkdir -p "${BACKUP_FOLDER}" ||
         fatal "Failed to make directory.\nFailing command: ${C["FailingCommand"]}mkdir -p \"${BACKUP_FOLDER}\""
     cp "${COMPOSE_ENV}" "${BACKUP_FOLDER}/" ||
         fatal "Failed to copy backup.\nFailing command: ${C["FailingCommand"]}cp \"${COMPOSE_ENV}\" \"${BACKUP_FOLDER}/\""
 
-    info "Copying appplication env folder to ${F[C]}${BACKUP_FOLDER}/${APP_ENV_FOLDER_NAME}${NC}"
+    info "Copying appplication env folder to ${C["Folder"]}${BACKUP_FOLDER}/${APP_ENV_FOLDER_NAME}${NC}"
     cp -r "${APP_ENV_FOLDER}" "${BACKUP_FOLDER}/" ||
         fatal "Failed to copy backup.\nFailing command: ${C["FailingCommand"]}cp -r \"${APP_ENV_FOLDER}\" \"${BACKUP_FOLDER}/\""
 
     if [[ -f ${COMPOSE_OVERRIDE} ]]; then
-        info "Copying override file to ${F[C]}${BACKUP_FOLDER}/${COMPOSE_OVERRIDE_NAME}${NC}"
+        info "Copying override file to ${C["Folder"]}${BACKUP_FOLDER}/${COMPOSE_OVERRIDE_NAME}${NC}"
         cp "${COMPOSE_OVERRIDE}" "${BACKUP_FOLDER}/" ||
             fatal "Failed to copy backup.\nFailing command: ${C["FailingCommand"]}cp \"${COMPOSE_OVERRIDE}\" \"${BACKUP_FOLDER}/\""
     fi

--- a/.scripts/env_copy.sh
+++ b/.scripts/env_copy.sh
@@ -10,7 +10,7 @@ env_copy() {
 
     if [[ ! -f ${FROM_VAR_FILE} ]]; then
         # Source file does not exist, warn and return
-        warn "File ${F[C]}${FROM_VAR_FILE}${NC} does not exist."
+        warn "File ${C["File"]}${FROM_VAR_FILE}${NC} does not exist."
         return
     fi
     if [[ ${FROM_VAR_FILE} == "${TO_VAR_FILE}" && ${FROM_VAR} == "${TO_VAR}" ]]; then
@@ -26,7 +26,7 @@ env_copy() {
     fi
     if [[ ! -f ${TO_VAR_FILE} ]]; then
         # Destination file does not exist, create it
-        notice "Creating ${F[C]}${TO_VAR_FILE}${NC}"
+        notice "Creating ${C["File"]}${TO_VAR_FILE}${NC}"
         touch "${TO_VAR_FILE}"
     fi
     if run_script 'env_var_exists' "${TO_VAR}" "${TO_VAR_FILE}"; then
@@ -35,15 +35,15 @@ env_copy() {
     fi
 
     if [[ ${FROM_VAR_FILE} == "${TO_VAR_FILE}" ]]; then
-        notice "Copying variable in ${F[C]}${FROM_VAR_FILE}${NC}:"
-        notice "   ${F[C]}${FROM_VAR}${NC} to ${F[C]}${TO_VAR}${NC}"
+        notice "Copying variable in ${C["File"]}${FROM_VAR_FILE}${NC}:"
+        notice "   ${C["Var"]}${FROM_VAR}${NC} to ${C["Var"]}${TO_VAR}${NC}"
     else
         notice "Copying variable:"
-        notice "   ${F[C]}${FROM_VAR}${NC} [${F[C]}${FROM_VAR_FILE}${NC}] to"
-        notice "   ${F[C]}${TO_VAR}${NC} [${F[C]}${TO_VAR_FILE}${NC}]"
+        notice "   ${C["Var"]}${FROM_VAR}${NC} [${C["File"]}${FROM_VAR_FILE}${NC}] to"
+        notice "   ${C["Var"]}${TO_VAR}${NC} [${C["File"]}${TO_VAR_FILE}${NC}]"
     fi
     printf '\n%s\n' "${NEW_VAR_LINE}" >> "${TO_VAR_FILE}" ||
-        fatal "Failed to add '${F[C]}${NEW_VAR_LINE}${NC}' in ${F[C]}${TO_VAR_FILE}${NC}\nFailing command: ${C["FailingCommand"]}printf '\n%s\n' \"${NEW_VAR_LINE}\" >> \"${TO_VAR_FILE}\""
+        fatal "Failed to add '${C["Var"]}${NEW_VAR_LINE}${NC}' in ${C["File"]}${TO_VAR_FILE}${NC}\nFailing command: ${C["FailingCommand"]}printf '\n%s\n' \"${NEW_VAR_LINE}\" >> \"${TO_VAR_FILE}\""
 }
 
 test_env_copy() {

--- a/.scripts/env_create.sh
+++ b/.scripts/env_create.sh
@@ -18,7 +18,7 @@ env_create() {
             fatal "${F[C]}${APP_ENV_FOLDER}${NC} is a file, should be a folder"
         fi
     else
-        warn "Folder ${F[C]}${APP_ENV_FOLDER}${NC} not found. Creating it."
+        warn "Folder ${C["Folder"]}${APP_ENV_FOLDER}${NC} not found. Creating it."
         mkdir -p "${APP_ENV_FOLDER}" ||
             fatal "Failed to create folder.\nFailing command: ${C["FailingCommand"]}mkdir -p \"${APP_ENV_FOLDER}\""
     fi

--- a/.scripts/env_delete.sh
+++ b/.scripts/env_delete.sh
@@ -14,7 +14,7 @@ env_delete() {
     fi
     if [[ ! -f ${VAR_FILE} ]]; then
         # Variable file does not exist, warn and return
-        warn "File ${F[C]}${VAR_FILE}${NC} does not exist."
+        warn "File ${C["File"]}${VAR_FILE}${NC} does not exist."
         return
     fi
     if ! grep -q -P "^\s*\K${DELETE_VAR}(?=\s*=)" "${VAR_FILE}"; then
@@ -22,10 +22,10 @@ env_delete() {
         return
     fi
 
-    notice "Removing variables from ${F[C]}${VAR_FILE}${NC}:"
-    notice "   ${F[C]}${DELETE_VAR}${NC}"
+    notice "Removing variables from ${C["File"]}${VAR_FILE}${NC}:"
+    notice "   ${C["Var"]}${DELETE_VAR}${NC}"
     sed -i "/^\s*${DELETE_VAR}\s*=/d" "${VAR_FILE}" ||
-        fatal "Failed to remove var ${F[C]}${DELETE_VAR}${NC} in ${F[C]}${VAR_FILE}${NC}\nFailing command: ${C["FailingCommand"]}sed -i \"/^\\s*${DELETE_VAR}\\s*=/d\" \"${VAR_FILE}\""
+        fatal "Failed to remove var ${C["Var"]}${DELETE_VAR}${NC} in ${C["File"]}${VAR_FILE}${NC}\nFailing command: ${C["FailingCommand"]}sed -i \"/^\\s*${DELETE_VAR}\\s*=/d\" \"${VAR_FILE}\""
 }
 
 test_env_delete() {

--- a/.scripts/env_get.sh
+++ b/.scripts/env_get.sh
@@ -26,7 +26,7 @@ env_get() {
         grep --color=never -Po "^\s*${GET_VAR}\s*=\K.*" "${VAR_FILE}" | tail -1 | xargs || true
     else
         # VAR_FILE does not exist, give a warning
-        warn "File ${F[C]}${VAR_FILE}${NC} does not exist."
+        warn "File ${C["File"]}${VAR_FILE}${NC} does not exist."
     fi
 
 }

--- a/.scripts/env_merge_newonly.sh
+++ b/.scripts/env_merge_newonly.sh
@@ -17,7 +17,7 @@ env_merge_newonly() {
 
     # If "MergeFromFile" doesn't exists, give a warning
     if [[ ! -f ${MergeFromFile} ]]; then
-        warn "File ${F[C]}${MergeFromFile}${NC} does not exist."
+        warn "File ${C["File"]}${MergeFromFile}${NC} does not exist."
     else
         local MergeFromLines=()
         # Read all variable lines into an array, stripping whitespace before and after the variable name
@@ -33,13 +33,13 @@ env_merge_newonly() {
             done
         fi
         if [[ ${#MergeFromLines[@]} != 0 ]]; then
-            notice "Adding variables to ${F[C]}${MergeToFile}${NC}:"
-            echo >> "${MergeToFile}" || fatal "Failed to write to ${F[C]}${MergeToFile}${NC}.\nFailing command: ${C["FailingCommand"]}echo >> \"${MergeToFile}\"${NC}"
+            notice "Adding variables to ${C["File"]}${MergeToFile}${NC}:"
+            echo >> "${MergeToFile}" || fatal "Failed to write to ${C["File"]}${MergeToFile}${NC}.\nFailing command: ${C["FailingCommand"]}echo >> \"${MergeToFile}\"${NC}"
             for index in "${!MergeFromLines[@]}"; do
                 local line="${MergeFromLines[index]}" 2> /dev/null
-                notice "   ${F[C]}${line}${NC}"
+                notice "   ${C["Var"]}${line}${NC}"
                 env -i line="${line}" MergeToFile="${MergeToFile}" \
-                    printf '%s\n' "${line}" >> "${MergeToFile}" 2> /dev/null || fatal "Failed to add variable to ${F[C]}${MergeToFile}${NC}"
+                    printf '%s\n' "${line}" >> "${MergeToFile}" 2> /dev/null || fatal "Failed to add variable to ${C["File"]}${MergeToFile}${NC}"
             done
         fi
     fi

--- a/.scripts/env_migrate.sh
+++ b/.scripts/env_migrate.sh
@@ -30,7 +30,7 @@ env_migrate() {
 
     if [[ ! -f ${ToVarFile} ]]; then
         # Destination file does not exist, create it
-        notice "Creating ${F[C]}${ToVarFile}${NC}"
+        notice "Creating ${C["File"]}${ToVarFile}${NC}"
         touch "${ToVarFile}"
     fi
 

--- a/.scripts/env_rename.sh
+++ b/.scripts/env_rename.sh
@@ -10,7 +10,7 @@ env_rename() {
 
     if [[ ! -f ${FROM_VAR_FILE} ]]; then
         # Source file does not exist, warn and return
-        warn "File ${F[C]}${FROM_VAR_FILE}${NC} does not exist."
+        warn "File ${C["File"]}${FROM_VAR_FILE}${NC} does not exist."
         return
     fi
     if [[ ${FROM_VAR_FILE} == "${TO_VAR_FILE}" && ${FROM_VAR} == "${TO_VAR}" ]]; then
@@ -26,7 +26,7 @@ env_rename() {
     fi
     if [[ ! -f ${TO_VAR_FILE} ]]; then
         # Destination file does not exist, create it
-        notice "Creating ${F[C]}${TO_VAR_FILE}${NC}"
+        notice "Creating ${C["File"]}${TO_VAR_FILE}${NC}"
         touch "${TO_VAR_FILE}"
     fi
     if run_script 'env_var_exists' "${TO_VAR}" "${TO_VAR_FILE}"; then
@@ -35,17 +35,17 @@ env_rename() {
     fi
 
     if [[ ${FROM_VAR_FILE} == "${TO_VAR_FILE}" ]]; then
-        notice "Renaming variable in ${F[C]}${FROM_VAR_FILE}${NC}:"
-        notice "   ${F[C]}${FROM_VAR}${NC} to ${F[C]}${TO_VAR}${NC}"
+        notice "Renaming variable in ${C["File"]}${FROM_VAR_FILE}${NC}:"
+        notice "   ${C["Var"]}${FROM_VAR}${NC} to ${C["Var"]}${TO_VAR}${NC}"
     else
         notice "Moving variable:"
-        notice "   ${F[C]}${FROM_VAR}${NC} [${F[C]}${FROM_VAR_FILE}${NC}] to"
-        notice "   ${F[C]}${TO_VAR}${NC} [${F[C]}${TO_VAR_FILE}${NC}]"
+        notice "   ${C["Var"]}${FROM_VAR}${NC} [${C["File"]}${FROM_VAR_FILE}${NC}] to"
+        notice "   ${C["Var"]}${TO_VAR}${NC} [${C["File"]}${TO_VAR_FILE}${NC}]"
     fi
     printf '\n%s\n' "${NEW_VAR_LINE}" >> "${TO_VAR_FILE}" ||
-        fatal "Failed to add '${F[C]}${NEW_VAR_LINE}${NC}' in ${F[C]}${TO_VAR_FILE}${NC}\nFailing command: ${C["FailingCommand"]}printf '\n%s\n' \"${NEW_VAR_LINE}\" >> \"${TO_VAR_FILE}\""
+        fatal "Failed to add '${C["Var"]}${NEW_VAR_LINE}${NC}' in ${C["File"]}${TO_VAR_FILE}${NC}\nFailing command: ${C["FailingCommand"]}printf '\n%s\n' \"${NEW_VAR_LINE}\" >> \"${TO_VAR_FILE}\""
     sed -i "/^\s*${FROM_VAR}\s*=/d" "${FROM_VAR_FILE}" ||
-        fatal "Failed to remove var ${F[C]}${FROM_VAR}${NC} in ${F[C]}${FROM_VAR_FILE}${NC}\nFailing command: ${C["FailingCommand"]}sed -i \"/^\\s*${FROM_VAR}\\s*=/d\" \"${FROM_VAR_FILE}\""
+        fatal "Failed to remove var ${C["Var"]}${FROM_VAR}${NC} in ${C["File"]}${FROM_VAR_FILE}${NC}\nFailing command: ${C["FailingCommand"]}sed -i \"/^\\s*${FROM_VAR}\\s*=/d\" \"${FROM_VAR_FILE}\""
 }
 
 test_env_rename() {

--- a/.scripts/env_sanitize.sh
+++ b/.scripts/env_sanitize.sh
@@ -17,7 +17,7 @@ env_sanitize() {
             # If the variable is empty get the default value
             local Default
             Default="$(run_script 'var_default_value' "${VarName}")"
-            notice "Setting ${F[C]}${VarName}=${Default}${NC}"
+            notice "Setting ${C["Var"]}${VarName}=${Default}${NC}"
             run_script 'env_set_literal' "${VarName}" "${Default}"
         fi
     done
@@ -28,7 +28,7 @@ env_sanitize() {
             # If the variable is empty or contains an "x", get the default value
             local Default
             Default="$(run_script 'var_default_value' "${VarName}")"
-            notice "Setting ${F[C]}${VarName}=${Default}${NC}"
+            notice "Setting ${C["Var"]}${VarName}=${Default}${NC}"
             run_script 'env_set_literal' "${VarName}" "${Default}"
         fi
     done
@@ -37,7 +37,7 @@ env_sanitize() {
     local WATCHTOWER_NETWORK_MODE
     WATCHTOWER_NETWORK_MODE="$(run_script 'env_get' WATCHTOWER__NETWORK_MODE)"
     if [[ ${WATCHTOWER_NETWORK_MODE-} == "none" ]]; then
-        notice "Changing ${F[C]}WATCHTOWER__NETWORK_MODE${NC} from ${F[C]}'none'${NC} to ${F[C]}''${NC}"
+        notice "Changing ${C["Var"]}WATCHTOWER__NETWORK_MODE${NC} from ${C["Var"]}'none'${NC} to ${C["Var"]}''${NC}"
         run_script 'env_set' WATCHTOWER__NETWORK_MODE ""
     fi
 
@@ -62,7 +62,7 @@ env_sanitize() {
         if [[ ${Value} == *~* ]]; then
             # Value contains a "~", repace it with the user's home directory
             Value="${Value//\~/"${DETECTED_HOMEDIR}"}"
-            notice "Setting ${F[C]}${VarName}=${Value}${NC}"
+            notice "Setting ${C["Var"]}${VarName}=${Value}${NC}"
             run_script 'env_set_literal' "${VarName}" "${Value}"
         fi
     done

--- a/.scripts/env_set.sh
+++ b/.scripts/env_set.sh
@@ -32,7 +32,7 @@ env_set() {
         mkdir -p "${VAR_FILE%/*}" && touch "${VAR_FILE}"
     fi
     sed -i "/^\s*${SET_VAR}\s*=/d" "${VAR_FILE}" || true
-    echo "${SET_VAR}=${NEW_VAL}" >> "${VAR_FILE}" || fatal "Failed to set ${F[C]}${SET_VAR}=${NEW_VAL}${NC}\nFailing command: ${C["FailingCommand"]} \"echo ${SET_VAR}=${NEW_VAL}\" >> \"${VAR_FILE}\""
+    echo "${SET_VAR}=${NEW_VAL}" >> "${VAR_FILE}" || fatal "Failed to set ${C["Var"]}${SET_VAR}=${NEW_VAL}${NC}\nFailing command: ${C["FailingCommand"]} \"echo ${SET_VAR}=${NEW_VAL}\" >> \"${VAR_FILE}\""
 }
 
 test_env_set() {

--- a/.scripts/env_set_literal.sh
+++ b/.scripts/env_set_literal.sh
@@ -28,7 +28,7 @@ env_set_literal() {
         mkdir -p "${VAR_FILE%/*}" && touch "${VAR_FILE}"
     fi
     sed -i "/^\s*${SET_VAR}\s*=/d" "${VAR_FILE}" || true
-    echo "${SET_VAR}=${NEW_VAL}" >> "${VAR_FILE}" || fatal "Failed to set ${F[C]}${SET_VAR}=${NEW_VAL}${NC}\nFailing command: ${C["FailingCommand"]} \"echo ${SET_VAR}=${NEW_VAL}\" >> \"${VAR_FILE}\""
+    echo "${SET_VAR}=${NEW_VAL}" >> "${VAR_FILE}" || fatal "Failed to set ${C["Var"]}${SET_VAR}=${NEW_VAL}${NC}\nFailing command: ${C["FailingCommand"]} \"echo ${SET_VAR}=${NEW_VAL}\" >> \"${VAR_FILE}\""
 }
 
 test_env_set_literal() {

--- a/.scripts/env_update.sh
+++ b/.scripts/env_update.sh
@@ -27,12 +27,12 @@ env_update() {
     done
 
     local MKTEMP_ENV_UPDATED
-    MKTEMP_ENV_UPDATED=$(mktemp) || fatal "Failed to create temporary update ${F[C]}.env${NC} file.\nFailing command: ${C["FailingCommand"]}mktemp"
-    printf '%s\n' "${UPDATED_ENV_LINES[@]}" > "${MKTEMP_ENV_UPDATED}" || fatal "Failed to write temporary ${F[C]}.env${NC} update file."
+    MKTEMP_ENV_UPDATED=$(mktemp) || fatal "Failed to create temporary update ${C["File"]}.env${NC} file.\nFailing command: ${C["FailingCommand"]}mktemp"
+    printf '%s\n' "${UPDATED_ENV_LINES[@]}" > "${MKTEMP_ENV_UPDATED}" || fatal "Failed to write temporary ${C["File"]}.env${NC} update file."
     cp -f "${MKTEMP_ENV_UPDATED}" "${COMPOSE_ENV}" ||
         fatal "Failed to copy file.\nFailing command: ${C["FailingCommand"]}cp -f \"${MKTEMP_ENV_UPDATED}\" \"${COMPOSE_ENV}\""
     rm -f "${MKTEMP_ENV_UPDATED}" ||
-        warn "Failed to remove temporary ${F[C]}.env${NC} update file.\nFailing command: ${C["FailingCommand"]}rm -f \"${MKTEMP_ENV_UPDATED}\""
+        warn "Failed to remove temporary ${C["File"]}.env${NC} update file.\nFailing command: ${C["FailingCommand"]}rm -f \"${MKTEMP_ENV_UPDATED}\""
     run_script 'set_permissions' "${COMPOSE_ENV}"
 
     # Process all referenced appname.env files
@@ -50,13 +50,13 @@ env_update() {
                 run_script 'env_format_lines' "${APP_ENV_FILE}" "${APP_DEFAULT_ENV_FILE}" "${appname}"
             )
             local MKTEMP_APP_ENV_UPDATED
-            MKTEMP_APP_ENV_UPDATED=$(mktemp) || fatal "Failed to create temporary update ${F[C]}${appname}.env${NC} file.\nFailing command: ${C["FailingCommand"]}mktemp${NC}"
+            MKTEMP_APP_ENV_UPDATED=$(mktemp) || fatal "Failed to create temporary update ${C["File"]}${appname}.env${NC} file.\nFailing command: ${C["FailingCommand"]}mktemp${NC}"
             printf '%s\n' "${UPDATED_APP_ENV_LINES[@]}" > "${MKTEMP_APP_ENV_UPDATED}" ||
-                fatal "Failed to write temporary ${F[C]}${appname}.env${NC} update file."
+                fatal "Failed to write temporary ${C["File"]}${appname}.env${NC} update file."
             cp -f "${MKTEMP_APP_ENV_UPDATED}" "${APP_ENV_FILE}" ||
                 fatal "Failed to copy file.\nFailing command: ${C["FailingCommand"]}cp -f \"${MKTEMP_APP_ENV_UPDATED}\" \"${APP_ENV_FILE}\""
             rm -f "${MKTEMP_APP_ENV_UPDATED}" ||
-                warn "Failed to remove temporary ${F[C]}${appname}.env${NC} update file.\nFailing command: ${C["FailingCommand"]}rm -f \"${MKTEMP_APP_ENV_UPDATED}\""
+                warn "Failed to remove temporary ${C["File"]}${appname}.env${NC} update file.\nFailing command: ${C["FailingCommand"]}rm -f \"${MKTEMP_APP_ENV_UPDATED}\""
             run_script 'set_permissions' "${APP_ENV_FILE}"
         fi
     done

--- a/.scripts/menu_add_var.sh
+++ b/.scripts/menu_add_var.sh
@@ -204,11 +204,11 @@ menu_add_var() {
                             if run_script 'question_prompt' N "${Heading}\n\n${Question}" "Create Stock Variables" "" "Create" "Back"; then
                                 Heading="$(run_script 'menu_heading' ":${AppName}" "${VarNameHeading}")"
                                 {
-                                    notice "Adding variables to ${F[C]}${COMPOSE_ENV}${NC}:"
+                                    notice "Adding variables to ${C["File"]}${COMPOSE_ENV}${NC}:"
                                     for Option in "${ValidStockOptions[@]}"; do
                                         local DefaultValue
                                         DefaultValue="$(run_script 'var_default_value' "${Option// /}")"
-                                        notice "   ${F[C]}${Option// /}=${DefaultValue}${NC}"
+                                        notice "   ${C["Var"]}${Option// /}=${DefaultValue}${NC}"
                                         run_script 'env_set_literal' "${Option// /}" "${DefaultValue}"
                                     done
                                 } |& dialog_pipe "${DC["TitleSuccess"]}Creating Stock Variables" "${Heading}" "${DIALOGTIMEOUT}"

--- a/.scripts/menu_config_vars.sh
+++ b/.scripts/menu_config_vars.sh
@@ -16,11 +16,11 @@ menu_config_vars() {
     while true; do
         if [[ -n ${CurrentGlobalEnvFile-} ]]; then
             rm -f "${CurrentGlobalEnvFile}" ||
-                warn "Failed to remove temporary ${F[C]}.env${NC} file.\nFailing command: ${C["FailingCommand"]}rm -f \"${CurrentGlobalEnvFile}\""
+                warn "Failed to remove temporary ${C["File"]}.env${NC} file.\nFailing command: ${C["FailingCommand"]}rm -f \"${CurrentGlobalEnvFile}\""
         fi
         if [[ -n ${CurrentAppEnvFile-} ]]; then
             rm -f "${CurrentAppEnvFile}" ||
-                warn "Failed to remove temporary ${F[C]}${appname}.env${NC} file.\nFailing command: ${C["FailingCommand"]}rm -f \"${CurrentAppEnvFile}\""
+                warn "Failed to remove temporary ${C["File"]}${appname}.env${NC} file.\nFailing command: ${C["FailingCommand"]}rm -f \"${CurrentAppEnvFile}\""
         fi
         local DefaultGlobalEnvFile=''
         local DefaultAppEnvFile=''
@@ -227,11 +227,11 @@ menu_config_vars() {
     done
     if [[ -n ${CurrentGlobalEnvFile-} ]]; then
         rm -f "${CurrentGlobalEnvFile}" ||
-            warn "Failed to remove temporary ${F[C]}.env${NC} file.\nFailing command: ${C["FailingCommand"]}rm -f \"${CurrentGlobalEnvFile}\""
+            warn "Failed to remove temporary ${C["File"]}.env${NC} file.\nFailing command: ${C["FailingCommand"]}rm -f \"${CurrentGlobalEnvFile}\""
     fi
     if [[ -n ${CurrentAppEnvFile-} ]]; then
         rm -f "${CurrentAppEnvFile}" ||
-            warn "Failed to remove temporary ${F[C]}${appname}.env${NC} file.\nFailing command: ${C["FailingCommand"]}rm -f \"${CurrentAppEnvFile}\""
+            warn "Failed to remove temporary ${C["File"]}${appname}.env${NC} file.\nFailing command: ${C["FailingCommand"]}rm -f \"${CurrentAppEnvFile}\""
     fi
 }
 

--- a/.scripts/override_backup.sh
+++ b/.scripts/override_backup.sh
@@ -7,16 +7,16 @@ override_backup() {
         local DOCKER_VOLUME_CONFIG
         DOCKER_VOLUME_CONFIG="$(run_script 'env_get' DOCKER_VOLUME_CONFIG)"
         if [[ -z ${DOCKER_VOLUME_CONFIG-} ]]; then
-            fatal "${F[C]}DOCKER_VOLUME_CONFIG${NC} is not set in ${F[C]}${COMPOSE_ENV}${NC}"
+            fatal "${C["Var"]}DOCKER_VOLUME_CONFIG${NC} is not set in ${C["File"]}${COMPOSE_ENV}${NC}"
         fi
         local BACKUPTIME
         BACKUPTIME=$(date +"%Y%m%d%H%M%S")
-        info "Copying ${F[C]}docker-compose.override.yml${NC} file to ${F[C]}${DOCKER_VOLUME_CONFIG}/.compose.backups/docker-compose.override.yml.${BACKUPTIME}${NC}"
+        info "Copying ${C["File"]}docker-compose.override.yml${NC} file to ${C["File"]}${DOCKER_VOLUME_CONFIG}/.compose.backups/docker-compose.override.yml.${BACKUPTIME}${NC}"
         mkdir -p "${DOCKER_VOLUME_CONFIG}/.compose.backups" || fatal "Failed to make directory.\nFailing command: ${C["FailingCommand"]}mkdir -p \"${DOCKER_VOLUME_CONFIG}/.compose.backups\""
         cp "${COMPOSE_FOLDER}/docker-compose.override.yml" "${DOCKER_VOLUME_CONFIG}/.compose.backups/docker-compose.override.yml.${BACKUPTIME}" || fatal "Failed to copy file.\nFailing command: ${C["FailingCommand"]}cp \"${COMPOSE_FOLDER}/docker-compose.override.yml\" \"${DOCKER_VOLUME_CONFIG}/.compose.backups/docker-compose.override.yml.${BACKUPTIME}\""
         run_script 'set_permissions' "${DOCKER_VOLUME_CONFIG}/.compose.backups"
-        info "Removing old ${F[C]}docker-compose.override.yml${NC} backups."
-        find "${DOCKER_VOLUME_CONFIG}/.compose.backups" -type f -name "docker-compose.override.yml.*" -mtime +3 -delete > /dev/null 2>&1 || warn "Old ${F[C]}docker-compose.override.yml${NC} backups not removed."
+        info "Removing old ${C["File"]}docker-compose.override.yml${NC} backups."
+        find "${DOCKER_VOLUME_CONFIG}/.compose.backups" -type f -name "docker-compose.override.yml.*" -mtime +3 -delete > /dev/null 2>&1 || warn "Old ${C["File"]}docker-compose.override.yml${NC} backups not removed."
     fi
 }
 

--- a/.scripts/override_var_rename.sh
+++ b/.scripts/override_var_rename.sh
@@ -11,8 +11,8 @@ override_var_rename() {
         return
     fi
     if run_script 'override_var_exists' "${FromVar}"; then
-        notice "Renaming variable in ${F[C]}${COMPOSE_OVERRIDE}${NC}:"
-        notice "   ${F[C]}${FromVar}${NC} to ${F[C]}${ToVar}${NC}"
+        notice "Renaming variable in ${C["File"]}${COMPOSE_OVERRIDE}${NC}:"
+        notice "   ${C["Var"]}${FromVar}${NC} to ${C["Var"]}${ToVar}${NC}"
         # Replace $FromVar or ${FromVar followed by a word break to $ToVar or ${ToVar
         sed -i -E "s/([$]\{?)${FromVar}\b/\1${ToVar}/g" "${COMPOSE_OVERRIDE}" ||
             fatal "Failed to rename variable in override file.\nFailing command: ${C["FailingCommand"]} sed -i -E \"s/([$]\\{?)${FromVar}\\\\b/\\\\1${ToVar}/g\" \"${COMPOSE_OVERRIDE}\""

--- a/.scripts/package_manager_run.sh
+++ b/.scripts/package_manager_run.sh
@@ -19,16 +19,16 @@ package_manager_run() {
             local COMMAND_DEPS=("curl" "dialog" "git" "grep" "sed")
             for COMMAND_DEP in "${COMMAND_DEPS[@]}"; do
                 if [[ -z "$(command -v "${COMMAND_DEP}")" ]]; then
-                    fatal "${F[C]}${COMMAND_DEP}${NC} is not available. Please install ${F[C]}${COMMAND_DEP}${NC} and try again."
+                    fatal "${C["Program"]}${COMMAND_DEP}${NC} is not available. Please install ${C["Program"]}${COMMAND_DEP}${NC} and try again."
                 fi
             done
         elif [[ ${ACTION} == "install_docker" ]]; then
             if [[ -z "$(command -v docker)" ]]; then
-                fatal "${F[C]}docker${NC} is not available. Please install ${F[C]}docker${NC} and try again."
+                fatal "${C["Program"]}docker${NC} is not available. Please install ${C["Program"]}docker${NC} and try again."
             fi
             if ! docker compose version > /dev/null 2>&1; then
-                warn "Please see ${F[C]}https://docs.docker.com/compose/install/linux/${NC} to install ${F[C]}docker compose${NC}"
-                fatal "${F[C]}docker compose${NC} is not available. Please install ${F[C]}docker compose${NC} and try again."
+                warn "Please see ${C["URL"]}https://docs.docker.com/compose/install/linux/${NC} to install ${C["Program"]}docker compose${NC}"
+                fatal "${F[C]}docker compose${NC} is not available. Please install ${C["Program"]}docker compose${NC} and try again."
             fi
         fi
     fi

--- a/.scripts/pm_yum_repos.sh
+++ b/.scripts/pm_yum_repos.sh
@@ -17,7 +17,7 @@ pm_yum_repos() {
         REDIRECT='run_command_dialog "${Title}" "${COMMAND}" "" '
     fi
     COMMAND="sudo bash ${MKTEMP_GET_IUS}"
-    eval "${REDIRECT}${COMMAND}" || warn "Failed to install ${F[C]}IUS${NC}.\nFailing command: ${C["FailingCommand"]}${COMMAND}"
+    eval "${REDIRECT}${COMMAND}" || warn "Failed to install IUS.\nFailing command: ${C["FailingCommand"]}${COMMAND}"
     rm -f "${MKTEMP_GET_IUS}" || warn "Failed to remove temporary IUS repo install script.\nFailing command: ${C["FailingCommand"]}rm -f \"${MKTEMP_GET_IUS}\""
 }
 

--- a/.scripts/request_reboot.sh
+++ b/.scripts/request_reboot.sh
@@ -6,7 +6,7 @@ request_reboot() {
     notice "Your system may need to reboot for changes to take effect."
     warn "If this is your first run reboot is required."
     warn "Failure to reboot on first run can cause errors with other operations."
-    notice "Please run ${F[Y]}sudo reboot${NC} manually."
+    notice "Please run '${C["UserCommand"]}sudo reboot${NC}' manually."
     notice "If this is not your first run you may disregard this message."
 }
 

--- a/.scripts/set_permissions.sh
+++ b/.scripts/set_permissions.sh
@@ -8,15 +8,15 @@ set_permissions() {
         # https://en.wikipedia.org/wiki/Unix_filesystem
         # Split into two in order to keep the lines shorter
         "/" | "/bin" | "/boot" | "/dev" | "/etc" | "/home" | "/lib" | "/media" | "/mnt" | "/opt" | "/proc" | "/root" | "/sbin" | "/srv" | "/sys" | "/tmp" | "/unix")
-            error "Skipping permissions on ${F[C]}${CH_PATH}${NC} because it is a system path."
+            error "Skipping permissions on ${C["Folder"]}${CH_PATH}${NC} because it is a system path."
             return
             ;;
         "/usr" | "/usr/include" | "/usr/lib" | "/usr/libexec" | "/usr/local" | "/usr/share" | "/var" | "/var/log" | "/var/mail" | "/var/spool" | "/var/tmp")
-            error "Skipping permissions on ${F[C]}${CH_PATH}${NC} because it is a system path."
+            error "Skipping permissions on ${C["Folder"]}${CH_PATH}${NC} because it is a system path."
             return
             ;;
         ${DETECTED_HOMEDIR}*)
-            info "Setting permissions for ${F[C]}${CH_PATH}${NC}"
+            info "Setting permissions for ${C["Folder"]}${CH_PATH}${NC}"
             ;;
         *)
             # TODO: Consider adding a prompt to confirm setting permissions
@@ -26,12 +26,12 @@ set_permissions() {
     local CH_PUID=${2:-$DETECTED_PUID}
     local CH_PGID=${3:-$DETECTED_PGID}
     if [[ ${CH_PUID} -ne 0 ]] && [[ ${CH_PGID} -ne 0 ]]; then
-        info "Taking ownership of ${F[C]}${CH_PATH}${NC} for user ${F[C]}${CH_PUID}${NC} and group ${F[C]}${CH_PGID}${NC}"
+        info "Taking ownership of ${C["Folder"]}${CH_PATH}${NC} for user ${C["User"]}${CH_PUID}${NC} and group ${C["User"]}${CH_PGID}${NC}"
         sudo chown -R "${CH_PUID}":"${CH_PGID}" "${CH_PATH}" > /dev/null 2>&1 || true
-        info "Setting file and folder permissions in ${F[C]}${CH_PATH}${NC}"
+        info "Setting file and folder permissions in ${C["Folder"]}${CH_PATH}${NC}"
         sudo chmod -R a=,a+rX,u+w,g+w "${CH_PATH}" > /dev/null 2>&1 || true
     fi
-    info "Setting executable permission on ${F[C]}${SCRIPTNAME}${NC}"
+    info "Setting executable permission on ${C["File"]}${SCRIPTNAME}${NC}"
     sudo chmod +x "${SCRIPTNAME}" > /dev/null 2>&1 || fatal "ds must be executable.\nFailing command: ${C["FailingCommand"]}sudo chmod +x \"${SCRIPTNAME}\""
 }
 

--- a/.scripts/setup_docker_group.sh
+++ b/.scripts/setup_docker_group.sh
@@ -9,8 +9,8 @@ setup_docker_group() {
     if [[ ${CI-} == true ]]; then
         notice "Skipping usermod in CI."
     else
-        info "Adding ${F[C]}${DETECTED_UNAME}${NC} to docker group."
-        sudo usermod -aG docker "${DETECTED_UNAME}" > /dev/null 2>&1 || fatal "Failed to add ${F[C]}${DETECTED_UNAME}${NC} to docker group.\nFailing command: ${C["FailingCommand"]}sudo usermod -aG docker \"${DETECTED_UNAME}\""
+        info "Adding ${C["User"]}${DETECTED_UNAME}${NC} to docker group."
+        sudo usermod -aG docker "${DETECTED_UNAME}" > /dev/null 2>&1 || fatal "Failed to add ${C["User"]}${DETECTED_UNAME}${NC} to docker group.\nFailing command: ${C["FailingCommand"]}sudo usermod -aG docker \"${DETECTED_UNAME}\""
     fi
 }
 

--- a/.scripts/symlink_ds.sh
+++ b/.scripts/symlink_ds.sh
@@ -13,16 +13,16 @@ symlink_ds() {
 
     for SYMLINK_TARGET in "${SYMLINK_TARGETS[@]}"; do
         if [[ -L ${SYMLINK_TARGET} ]] && [[ ${SCRIPTNAME} != "$(readlink -f "${SYMLINK_TARGET}")" ]]; then
-            info "Attempting to remove ${F[C]}${SYMLINK_TARGET}${NC} symlink."
+            info "Attempting to remove ${C["File"]}${SYMLINK_TARGET}${NC} symlink."
             sudo rm -f "${SYMLINK_TARGET}" || fatal "Failed to remove file.\nFailing command: ${C["FailingCommand"]}sudo rm -f \"${SYMLINK_TARGET}\""
         fi
         if [[ ! -L ${SYMLINK_TARGET} ]]; then
-            info "Creating ${F[C]}${SYMLINK_TARGET}${NC} symbolic link for ${APPLICATION_NAME}."
+            info "Creating ${C["File"]}${SYMLINK_TARGET}${NC} symbolic link for ${APPLICATION_NAME}."
             mkdir -p "$(dirname "${SYMLINK_TARGET}")" || fatal "Failed to create directory.\nFailing command: ${C["FailingCommand"]}mkdir -p \"$(dirname "${SYMLINK_TARGET}")\""
             sudo ln -s -T "${SCRIPTNAME}" "${SYMLINK_TARGET}" || fatal "Failed to create symlink.\nFailing command: ${C["FailingCommand"]}sudo ln -s -T \"${SCRIPTNAME}\" \"${SYMLINK_TARGET}\""
         fi
         if [[ ${PATH} != *"$(dirname "${SYMLINK_TARGET}")"* ]]; then
-            warn "${F[C]}$(dirname "${SYMLINK_TARGET}")${NC} not found in PATH. Please add it to your PATH in order to use the ${F[C]}ds${NC} command alias."
+            warn "${C["File"]}$(dirname "${SYMLINK_TARGET}")${NC} not found in PATH. Please add it to your PATH in order to use the ${C["UserCommand"]}ds${NC} command alias."
         fi
     done
 }

--- a/.scripts/update_self.sh
+++ b/.scripts/update_self.sh
@@ -22,31 +22,31 @@ update_self() {
             return 1
         fi
         RemoteVersion="$(ds_version "${CurrentBranch}")"
-        Question="Would you like to update ${APPLICATION_NAME} from ${F[C]}${CurrentVersion}${NC} to ${F[C]}${RemoteVersion}${NC} now?"
+        Question="Would you like to update ${APPLICATION_NAME} from ${C["Version"]}${CurrentVersion}${NC} to ${C["Version"]}${RemoteVersion}${NC} now?"
         NoNotice="${APPLICATION_NAME} will not be updated."
-        YesNotice="Updating ${APPLICATION_NAME} from ${F[C]}${CurrentVersion}${NC} to ${F[C]}${RemoteVersion}${NC}"
+        YesNotice="Updating ${APPLICATION_NAME} from ${C["Version"]}${CurrentVersion}${NC} to ${C["Version"]}${RemoteVersion}${NC}"
     elif [[ ${BRANCH-} == "${CurrentBranch-}" ]]; then
         RemoteVersion="$(ds_version "${BRANCH}")"
         if [[ ${CurrentVersion} == "${RemoteVersion}" ]]; then
-            Question="Would you like to forcefully re-apply ${APPLICATION_NAME} update ${F[C]}${CurrentVersion}${NC}?"
+            Question="Would you like to forcefully re-apply ${APPLICATION_NAME} update ${C["Version"]}${CurrentVersion}${NC}?"
             NoNotice="${APPLICATION_NAME} will not be updated."
-            YesNotice="Updating ${APPLICATION_NAME} to ${F[C]}${RemoteVersion}${NC}"
+            YesNotice="Updating ${APPLICATION_NAME} to ${C["Version"]}${RemoteVersion}${NC}"
         else
-            Question="Would you like to update ${APPLICATION_NAME} from ${F[C]}${CurrentVersion}${NC} to ${F[C]}${RemoteVersion}${NC} now?"
-            NoNotice="${APPLICATION_NAME} will not be updated from ${F[C]}${CurrentVersion}${NC} to ${F[C]}${RemoteVersion}${NC}"
-            YesNotice="Updating ${APPLICATION_NAME} from ${F[C]}${CurrentVersion}${NC} to ${F[C]}${RemoteVersion}${NC}"
+            Question="Would you like to update ${APPLICATION_NAME} from ${C["Version"]}${CurrentVersion}${NC} to ${C["Version"]}${RemoteVersion}${NC} now?"
+            NoNotice="${APPLICATION_NAME} will not be updated from ${C["Version"]}${CurrentVersion}${NC} to ${C["Version"]}${RemoteVersion}${NC}"
+            YesNotice="Updating ${APPLICATION_NAME} from ${C["Version"]}${CurrentVersion}${NC} to ${C["Version"]}${RemoteVersion}${NC}"
         fi
     else
         RemoteVersion="$(ds_version "${BRANCH}")"
-        Question="Would you like to update ${APPLICATION_NAME} from ${F[C]}${CurrentVersion}${NC} to ${F[C]}${RemoteVersion}${NC} now?"
-        NoNotice="${APPLICATION_NAME} will not be updated from ${F[C]}${CurrentVersion}${NC} to ${F[C]}${RemoteVersion}${NC}"
-        YesNotice="Updating ${APPLICATION_NAME} from ${F[C]}${CurrentVersion}${NC} to ${F[C]}${RemoteVersion}${NC}"
+        Question="Would you like to update ${APPLICATION_NAME} from ${C["Version"]}${CurrentVersion}${NC} to ${C["Version"]}${RemoteVersion}${NC} now?"
+        NoNotice="${APPLICATION_NAME} will not be updated from ${C["Version"]}${CurrentVersion}${NC} to ${C["Version"]}${RemoteVersion}${NC}"
+        YesNotice="Updating ${APPLICATION_NAME} from ${C["Version"]}${CurrentVersion}${NC} to ${C["Version"]}${RemoteVersion}${NC}"
     fi
     popd &> /dev/null
 
     if ! ds_branch_exists "${BRANCH}"; then
         BRANCH="${BRANCH:-"${CurrentBranch}"}"
-        local ErrorMessage="${APPLICATION_NAME} branch '${F[C]}${BRANCH}${NC}' does not exists."
+        local ErrorMessage="${APPLICATION_NAME} branch '${C["Branch"]}${BRANCH}${NC}' does not exists."
         if use_dialog_box; then
             error "${ErrorMessage}" |&
                 dialog_pipe "${DC[TitleError]}${Title}" "${DC[CommandLine]} ds --update $*"
@@ -58,12 +58,12 @@ update_self() {
     if [[ -z ${BRANCH-} && ${CurrentVersion} == "${RemoteVersion}" ]]; then
         if use_dialog_box; then
             {
-                notice "${APPLICATION_NAME} is already up to date on branch ${F[C]}${CurrentBranch}${NC}."
-                notice "Current version is ${F[C]}${CurrentVersion}${NC}"
+                notice "${APPLICATION_NAME} is already up to date on branch ${C["Branch"]}${CurrentBranch}${NC}."
+                notice "Current version is ${C["Version"]}${CurrentVersion}${NC}"
             } |& dialog_pipe "${DC[TitleWarning]}${Title}" "${DC[CommandLine]} ds --update $*"
         else
-            notice "${APPLICATION_NAME} is already up to date on branch ${F[C]}${CurrentBranch}${NC}."
-            notice "Current version is ${F[C]}${CurrentVersion}${NC}"
+            notice "${APPLICATION_NAME} is already up to date on branch ${C["Branch"]}${CurrentBranch}${NC}."
+            notice "Current version is ${C["Version"]}${CurrentVersion}${NC}"
         fi
         return 0
     fi
@@ -111,8 +111,8 @@ commands_update_self() {
     info "Fetching recent changes from git."
     eval git fetch ${QUIET-} --all --prune || fatal "Failed to fetch recent changes from git.\nFailing command: ${C["FailingCommand"]}git fetch ${QUIET-} --all --prune"
     if [[ ${CI-} != true ]]; then
-        eval git switch ${QUIET-} --force "${BRANCH}" || fatal "Failed to switch to github branch ${F[C]}${BRANCH}${NC}.\nFailing command: ${C["FailingCommand"]}git switch ${QUIET-} --force \"${BRANCH}\""
-        eval git reset ${QUIET-} --hard origin/"${BRANCH}" || fatal "Failed to reset to branch ${F[C]}origin/${BRANCH}${NC}.\nFailing command: ${C["FailingCommand"]}git reset ${QUIET-} --hard origin/\"${BRANCH}\""
+        eval git switch ${QUIET-} --force "${BRANCH}" || fatal "Failed to switch to github branch ${C["Branch"]}${BRANCH}${NC}.\nFailing command: ${C["FailingCommand"]}git switch ${QUIET-} --force \"${BRANCH}\""
+        eval git reset ${QUIET-} --hard origin/"${BRANCH}" || fatal "Failed to reset to branch ${C["Branch"]}origin/${BRANCH}${NC}.\nFailing command: ${C["FailingCommand"]}git reset ${QUIET-} --hard origin/\"${BRANCH}\""
         info "Pulling recent changes from git."
         eval git pull ${QUIET-} || fatal "Failed to pull recent changes from git.\nFailing command: ${C["FailingCommand"]}git pull ${QUIET-}"
     fi
@@ -122,7 +122,7 @@ commands_update_self() {
     git ls-tree -rt --name-only "${BRANCH}" | xargs sudo chown "${DETECTED_PUID}":"${DETECTED_PGID}" > /dev/null 2>&1 || true
     sudo chown -R "${DETECTED_PUID}":"${DETECTED_PGID}" "${SCRIPTPATH}/.git" > /dev/null 2>&1 || true
     sudo chown "${DETECTED_PUID}":"${DETECTED_PGID}" "${SCRIPTPATH}" > /dev/null 2>&1 || true
-    notice "Updated ${APPLICATION_NAME} to ${F[C]}$(ds_version)${NC}"
+    notice "Updated ${APPLICATION_NAME} to ${C["Version"]}$(ds_version)${NC}"
     popd &> /dev/null
     if [[ -z $* ]]; then
         exec bash "${SCRIPTNAME}" -e

--- a/.scripts/yml_merge.sh
+++ b/.scripts/yml_merge.sh
@@ -9,7 +9,7 @@ yml_merge() {
 commands_yml_merge() {
     run_script 'appvars_create_all'
     local COMPOSE_FILE=""
-    notice "Adding enabled app templates to merge ${F[C]}docker-compose.yml${NC}. Please be patient, this can take a while."
+    notice "Adding enabled app templates to merge ${C["File"]}docker-compose.yml${NC}. Please be patient, this can take a while."
     local ENABLED_APPS
     ENABLED_APPS="$(run_script 'app_list_enabled')"
     for APPNAME in ${ENABLED_APPS-}; do
@@ -24,12 +24,12 @@ commands_yml_merge() {
             if [[ -f ${main_yml} ]]; then
                 if run_script 'app_is_depreciated' "${APPNAME}"; then
                     warn "${C["App"]}${AppName}${NC} IS DEPRECATED!"
-                    warn "Please run '${F[C]}ds --status-disable ${AppName}${NC}' to disable it."
+                    warn "Please run '${C["UserCommand"]}ds --status-disable ${AppName}${NC}' to disable it."
                 fi
                 local arch_yml
                 arch_yml="$(run_script 'app_instance_file' "${appname}" ".${ARCH}.yml")"
                 if [[ ! -f ${arch_yml} ]]; then
-                    error "${F[C]}${arch_yml}${NC} does not exist."
+                    error "${C["File"]}${arch_yml}${NC} does not exist."
                     continue
                 fi
                 COMPOSE_FILE="${COMPOSE_FILE}:${arch_yml}"
@@ -41,14 +41,14 @@ commands_yml_merge() {
                     if [[ -f ${hostname_yml} ]]; then
                         COMPOSE_FILE="${COMPOSE_FILE}:${hostname_yml}"
                     else
-                        info "${F[C]}${hostname_yml}${NC} does not exist."
+                        info "${C["File"]}${hostname_yml}${NC} does not exist."
                     fi
                     local ports_yml
                     ports_yml="$(run_script 'app_instance_file' "${appname}" ".ports.yml")"
                     if [[ -f ${ports_yml} ]]; then
                         COMPOSE_FILE="${COMPOSE_FILE}:${ports_yml}"
                     else
-                        info "${F[C]}${ports_yml}${NC} does not exist."
+                        info "${C["File"]}${ports_yml}${NC} does not exist."
                     fi
                 elif [[ -n ${AppNetMode} ]]; then
                     local netmode_yml
@@ -56,7 +56,7 @@ commands_yml_merge() {
                     if [[ -f ${netmode_yml} ]]; then
                         COMPOSE_FILE="${COMPOSE_FILE}:${netmode_yml}"
                     else
-                        info "${F[C]}${netmode_yml}${NC} does not exist."
+                        info "${C["File"]}${netmode_yml}${NC} does not exist."
                     fi
                 fi
                 local MultipleStorage
@@ -91,26 +91,26 @@ commands_yml_merge() {
                     if [[ -f ${devices_yml} ]]; then
                         COMPOSE_FILE="${COMPOSE_FILE}:${devices_yml}"
                     else
-                        info "${F[C]}${devices_yml}${NC} does not exist."
+                        info "${C["File"]}${devices_yml}${NC} does not exist."
                     fi
                 fi
                 COMPOSE_FILE="${COMPOSE_FILE}:${main_yml}"
                 info "All configurations for ${C["App"]}${AppName}${NC} are included."
             else
-                warn "${F[C]}${main_yml}${NC} does not exist."
+                warn "${C["File"]}${main_yml}${NC} does not exist."
             fi
             run_script 'appfolders_create' "${APPNAME}"
         else
-            error "${F[C]}${APP_FOLDER}/${NC} does not exist."
+            error "${C["File"]}${APP_FOLDER}/${NC} does not exist."
         fi
     done
     if [[ -z ${COMPOSE_FILE} ]]; then
         fatal "No enabled apps found."
     fi
-    info "Running compose config to create ${F[C]}docker-compose.yml${NC} file from enabled templates."
+    info "Running compose config to create ${C["File"]}docker-compose.yml${NC} file from enabled templates."
     export COMPOSE_FILE="${COMPOSE_FILE#:}"
     eval "docker compose --project-directory ${COMPOSE_FOLDER}/ config > ${COMPOSE_FOLDER}/docker-compose.yml" || fatal "Failed to output compose config.\nFailing command: ${C["FailingCommand"]}docker compose --project-directory ${COMPOSE_FOLDER}/ config > \"${COMPOSE_FOLDER}/docker-compose.yml\""
-    info "Merging ${F[C]}docker-compose.yml${NC} complete."
+    info "Merging ${C["File"]}docker-compose.yml${NC} complete."
 }
 test_yml_merge() {
     run_script 'appvars_create' WATCHTOWER

--- a/main.sh
+++ b/main.sh
@@ -112,12 +112,15 @@ declare -Agr C=( # Pre-defined colors
 
     ["App"]="${F[C]}"
     ["Branch"]="${F[C]}"
-    ["Command"]="${F[C]}"
-    ["RunningCommand"]="${F[C]}"
-    ["UserCommand"]="${F[C]}"
-    ["FailingCommand"]="${F[C]}"
+    ["FailingCommand"]="${F[R]}"
     ["File"]="${F[C]}"
     ["Folder"]="${F[C]}"
+    ["Program"]="${F[C]}"
+    ["RunningCommand"]="${F[G]}"
+    ["Theme"]="${F[C]}"
+    ["User"]="${F[C]}"
+    ["URL"]="${F[M]}"
+    ["UserCommand"]="${F[Y]}"
     ["Var"]="${F[C]}"
     ["Version"]="${F[C]}"
 )
@@ -154,7 +157,7 @@ declare -Ax DC=()
 declare -x DIALOGOTS
 
 # Log Functions
-MKTEMP_LOG=$(mktemp) || echo -e "Failed to create temporary log file.\nFailing command: ${F[C]}mktemp"
+MKTEMP_LOG=$(mktemp) || echo -e "Failed to create temporary log file.\nFailing command: ${C["FailingCommand"]}mktemp"
 readonly MKTEMP_LOG
 echo "DockSTARTer Log" > "${MKTEMP_LOG}"
 create_strip_log_colors_SEDSTRING() {
@@ -376,7 +379,7 @@ dialog_success() {
 }
 
 ds_branch() {
-    pushd "${SCRIPTPATH}" &> /dev/null || fatal "Failed to change directory.\nFailing command: ${F[C]}pushd \"${SCRIPTPATH}\""
+    pushd "${SCRIPTPATH}" &> /dev/null || fatal "Failed to change directory.\nFailing command: ${C["FailingCommand"]}pushd \"${SCRIPTPATH}\""
     git fetch --quiet &> /dev/null || true
     git symbolic-ref --short HEAD 2> /dev/null || true
     popd &> /dev/null
@@ -388,7 +391,7 @@ ds_branch_exists() {
     local CheckBranch
     CheckBranch=${1:-"${CurrentBranch}"}
 
-    pushd "${SCRIPTPATH}" &> /dev/null || fatal "Failed to change directory.\nFailing command: ${F[C]}pushd \"${SCRIPTPATH}\""
+    pushd "${SCRIPTPATH}" &> /dev/null || fatal "Failed to change directory.\nFailing command: ${C["FailingCommand"]}pushd \"${SCRIPTPATH}\""
     local -i result=0
     git ls-remote --exit-code --heads origin "${CheckBranch}" &> /dev/null || result=$?
     popd &> /dev/null
@@ -407,7 +410,7 @@ ds_version() {
         Branch="$(ds_branch)"
     fi
 
-    pushd "${SCRIPTPATH}" &> /dev/null || fatal "Failed to change directory.\nFailing command: ${F[C]}pushd \"${SCRIPTPATH}\""
+    pushd "${SCRIPTPATH}" &> /dev/null || fatal "Failed to change directory.\nFailing command: ${C["FailingCommand"]}pushd \"${SCRIPTPATH}\""
     if [[ -z ${CheckBranch-} ]] || ds_branch_exists "${Branch}"; then
         # Get the current tag. If no tag, use the commit instead.
         local VersionString
@@ -423,7 +426,7 @@ ds_version() {
     popd &> /dev/null
 }
 ds_update_available() {
-    pushd "${SCRIPTPATH}" &> /dev/null || fatal "Failed to change directory.\nFailing command: ${F[C]}pushd \"${SCRIPTPATH}\""
+    pushd "${SCRIPTPATH}" &> /dev/null || fatal "Failed to change directory.\nFailing command: ${C["FailingCommand"]}pushd \"${SCRIPTPATH}\""
     git fetch --quiet &> /dev/null
     local -i result=0
     # shellcheck disable=SC2319 # This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
@@ -928,7 +931,7 @@ main() {
     else
         if ! check_repo; then
             warn "Attempting to clone ${APPLICATION_NAME} repo to ${DETECTED_HOMEDIR}/.docker location."
-            git clone https://github.com/GhostWriters/DockSTARTer "${DETECTED_HOMEDIR}/.docker" || fatal "Failed to clone ${APPLICATION_NAME} repo.\nFailing command: ${F[C]}git clone https://github.com/GhostWriters/DockSTARTer \"${DETECTED_HOMEDIR}/.docker\""
+            git clone https://github.com/GhostWriters/DockSTARTer "${DETECTED_HOMEDIR}/.docker" || fatal "Failed to clone ${APPLICATION_NAME} repo.\nFailing command: ${C["FailingCommand"]}git clone https://github.com/GhostWriters/DockSTARTer \"${DETECTED_HOMEDIR}/.docker\""
             notice "Performing first run install."
             exec bash "${DETECTED_HOMEDIR}/.docker/main.sh" "-fvi"
         fi
@@ -941,7 +944,7 @@ main() {
         if ds_update_available; then
             notice "${APPLICATION_NAME} [${F[C]}${APPLICATION_VERSION}${NC}]"
             notice "An update to ${APPLICATION_NAME} is available."
-            notice "Run '${F[C]}ds -u${NC}' to update to version ${F[C]}$(ds_version "${Branch}")${NC}."
+            notice "Run '${C["UserCommand"]}ds -u${NC}' to update to version ${C["Version"]}$(ds_version "${Branch}")${NC}."
         else
             info "${APPLICATION_NAME} [${F[C]}${APPLICATION_VERSION}${NC}]"
         fi
@@ -951,11 +954,11 @@ main() {
             MainBranch="${SOURCE_BRANCH}"
         fi
         warn "${APPLICATION_NAME} branch '${F[C]}${Branch}${NC}' appears to no longer exist."
-        warn "${APPLICATION_NAME} is currently on version ${F[C]}$(ds_version)${NC}."
+        warn "${APPLICATION_NAME} is currently on version ${C["Version"]}$(ds_version)${NC}."
         if ! ds_branch_exists "${MainBranch}"; then
             error "${APPLICATION_NAME} does not appear to have a '${F[C]}${TARGET_BRANCH}${NC}' or '${F[C]}${SOURCE_BRANCH}${NC}' branch."
         else
-            warn "Run '${F[C]}ds -u ${MainBranch}${NC}' to update to the latest stable release ${F[C]}$(ds_version "${MainBranch}")${NC}."
+            warn "Run '${C["UserCommand"]}ds -u ${MainBranch}${NC}' to update to the latest stable release ${C["Version"]}$(ds_version "${MainBranch}")${NC}."
         fi
     fi
     # Apply the GUI theme
@@ -1242,10 +1245,10 @@ main() {
                 local NoticeText
                 local CommandLine
                 if [[ -n ${THEME-} ]]; then
-                    NoticeText="Applying ${APPLICATION_NAME} theme ${F[C]}${THEME}${NC}"
+                    NoticeText="Applying ${APPLICATION_NAME} theme ${C["Theme"]}${THEME}${NC}"
                     CommandLine="ds --theme \"${THEME}\""
                 else
-                    NoticeText="Applying ${APPLICATION_NAME} theme ${F[C]}$(run_script 'theme_name')${NC}"
+                    NoticeText="Applying ${APPLICATION_NAME} theme ${C["Theme"]}$(run_script 'theme_name')${NC}"
                     CommandLine="ds --theme"
                 fi
                 notice "${NoticeText}"


### PR DESCRIPTION
…bles

Replaced all instances of `${F[C]}` with `${C["<Colortag>"]}`. where `<ColorTag>`  is `App`, `Var`, etc.

Make `FailingCommand` RED
Make `RunningCommand` GREEN
Make `UserCommand` YELLOW
Make `URL` MAGENTA

# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Standardize color usage across the codebase by introducing semantic color tags and replacing all hard-coded CYAN references with corresponding entries from the new C associative array.

Enhancements:
- Introduce a C associative array mapping semantic tags (App, Var, Branch, File, etc.) to color codes
- Replace all occurrences of hard-coded ${F[C]} with ${C[<Tag>]} to use semantic color references
- Assign FailingCommand to red, RunningCommand to green, UserCommand to yellow, and URL to magenta in the new color map