### PR TITLE
Fix `app_is_runnable` for instances of apps.

### DIFF
--- a/.scripts/app_is_runnable.sh
+++ b/.scripts/app_is_runnable.sh
@@ -4,9 +4,11 @@ IFS=$'\n\t'
 
 app_is_runnable() {
     local appname=${1-}
-    appname=${appname,,}
-    local main_yml="${TEMPLATES_FOLDER}/${appname}/${appname}.yml"
-    local arch_yml="${TEMPLATES_FOLDER}/${appname}/${appname}.${ARCH}.yml"
+    local basename
+    basename=$(run_script 'appname_to_baseappname' "${appname}")
+    basename=${basename,,}
+    local main_yml="${TEMPLATES_FOLDER}/${basename}/${basename}.yml"
+    local arch_yml="${TEMPLATES_FOLDER}/${basename}/${basename}.${ARCH}.yml"
     [[ -f ${main_yml} && -f ${arch_yml} ]]
 }
 


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Bug Fixes:
- Use appname_to_baseappname and lowercase the result before locating template files to correctly detect runnable instances of apps on different architectures