### PR TITLE
Add color to the warning about `dialog` not being installed.

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -757,9 +757,9 @@ cmdline() {
                 if [[ -n ${DIALOG-} ]]; then
                     PROMPT="GUI"
                 else
-                    warn "The '--gui' option requires the dialog command to be installed."
-                    warn "'dialog' command not found. Run 'ds -fiv' to install all dependencies."
-                    warn "Coninuing without '--gui' option."
+                    warn "The '${C["UserCommand"]}--gui${NC}' option requires the '${C["Program"]}dialog$}NC}' command to be installed."
+                    warn "'${C["Program"]}dialog${NC}' command not found. Run '${C["UserCommand"]}ds -fiv${NC}' to install all dependencies."
+                    warn "Coninuing without '${C["UserCommand"]}--gui${NC}' option."
                 fi
                 ;;
             h | help)
@@ -1411,9 +1411,9 @@ main() {
         PROMPT="GUI"
         run_script 'menu_main'
     else
-        error "The GUI requires the dialog command to be installed."
-        error "'dialog' command not found. Run 'ds -fiv' to install all dependencies."
-        fatal "Unable to start GUI without dialog command."
+        error "The GUI requires the '${C["Program"]}dialog${NC}' command to be installed."
+        error "'${C["Program"]}dialog${NC}' command not found. Run '${C["UserCommand"]}ds -fiv${NC}' to install all dependencies."
+        fatal "Unable to start GUI without '${C["Program"]}dialog${NC}' command."
     fi
 
 }


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Colorize warning and error messages related to the missing 'dialog' dependency to improve readability

Enhancements:
- Apply shell color variables to the '--gui' option prompt, 'dialog' command reference, and 'ds -fiv' install instruction in warnings
- Update GUI startup errors to use colored formatting for the 'dialog' command reference and installation hint