### PR TITLE
Adjust file, folder and "running command" colors in notices

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -95,8 +95,13 @@ declare -Agr F=( # Foreground
     [W]=$(tput setaf 7 2> /dev/null || echo -e "\e[37m") # White
     [Y]=$(tput setaf 3 2> /dev/null || echo -e "\e[33m") # Yellow
 )
-NC=$(tput sgr0 2> /dev/null || echo -e "\e[0m")
+
+BD=$(tput bold 2> /dev/null || echo -e "\e[1m") # Bold
+readonly BD
+export BD
+NC=$(tput sgr0 2> /dev/null || echo -e "\e[0m") # No Color
 readonly NC
+export NC
 BS=$(tput cup 1000 0 2> /dev/null || true) # Bottom of screen
 readonly BS
 export BS
@@ -113,10 +118,10 @@ declare -Agr C=( # Pre-defined colors
     ["App"]="${F[C]}"
     ["Branch"]="${F[C]}"
     ["FailingCommand"]="${F[R]}"
-    ["File"]="${F[C]}"
-    ["Folder"]="${F[C]}"
+    ["File"]="${F[C]}${BD}"
+    ["Folder"]="${F[C]}${BD}"
     ["Program"]="${F[C]}"
-    ["RunningCommand"]="${F[G]}"
+    ["RunningCommand"]="${F[G]}${BD}"
     ["Theme"]="${F[C]}"
     ["User"]="${F[C]}"
     ["URL"]="${F[M]}"


### PR DESCRIPTION
Make file and folder names Bold Cyan.
Make running command-lines Bold Green.

# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Improve notice text styling by introducing a bold ANSI code and applying it to file names, folder names, and running command outputs

Enhancements:
- Introduce BD constant for ANSI bold styling and export it
- Apply bold cyan styling to file and folder names in notices
- Apply bold green styling to running command lines in notices