### PR TITLE
Change `URL` notice color from Magenta to Underlined Magenta

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -99,6 +99,9 @@ declare -Agr F=( # Foreground
 BD=$(tput bold 2> /dev/null || echo -e "\e[1m") # Bold
 readonly BD
 export BD
+UL=$(tput smul 2> /dev/null || echo -e "\e[4m") # Underline
+readonly UL
+export UL
 NC=$(tput sgr0 2> /dev/null || echo -e "\e[0m") # No Color
 readonly NC
 export NC
@@ -125,7 +128,7 @@ declare -Agr C=( # Pre-defined colors
     ["Theme"]="${F[C]}"
     ["Update"]="${F[G]}"
     ["User"]="${F[C]}"
-    ["URL"]="${F[M]}"
+    ["URL"]="${F[M]}${UL}"
     ["UserCommand"]="${F[Y]}${BD}"
     ["Var"]="${F[C]}"
     ["Version"]="${F[C]}"


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Add underline formatting support and apply it to URL notices

Enhancements:
- Introduce UL constant for underlined text formatting
- Change URL notice style to use underlined magenta