### PR TITLE
Replace outputting the `Bottom of Screen` ANSI code with ` tput reset…

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -626,7 +626,7 @@ cleanup() {
     trap - ERR EXIT SIGABRT SIGALRM SIGHUP SIGINT SIGQUIT SIGTERM
 
     if [[ ${PROMPT:-CLI} == "GUI" ]]; then
-        echo -n "${BS}"
+        tput reset
     fi
 
     sudo sh -c "cat ${MKTEMP_LOG:-/dev/null} >> ${SCRIPTPATH}/dockstarter.log" || true


### PR DESCRIPTION
…` on cleanup

# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Enhancements:
- Replace echo -n "${BS}" with tput reset in cleanup when PROMPT is GUI