### PR TITLE
Add `Bold`, `Underline`, and `Bottom of Screen` ANSI codes to the ANSI codes to strip

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -172,7 +172,7 @@ echo "DockSTARTer Log" > "${MKTEMP_LOG}"
 create_strip_log_colors_SEDSTRING() {
     # Create the search string to strip ANSI colors
     # String is saved after creation, so this is only done on the first call
-    local -a ANSICOLORS=("${F[@]}" "${B[@]}" "${NC}")
+    local -a ANSICOLORS=("${F[@]}" "${B[@]}" "${BD}" "${UL}" "${NC}" "${BS}")
     for index in "${!ANSICOLORS[@]}"; do
         # Escape characters used by sed
         ANSICOLORS[index]=$(printf '%s' "${ANSICOLORS[index]}" | sed -E 's/[]{}()[/{}\.''''$]/\\&/g')


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Introduce ANSI underline support and extend the color-stripping logic to remove bold, underline, and bottom-of-screen sequences while updating URL styling to use underline.

Enhancements:
- Define and export a UL constant for ANSI underline codes
- Apply underline formatting to URL text styling
- Include bold, underline, and bottom-of-screen codes in the ANSI stripping pattern