### PR TITLE
Replace another `echo -e` with `printf '%b\n` in the logging function

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -210,7 +210,7 @@ log() {
         fi
     fi
     # Output the message to the log file without color
-    echo -e "${STRIPPED_MESSAGE-}" >> "${MKTEMP_LOG}"
+    printf '%b\n' "${STRIPPED_MESSAGE-}" >> "${MKTEMP_LOG}"
 }
 timestamped_log() {
     local TOTERM=${1-}


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Enhancements:
- Replace echo -e with printf '%b\n' in log() to ensure consistent escape sequence handling