### PR TITLE
Show the "nicename" of apps as they are discovered for the app select…

### DIFF
--- a/.scripts/menu_app_select.sh
+++ b/.scripts/menu_app_select.sh
@@ -18,26 +18,26 @@ menu_app_select() {
         ) | tr '[:upper:]' '[:lower:]' | sort -u)
         echo "Currently added applications:"
         local LastAppLetter=''
-        for APPNAME in "${AllApps[@]-}"; do
+        for appname in "${AllApps[@]-}"; do
             local main_yml
-            main_yml="$(run_script 'app_instance_file' "${APPNAME}" ".yml")"
+            main_yml="$(run_script 'app_instance_file' "${appname}" ".yml")"
             if [[ -f ${main_yml} ]]; then
-                local AppLetter=${APPNAME:0:1}
+                local AppLetter=${appname:0:1}
                 AppLetter=${AppLetter^^}
                 if [[ -n ${LastAppLetter-} && ${LastAppLetter} != "${AppLetter}" ]]; then
                     printf '%s\n' "" "" "OFF" >> "${AppListFile}"
                 fi
                 LastAppLetter=${AppLetter}
                 local main_yml
-                arch_yml="$(run_script 'app_instance_file' "${APPNAME}" ".${ARCH}.yml")"
+                arch_yml="$(run_script 'app_instance_file' "${appname}" ".${ARCH}.yml")"
                 if [[ -f ${arch_yml} ]]; then
                     local AppName
-                    AppName=$(run_script 'app_nicename_from_template' "${APPNAME}")
+                    AppName=$(run_script 'app_nicename_from_template' "${appname}")
                     local AppDescription
-                    AppDescription=$(run_script 'app_description_from_template' "${APPNAME}")
+                    AppDescription=$(run_script 'app_description_from_template' "${appname}")
                     local AppOnOff
-                    if run_script 'app_is_added' "${APPNAME}"; then
-                        echo "   ${APPNAME}"
+                    if run_script 'app_is_added' "${AppName}"; then
+                        echo "   ${AppName}"
                         AppOnOff="on"
                         printf '%s\n' "${AppName}" >> "${AddedAppsFile}"
                     else


### PR DESCRIPTION
…ion screen

Rename `APPNAME` variable to `appname`, to show that the values are lower-case. Display the mixed-case "nicename" of apps (stored in variable AppName) when they are discovered in the user file.

# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Rename the APPNAME variable to lowercase and update the app selection menu to display and use each app's mixed-case nicename instead of its lowercase code name

Enhancements:
- Rename APPNAME variable to appname to accurately reflect lowercase usage
- Use the mixed-case nicename for discovered apps in the selection menu and related checks