### PR TITLE
Optimize `app_is_deprecated` and `app_is_nondeprecated` by avoiding c…

### DIFF
--- a/.scripts/app_is_deprecated.sh
+++ b/.scripts/app_is_deprecated.sh
@@ -3,12 +3,15 @@ set -Eeuo pipefail
 IFS=$'\n\t'
 
 app_is_deprecated() {
-    local APPNAME=${1-}
-    local LABELS_FILE
-    LABELS_FILE="$(run_script 'app_instance_file' "${APPNAME}" ".labels.yml")"
+    local AppName=${1-}
+    local baseappname
+    baseappname=$(run_script 'appname_to_baseappname' "${AppName}")
+    baseappname="${baseappname,,}"
+    local labels_yml
+    labels_yml="${TEMPLATES_FOLDER}/${baseappname}/${baseappname}.labels.yml"
     local APP_DEPRECATED
-    if [[ -f ${LABELS_FILE} ]]; then
-        APP_DEPRECATED="$(grep --color=never -Po "\scom\.dockstarter\.appinfo\.deprecated: \K.*" "${LABELS_FILE}" | sed -E 's/^([^"].*[^"])$/"\1"/' | xargs || echo false)"
+    if [[ -f ${labels_yml} ]]; then
+        APP_DEPRECATED="$(grep --color=never -Po "\scom\.dockstarter\.appinfo\.deprecated: \K.*" "${labels_yml}" | sed -E 's/^([^"].*[^"])$/"\1"/' | xargs || echo false)"
     fi
     if [[ ${APP_DEPRECATED-} == "true" ]]; then
         return 0

--- a/.scripts/app_is_nondeprecated.sh
+++ b/.scripts/app_is_nondeprecated.sh
@@ -3,12 +3,15 @@ set -Eeuo pipefail
 IFS=$'\n\t'
 
 app_is_nondeprecated() {
-    local APPNAME=${1-}
-    local LABELS_FILE
-    LABELS_FILE="$(run_script 'app_instance_file' "${APPNAME}" ".labels.yml")"
+    local AppName=${1-}
+    local baseappname
+    baseappname=$(run_script 'appname_to_baseappname' "${AppName}")
+    baseappname="${baseappname,,}"
+    local labels_yml
+    labels_yml="${TEMPLATES_FOLDER}/${baseappname}/${baseappname}.labels.yml"
     local APP_DEPRECATED
-    if [[ -f ${LABELS_FILE} ]]; then
-        APP_DEPRECATED="$(grep --color=never -Po "\scom\.dockstarter\.appinfo\.deprecated: \K.*" "${LABELS_FILE}" | sed -E 's/^([^"].*[^"])$/"\1"/' | xargs || echo false)"
+    if [[ -f ${labels_yml} ]]; then
+        APP_DEPRECATED="$(grep --color=never -Po "\scom\.dockstarter\.appinfo\.deprecated: \K.*" "${labels_yml}" | sed -E 's/^([^"].*[^"])$/"\1"/' | xargs || echo false)"
     fi
     if [[ ${APP_DEPRECATED-} == "false" ]]; then
         return 0


### PR DESCRIPTION
…reating an instance file

# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Optimize deprecation checks by deriving the base app name and reading the labels file directly from the templates folder instead of generating an instance file

Enhancements:
- Simplify app_is_deprecated and app_is_nondeprecated to compute the base app name and locate its labels YAML in the templates folder
- Remove reliance on instance file creation by directly grepping the deprecation flag from the template’s labels file