### PR TITLE
Convert `\n` to newlines in log messages

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -203,10 +203,10 @@ log() {
     if [[ -n ${TOTERM} ]]; then
         if [[ -t 2 ]]; then
             # Stderr is not being redirected, output with color
-            echo -e "${MESSAGE-}" >&2
+            printf '%b\n' "${MESSAGE-}" >&2
         else
             # Stderr is being redirected, output without colorr
-            echo -e "${STRIPPED_MESSAGE-}" >&2
+            printf '%b\n' "${STRIPPED_MESSAGE-}" >&2
         fi
     fi
     # Output the message to the log file without color

--- a/main.sh
+++ b/main.sh
@@ -216,15 +216,14 @@ timestamped_log() {
     local TOTERM=${1-}
     local LogLevelTag=${2-}
     shift 2
+    LogMessage=$(printf '%b' "$@")
     # Create a notice for each argument passed to the function
-    for LogMessage in "$@"; do
-        local Timestamp
-        Timestamp=$(date +"%F %T")
-        # Create separate notices with the same timestamp for each line in a log message
-        while IFS= read -r line; do
-            log "${TOTERM-}" "${NC}${C["Timestamp"]}${Timestamp}${NC} ${LogLevelTag}   ${line}${NC}"
-        done <<< "${LogMessage}"
-    done
+    local Timestamp
+    Timestamp=$(date +"%F %T")
+    # Create separate notices with the same timestamp for each line in a log message
+    while IFS= read -r line; do
+        log "${TOTERM-}" "${NC}${C["Timestamp"]}${Timestamp}${NC} ${LogLevelTag}   ${line}${NC}"
+    done <<< "${LogMessage}"
 }
 trace() { timestamped_log "${TRACE-}" "${C["Trace"]}[TRACE ]${NC}" "$@"; }
 debug() { timestamped_log "${DEBUG-}" "${C["Debug"]}[DEBUG ]${NC}" "$@"; }


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Interpret '\n' escape sequences in log messages as actual newlines and ensure each resulting line is timestamped correctly

Enhancements:
- Replace echo -e with printf '%b\n' to output messages and stripped messages with proper escape interpretation
- Refactor timestamped_log to combine all arguments into one formatted message, expand escape sequences, and split it into lines for individual timestamped entries