### PR TITLE
Fix app_list` test

### DIFF
--- a/.scripts/app_list.sh
+++ b/.scripts/app_list.sh
@@ -23,6 +23,7 @@ app_list() {
 }
 
 test_app_list() {
+    run_script 'env_create'
     run_script 'app_list'
     # warn "CI does not test app_list."
 }


### PR DESCRIPTION
Create the `.env` file before testing `app_list` to avoid repeated warnings about the file not existing.

# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Create the .env file in the app_list test to suppress warnings about a missing .env

Bug Fixes:
- Preemptively create the .env file before running app_list to avoid missing file warnings

Tests:
- Invoke env_create in the app_list test setup