### PR TITLE
Add `strip_dialog_colors` function and use it in `question_prompt`

### DIFF
--- a/.scripts/question_prompt.sh
+++ b/.scripts/question_prompt.sh
@@ -29,6 +29,8 @@ question_prompt() {
         if [[ ${Default} == "N" ]]; then
             DIALOG_DEFAULT="--defaultno"
         fi
+        local NoticeQuestion
+        NoticeQuestion=$(strip_dialog_colors "${Question}")
         while true; do
             local YNPrompt
             if [[ ${Default} == Y ]]; then
@@ -38,7 +40,7 @@ question_prompt() {
             else
                 YNPrompt='[YN]'
             fi
-            notice "${Question}" &> /dev/null
+            notice "${NoticeQuestion}" &> /dev/null
             notice "${YNPrompt}" &> /dev/null
             # shellcheck disable=SC2206 # (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.
             local -a YesNoDialog=(
@@ -82,7 +84,8 @@ question_prompt() {
         else
             YNPrompt='[YN]'
         fi
-        notice "${Question}"
+        NoticeQuestion=$(strip_dialog_colors "${Question}")
+        notice "${NoticeQuestion}"
         notice "${YNPrompt}"
         while true; do
             read -rsn1 YN < /dev/tty

--- a/main.sh
+++ b/main.sh
@@ -186,7 +186,13 @@ create_strip_ansi_colors_SEDSTRING() {
 strip_ansi_colors_SEDSTRING="$(create_strip_ansi_colors_SEDSTRING)"
 readonly strip_ansi_colors_SEDSTRING
 strip_ansi_colors() {
+    # Strip ANSI colors from the arguments
     sed -E "${strip_ansi_colors_SEDSTRING}" <<< "$*"
+}
+strip_dialog_colors() {
+    # Strip Dialog colors from the arguments.  Dialog colors are in the form of '\Zc', where 'c' is any character
+    # shellcheck disable=SC2001 # See if you can use ${variable//search/replace} instead.
+    sed 's/\\Z.//g' <<< "$*"
 }
 log() {
     local TOTERM=${1-}


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Add strip_dialog_colors function to main.sh and update question_prompt to use it, ensuring dialog-specific color codes are removed before display

New Features:
- Introduce strip_dialog_colors function to strip Dialog \Z color codes
- Integrate strip_dialog_colors into question_prompt to remove color codes from questions before calling notice