### PR TITLE
Update `strip_ansi_colors` and `strip_dialog_colors`

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -186,13 +186,14 @@ create_strip_ansi_colors_SEDSTRING() {
 strip_ansi_colors_SEDSTRING="$(create_strip_ansi_colors_SEDSTRING)"
 readonly strip_ansi_colors_SEDSTRING
 strip_ansi_colors() {
-    # Strip ANSI colors from the arguments
-    sed -E "${strip_ansi_colors_SEDSTRING}" <<< "$*"
+    # Strip ANSI colors
+    local InputString=${1-}
+    sed -E "${strip_ansi_colors_SEDSTRING}" <<< "${InputString}"
 }
 strip_dialog_colors() {
     # Strip Dialog colors from the arguments.  Dialog colors are in the form of '\Zc', where 'c' is any character
-    # shellcheck disable=SC2001 # See if you can use ${variable//search/replace} instead.
-    sed 's/\\Z.//g' <<< "$*"
+    local InputString=${1-}
+    printf '%s' "${InputString//\\Z?/}"
 }
 log() {
     local TOTERM=${1-}


### PR DESCRIPTION
Only take a single argument for each function.
Replace `sed` with variable interpolation in `strip_dialog_colors`

# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Simplify and standardize color-stripping functions by consolidating their argument handling and optimizing dialog color removal

Enhancements:
- Restrict strip_ansi_colors and strip_dialog_colors to a single input argument
- Introduce a local InputString variable to each function
- Replace sed in strip_dialog_colors with Bash parameter expansion for faster color code removal