### PR TITLE
Change `UserCommand` notice color from Yellow to Bold Yellow

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -126,7 +126,7 @@ declare -Agr C=( # Pre-defined colors
     ["Update"]="${F[G]}"
     ["User"]="${F[C]}"
     ["URL"]="${F[M]}"
-    ["UserCommand"]="${F[Y]}"
+    ["UserCommand"]="${F[Y]}${BD}"
     ["Var"]="${F[C]}"
     ["Version"]="${F[C]}"
 )


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Enhancements:
- Display UserCommand notices in bold yellow instead of yellow