### PR TITLE
Create an `APPLICATION_COMMAND` global variable to set the `ds` comma…

### DIFF
--- a/.scripts/appvars_rename.sh
+++ b/.scripts/appvars_rename.sh
@@ -15,7 +15,7 @@ appvars_rename() {
         notice "Migrating vars."
         sed -i "s/^\s*${FROMAPP^^}__/${TOAPP^^}__/" "${COMPOSE_ENV}" || fatal "Failed to migrate vars from ${C["App"]}${FROMAPP^^}__${NC} to ${C["App"]}${TOAPP^^}__${NC}\nFailing command: ${C["FailingCommand"]}sed -i \"s/^\\s*${FROMAPP^^}__/${TOAPP^^}__/\" \"${COMPOSE_ENV}\""
         run_script 'appvars_create' "${TOAPP^^}"
-        notice "Completed migrating from ${C["App"]}${FROMAPP^^}${NC} to ${C["App"]}${TOAPP^^}${NC}. Run '${C["UserCommand"]}ds -c${NC}' to create the new container."
+        notice "Completed migrating from ${C["App"]}${FROMAPP^^}${NC} to ${C["App"]}${TOAPP^^}${NC}. Run '${C["UserCommand"]}${APPLICATION_COMMAND} -c${NC}' to create the new container."
     fi
 }
 

--- a/.scripts/docker_compose.sh
+++ b/.scripts/docker_compose.sh
@@ -115,7 +115,7 @@ docker_compose() {
                     eval "${Command}" ||
                         fatal "Failed to run compose.\nFailing command: ${C["FailingCommand"]}${Command}"
                 done
-            } |& dialog_pipe "${DC[TitleSuccess]}${Title}" "${YesNotice}${DC[NC]}\n${DC[CommandLine]} ds --compose ${ComposeInput}"
+            } |& dialog_pipe "${DC[TitleSuccess]}${Title}" "${YesNotice}${DC[NC]}\n${DC[CommandLine]} ${APPLICATION_COMMAND} --compose ${ComposeInput}"
         else
             [[ -n ${YesNotice-} ]] && notice "${YesNotice}"
             run_script 'require_docker'

--- a/.scripts/menu_add_app.sh
+++ b/.scripts/menu_add_app.sh
@@ -99,7 +99,7 @@ menu_add_app() {
                                 run_script 'env_backup'
                                 run_script 'appvars_create' "${AppName}"
                                 run_script 'env_update'
-                            } |& dialog_pipe "${DC[TitleSuccess]}Adding Built In Application" "${Heading}\n\n${DC[Subtitle]}Adding application:\n${DC[CommandLine]} ds --add ${AppName}" "${DIALOGTIMEOUT}"
+                            } |& dialog_pipe "${DC[TitleSuccess]}Adding Built In Application" "${Heading}\n\n${DC[Subtitle]}Adding application:\n${DC[CommandLine]} ${APPLICATION_COMMAND} --add ${AppName}" "${DIALOGTIMEOUT}"
                             return
                             ;;
                         EXTRA) # User Defined

--- a/.scripts/menu_app_select.sh
+++ b/.scripts/menu_app_select.sh
@@ -80,13 +80,13 @@ menu_app_select() {
             if [[ -n ${AppsToAdd-} || -n ${AppsToRemove-} ]]; then
                 if [[ -n ${AppsToAdd-} ]]; then
                     local FormattedAppList
-                    local HeadingAddCommand=' ds --add '
+                    local HeadingAddCommand=" ${APPLICATION_COMMAND} --add "
                     local Indent='          '
                     FormattedAppList="$(printf "${Indent}%s\n" "${AppsToAdd}" | fmt -w "${COLUMNS}")"
                     HeadingAdd="Adding applications:\n${DC[CommandLine]}${HeadingAddCommand}${FormattedAppList:${#Indent}}\n"
                 fi
                 if [[ -n ${AppsToRemove-} ]]; then
-                    local HeadingRemoveCommand=' ds --remove '
+                    local HeadingRemoveCommand=" ${APPLICATION_COMMAND} --remove "
                     local Indent='             '
                     FormattedAppList="$(printf "${Indent}%s\n" "${AppsToRemove}" | fmt -w "${COLUMNS}")"
                     HeadingRemove="${DC[Subtitle]}Removing applications:\n${DC[CommandLine]}${HeadingRemoveCommand}${FormattedAppList:${#Indent}}\n"

--- a/.scripts/menu_config.sh
+++ b/.scripts/menu_config.sh
@@ -11,7 +11,7 @@ menu_config() {
     {
         run_script 'env_backup'
         run_script 'appvars_create_all' || true
-    } |& dialog_pipe "${DC[TitleSuccess]}Creating environment variables for added apps" "Please be patient, this can take a while.\n${DC[CommandLine]} ds --env" "${DIALOGTIMEOUT}"
+    } |& dialog_pipe "${DC[TitleSuccess]}Creating environment variables for added apps" "Please be patient, this can take a while.\n${DC[CommandLine]} ${APPLICATION_COMMAND} --env" "${DIALOGTIMEOUT}"
     local OptionFullSetup="Full Setup"
     local OptionEditGlobalVars="Edit Global Variables"
     local OptionSelectApps="Select Applications"
@@ -80,11 +80,11 @@ menu_config() {
                         _dialog_ "${YesNoDialog[@]}" || YesNoDialogButtonPressed=$?
                         case ${DIALOG_BUTTONS[YesNoDialogButtonPressed]-} in
                             OK) # Stop
-                                run_script_dialog "${DC["TitleSuccess"]}Docker Compose" "Stopping all running services.\n${DC["CommandLine"]} ds --compose stop" "" \
+                                run_script_dialog "${DC["TitleSuccess"]}Docker Compose" "Stopping all running services.\n${DC["CommandLine"]} ${APPLICATION_COMMAND} --compose stop" "" \
                                     'docker_compose' "stop"
                                 ;;
                             EXTRA) # Down
-                                run_script_dialog "${DC["TitleSuccess"]}Docker Compose" "Stopping and removing all containers, networks, volumes, and images.\n${DC["CommandLine"]} ds --compose down" "" \
+                                run_script_dialog "${DC["TitleSuccess"]}Docker Compose" "Stopping and removing all containers, networks, volumes, and images.\n${DC["CommandLine"]} ${APPLICATION_COMMAND} --compose down" "" \
                                     'docker_compose' "down"
                                 ;;
                             CANCEL | ESC) ;; # Cancel

--- a/.scripts/menu_dialog_example.sh
+++ b/.scripts/menu_dialog_example.sh
@@ -15,7 +15,7 @@ menu_dialog_example() {
         Message="Applied theme ${ThemeName}"
     fi
     if [[ -z ${CommandLine} ]]; then
-        CommandLine="ds --theme"
+        CommandLine="${APPLICATION_COMMAND} --theme"
     fi
 
     local Title=''

--- a/.scripts/menu_display_options_theme.sh
+++ b/.scripts/menu_display_options_theme.sh
@@ -52,7 +52,7 @@ menu_display_options_theme() {
             OK)
                 CurrentTheme="${Choice}"
                 if run_script 'apply_theme' "${CurrentTheme}"; then
-                    run_script 'menu_dialog_example' "Applied theme ${CurrentTheme}" "ds --theme \"${CurrentTheme}\""
+                    run_script 'menu_dialog_example' "Applied theme ${CurrentTheme}" "${APPLICATION_COMMAND} --theme \"${CurrentTheme}\""
                 else
                     dialog_error "${Title}" "Unable to apply theme ${CurrentTheme}"
                 fi

--- a/.scripts/run_install.sh
+++ b/.scripts/run_install.sh
@@ -12,7 +12,7 @@ run_install() {
             {
                 notice "${YesNotice}"
                 run_install_commands
-            } |& dialog_pipe "${DC[TitleSuccess]}${Title}" "${YesNotice}\n${DC[CommandLine]} ds --install"
+            } |& dialog_pipe "${DC[TitleSuccess]}${Title}" "${YesNotice}\n${DC[CommandLine]} ${APPLICATION_COMMAND} --install"
         else
             notice "${YesNotice}"
             run_install_commands

--- a/.scripts/symlink_ds.sh
+++ b/.scripts/symlink_ds.sh
@@ -5,10 +5,10 @@ IFS=$'\n\t'
 symlink_ds() {
     run_script 'set_permissions' "${SCRIPTNAME}"
 
-    local SYMLINK_TARGETS=("/usr/bin/ds" "/usr/local/bin/ds")
+    local SYMLINK_TARGETS=("/usr/bin/${APPLICATION_COMMAND}" "/usr/local/bin/${APPLICATION_COMMAND}")
 
     if findmnt -n /usr | grep -P "\bro\b" > /dev/null; then
-        SYMLINK_TARGETS=("${HOME}/bin/ds" "${HOME}/.local/bin/ds")
+        SYMLINK_TARGETS=("${HOME}/bin/${APPLICATION_COMMAND}" "${HOME}/.local/bin/${APPLICATION_COMMAND}")
     fi
 
     for SYMLINK_TARGET in "${SYMLINK_TARGETS[@]}"; do
@@ -22,7 +22,7 @@ symlink_ds() {
             sudo ln -s -T "${SCRIPTNAME}" "${SYMLINK_TARGET}" || fatal "Failed to create symlink.\nFailing command: ${C["FailingCommand"]}sudo ln -s -T \"${SCRIPTNAME}\" \"${SYMLINK_TARGET}\""
         fi
         if [[ ${PATH} != *"$(dirname "${SYMLINK_TARGET}")"* ]]; then
-            warn "${C["File"]}$(dirname "${SYMLINK_TARGET}")${NC} not found in PATH. Please add it to your PATH in order to use the ${C["UserCommand"]}ds${NC} command alias."
+            warn "${C["File"]}$(dirname "${SYMLINK_TARGET}")${NC} not found in PATH. Please add it to your PATH in order to use the '${C["UserCommand"]}${APPLICATION_COMMAND}${NC}' command alias."
         fi
     done
 }

--- a/.scripts/update_self.sh
+++ b/.scripts/update_self.sh
@@ -49,7 +49,7 @@ update_self() {
         local ErrorMessage="${APPLICATION_NAME} branch '${C["Branch"]}${BRANCH}${NC}' does not exists."
         if use_dialog_box; then
             error "${ErrorMessage}" |&
-                dialog_pipe "${DC[TitleError]}${Title}" "${DC[CommandLine]} ds --update $*"
+                dialog_pipe "${DC[TitleError]}${Title}" "${DC[CommandLine]} ${APPLICATION_COMMAND} --update $*"
         else
             error "${ErrorMessage}"
         fi
@@ -60,7 +60,7 @@ update_self() {
             {
                 notice "${APPLICATION_NAME} is already up to date on branch ${C["Branch"]}${CurrentBranch}${NC}."
                 notice "Current version is ${C["Version"]}${CurrentVersion}${NC}"
-            } |& dialog_pipe "${DC[TitleWarning]}${Title}" "${DC[CommandLine]} ds --update $*"
+            } |& dialog_pipe "${DC[TitleWarning]}${Title}" "${DC[CommandLine]} ${APPLICATION_COMMAND} --update $*"
         else
             notice "${APPLICATION_NAME} is already up to date on branch ${C["Branch"]}${CurrentBranch}${NC}."
             notice "Current version is ${C["Version"]}${CurrentVersion}${NC}"
@@ -80,7 +80,7 @@ update_self() {
 
     if use_dialog_box; then
         commands_update_self "${BRANCH}" "${YesNotice}" "$@" |&
-            dialog_pipe "${DC[TitleSuccess]}${Title}" "${YesNotice}\n${DC[CommandLine]} ds --update $*"
+            dialog_pipe "${DC[TitleSuccess]}${Title}" "${YesNotice}\n${DC[CommandLine]} ${APPLICATION_COMMAND} --update $*"
     else
         commands_update_self "${BRANCH}" "${YesNotice}" "$@"
     fi

--- a/.scripts/yml_merge.sh
+++ b/.scripts/yml_merge.sh
@@ -24,7 +24,7 @@ commands_yml_merge() {
             if [[ -f ${main_yml} ]]; then
                 if run_script 'app_is_deprecated' "${APPNAME}"; then
                     warn "${C["App"]}${AppName}${NC} IS DEPRECATED!"
-                    warn "Please run '${C["UserCommand"]}ds --status-disable ${AppName}${NC}' to disable it."
+                    warn "Please run '${C["UserCommand"]}${APPLICATION_COMMAND} --status-disable ${AppName}${NC}' to disable it."
                 fi
                 local arch_yml
                 arch_yml="$(run_script 'app_instance_file' "${appname}" ".${ARCH}.yml")"

--- a/main.sh
+++ b/main.sh
@@ -3,6 +3,7 @@ set -Eeuo pipefail
 IFS=$'\n\t'
 
 declare -rx APPLICATION_NAME='DockSTARTer'
+declare -rx APPLICATION_COMMAND='ds'
 declare -rx SOURCE_BRANCH='master'
 declare -rx TARGET_BRANCH='main'
 
@@ -500,8 +501,8 @@ usage() {
         APPLICATION_HEADING+=" (${C["Update"]}Update Available${NC})"
     fi
     cat << EOF
-Usage: ds [OPTION]
-NOTE: ds shortcut is only available after the first run of
+Usage: ${APPLICATION_COMMAND} [OPTION]
+NOTE: ${APPLICATION_COMMAND} shortcut is only available after the first run of
     bash main.sh
 
 ${APPLICATION_HEADING}
@@ -758,7 +759,7 @@ cmdline() {
                     PROMPT="GUI"
                 else
                     warn "The '${C["UserCommand"]}--gui${NC}' option requires the '${C["Program"]}dialog$}NC}' command to be installed."
-                    warn "'${C["Program"]}dialog${NC}' command not found. Run '${C["UserCommand"]}ds -fiv${NC}' to install all dependencies."
+                    warn "'${C["Program"]}dialog${NC}' command not found. Run '${C["UserCommand"]}${APPLICATION_COMMAND} -fiv${NC}' to install all dependencies."
                     warn "Coninuing without '${C["UserCommand"]}--gui${NC}' option."
                 fi
                 ;;
@@ -948,7 +949,7 @@ main() {
     fi
     # Repo Check
     local DS_COMMAND
-    DS_COMMAND=$(command -v ds || true)
+    DS_COMMAND=$(command -v "${APPLICATION_COMMAND}" || true)
     if [[ -L ${DS_COMMAND} ]]; then
         local DS_SYMLINK
         DS_SYMLINK=$(readlink -f "${DS_COMMAND}")
@@ -956,7 +957,7 @@ main() {
             if check_repo; then
                 if run_script 'question_prompt' "${PROMPT:-CLI}" N "${APPLICATION_NAME} installation found at ${DS_SYMLINK} location. Would you like to run ${SCRIPTNAME} instead?"; then
                     run_script 'symlink_ds'
-                    DS_COMMAND=$(command -v ds || true)
+                    DS_COMMAND=$(command -v "${APPLICATION_COMMAND}" || true)
                     DS_SYMLINK=$(readlink -f "${DS_COMMAND}")
                 fi
             fi
@@ -981,7 +982,7 @@ main() {
         if ds_update_available; then
             warn "${APPLICATION_NAME} [${C["Version"]}${APPLICATION_VERSION}${NC}]"
             warn "An update to ${APPLICATION_NAME} is available."
-            warn "Run '${C["UserCommand"]}ds -u${NC}' to update to version ${C["Version"]}$(ds_version "${Branch}")${NC}."
+            warn "Run '${C["UserCommand"]}${APPLICATION_COMMAND} -u${NC}' to update to version ${C["Version"]}$(ds_version "${Branch}")${NC}."
         else
             info "${APPLICATION_NAME} [${C["Version"]}${APPLICATION_VERSION}${NC}]"
         fi
@@ -995,7 +996,7 @@ main() {
         if ! ds_branch_exists "${MainBranch}"; then
             error "${APPLICATION_NAME} does not appear to have a '${C["Branch"]}${TARGET_BRANCH}${NC}' or '${C["Branch"]}${SOURCE_BRANCH}${NC}' branch."
         else
-            warn "Run '${C["UserCommand"]}ds -u ${MainBranch}${NC}' to update to the latest stable release ${C["Version"]}$(ds_version "${MainBranch}")${NC}."
+            warn "Run '${C["UserCommand"]}${APPLICATION_COMMAND} -u ${MainBranch}${NC}' to update to the latest stable release ${C["Version"]}$(ds_version "${MainBranch}")${NC}."
         fi
     fi
     # Apply the GUI theme
@@ -1042,10 +1043,10 @@ main() {
                 local CommandLine
                 if [[ -n ${THEME-} ]]; then
                     NoticeText="Applying ${APPLICATION_NAME} theme '${C["Theme"]}${THEME}${NC}'"
-                    CommandLine="ds --theme \"${THEME}\""
+                    CommandLine="${APPLICATION_COMMAND} --theme \"${THEME}\""
                 else
                     NoticeText="Applying ${APPLICATION_NAME} theme '${C["Theme"]}$(run_script 'theme_name')${NC}'"
-                    CommandLine="ds --theme"
+                    CommandLine="${APPLICATION_COMMAND} --theme"
                 fi
                 notice "${NoticeText}"
                 if use_dialog_box; then
@@ -1066,56 +1067,56 @@ main() {
                 notice "Turning on GUI shadows."
                 run_script 'env_set' Shadow yes "${MENU_INI_FILE}"
                 if use_dialog_box; then
-                    run_script 'menu_dialog_example' "Turned on shadows" "ds --theme-shadow"
+                    run_script 'menu_dialog_example' "Turned on shadows" "${APPLICATION_COMMAND} --theme-shadow"
                 fi
                 ;;
             theme-no-shadow)
                 run_script 'env_set' Shadow no "${MENU_INI_FILE}"
                 notice "Turning off GUI shadows."
                 if use_dialog_box; then
-                    run_script 'menu_dialog_example' "Turned off shadows" "ds --theme-no-shadow"
+                    run_script 'menu_dialog_example' "Turned off shadows" "${APPLICATION_COMMAND} --theme-no-shadow"
                 fi
                 ;;
             theme-scrollbar)
                 run_script 'env_set' Scrollbar yes "${MENU_INI_FILE}"
                 notice "Turning on GUI scrollbars."
                 if use_dialog_box; then
-                    run_script 'menu_dialog_example' "Turned on scrollbars" "ds --theme-scrollbar"
+                    run_script 'menu_dialog_example' "Turned on scrollbars" "${APPLICATION_COMMAND} --theme-scrollbar"
                 fi
                 ;;
             theme-no-scrollbar)
                 run_script 'env_set' Scrollbar no "${MENU_INI_FILE}"
                 notice "Turning off GUI scrollbars."
                 if use_dialog_box; then
-                    run_script 'menu_dialog_example' "Turned off scrollbars" "ds --theme-no-scrollbar"
+                    run_script 'menu_dialog_example' "Turned off scrollbars" "${APPLICATION_COMMAND} --theme-no-scrollbar"
                 fi
                 ;;
             theme-lines)
                 run_script 'env_set' LineCharacters yes "${MENU_INI_FILE}"
                 notice "Turning on GUI line drawing characters."
                 if use_dialog_box; then
-                    run_script 'menu_dialog_example' "Turned on line drawing" "ds --theme-lines"
+                    run_script 'menu_dialog_example' "Turned on line drawing" "${APPLICATION_COMMAND} --theme-lines"
                 fi
                 ;;
             theme-no-lines)
                 notice "Turning off GUI line drawing characters."
                 run_script 'env_set' LineCharacters no "${MENU_INI_FILE}"
                 if use_dialog_box; then
-                    run_script 'menu_dialog_example' "Turned off line drawing" "ds --theme-no-lines"
+                    run_script 'menu_dialog_example' "Turned off line drawing" "${APPLICATION_COMMAND} --theme-no-lines"
                 fi
                 ;;
             theme-borders)
                 run_script 'env_set' Borders yes "${MENU_INI_FILE}"
                 notice "Turning on GUI borders."
                 if use_dialog_box; then
-                    run_script 'menu_dialog_example' "Turned on borders" "ds --theme-borders"
+                    run_script 'menu_dialog_example' "Turned on borders" "${APPLICATION_COMMAND} --theme-borders"
                 fi
                 ;;
             theme-no-borders)
                 notice "Turning off GUI borders."
                 run_script 'env_set' Borders no "${MENU_INI_FILE}"
                 if use_dialog_box; then
-                    run_script 'menu_dialog_example' "Turned off borders" "ds --theme-no-borders"
+                    run_script 'menu_dialog_example' "Turned off borders" "${APPLICATION_COMMAND} --theme-no-borders"
                 fi
                 ;;
             *)
@@ -1127,7 +1128,7 @@ main() {
     fi
     if [[ -n ${ADD-} ]]; then
         local CommandLine
-        CommandLine="ds --add $(run_script 'app_nicename' "${ADD}")"
+        CommandLine="${APPLICATION_COMMAND} --add $(run_script 'app_nicename' "${ADD}")"
         run_script_dialog "Add Application" "${DC[NC]} ${DC["CommandLine"]}${CommandLine}${DC[NC]}" "" \
             'appvars_create' "${ADD}"
         run_script 'env_update'
@@ -1154,7 +1155,7 @@ main() {
     if [[ -n ${ENVMETHOD-} ]]; then
         case "${ENVMETHOD-}" in
             env)
-                run_script_dialog "${DC["TitleSuccess"]}Creating environment variables for added apps" "Please be patient, this can take a while.\n${DC["CommandLine"]} ds --env" "" \
+                run_script_dialog "${DC["TitleSuccess"]}Creating environment variables for added apps" "Please be patient, this can take a while.\n${DC["CommandLine"]} ${APPLICATION_COMMAND} --env" "" \
                     'appvars_create_all'
                 exit
                 ;;
@@ -1162,7 +1163,7 @@ main() {
                 if [[ ${ENVVAR-} != "" ]]; then
                     if use_dialog_box; then
                         local CommandLine
-                        CommandLine="ds --env-get ${ENVVAR^^}"
+                        CommandLine="${APPLICATION_COMMAND} --env-get ${ENVVAR^^}"
                         for VarName in $(xargs -n1 <<< "${ENVVAR}"); do
                             run_script 'env_get' "${VarName}"
                         done |& dialog_pipe "Get Value of Variable" "${DC[NC]} ${DC["CommandLine"]}${CommandLine}" ""
@@ -1181,7 +1182,7 @@ main() {
                 if [[ ${ENVVAR-} != "" ]]; then
                     if use_dialog_box; then
                         local CommandLine
-                        CommandLine="ds --env-get-line ${ENVVAR}"
+                        CommandLine="${APPLICATION_COMMAND} --env-get-line ${ENVVAR}"
                         for VarName in $(xargs -n1 <<< "${ENVVAR}"); do
                             run_script 'env_get' "${VarName}"
                         done |& dialog_pipe "Get Value of Variable" "${DC[NC]} ${DC["CommandLine"]}${CommandLine}" ""
@@ -1200,7 +1201,7 @@ main() {
                 if [[ ${ENVVAR-} != "" ]]; then
                     if use_dialog_box; then
                         local CommandLine
-                        CommandLine="ds --env-get-line ${ENVVAR^^}"
+                        CommandLine="${APPLICATION_COMMAND} --env-get-line ${ENVVAR^^}"
                         for VarName in $(xargs -n1 <<< "${ENVVAR^^}"); do
                             run_script 'env_get_line' "${VarName}"
                         done |& dialog_pipe "Get Line of Variable" "${DC[NC]} ${DC["CommandLine"]}${CommandLine}" ""
@@ -1219,7 +1220,7 @@ main() {
                 if [[ ${ENVVAR-} != "" ]]; then
                     if use_dialog_box; then
                         local CommandLine
-                        CommandLine="ds --env-get-lower-line ${ENVVAR}"
+                        CommandLine="${APPLICATION_COMMAND} --env-get-lower-line ${ENVVAR}"
                         for VarName in $(xargs -n1 <<< "${ENVVAR}"); do
                             run_script 'env_get_line' "${VarName}"
                         done |& dialog_pipe "Get Line of Variable" "${DC[NC]} ${DC["CommandLine"]}${CommandLine}" ""
@@ -1238,7 +1239,7 @@ main() {
                 if [[ ${ENVVAR-} != "" ]]; then
                     if use_dialog_box; then
                         local CommandLine
-                        CommandLine="ds --env-get-lower-literal ${ENVVAR^^}"
+                        CommandLine="${APPLICATION_COMMAND} --env-get-lower-literal ${ENVVAR^^}"
                         for VarName in $(xargs -n1 <<< "${ENVVAR^^}"); do
                             run_script 'env_get_literal' "${VarName}"
                         done |& dialog_pipe "Get Literal Value of Variable" "${DC[NC]} ${DC["CommandLine"]}${CommandLine}" ""
@@ -1257,7 +1258,7 @@ main() {
                 if [[ ${ENVVAR-} != "" ]]; then
                     if use_dialog_box; then
                         local CommandLine
-                        CommandLine="ds --env-get-lower-literal ${ENVVAR}"
+                        CommandLine="${APPLICATION_COMMAND} --env-get-lower-literal ${ENVVAR}"
                         for VarName in $(xargs -n1 <<< "${ENVVAR}"); do
                             run_script 'env_get_literal' "${VarName}"
                         done |& dialog_pipe "Get Literal Value of Variable" "${DC[NC]} ${DC["CommandLine"]}${CommandLine}" ""
@@ -1296,7 +1297,7 @@ main() {
                 if [[ ${ENVAPP-} != "" ]]; then
                     if use_dialog_box; then
                         local CommandLine
-                        CommandLine="ds --env-appvars $(run_script 'app_nicename' "${ENVAPP}" | tr '\n' ' ')"
+                        CommandLine="${APPLICATION_COMMAND} --env-appvars $(run_script 'app_nicename' "${ENVAPP}" | tr '\n' ' ')"
                         for AppName in $(xargs -n1 <<< "${ENVAPP}"); do
                             run_script 'appvars_list' "${AppName}"
                         done |& dialog_pipe "Variables for Application" "${DC[NC]} ${DC["CommandLine"]}${CommandLine}" ""
@@ -1314,7 +1315,7 @@ main() {
                 if [[ ${ENVAPP-} != "" ]]; then
                     if use_dialog_box; then
                         local CommandLine
-                        CommandLine="ds --env-appvars-lines $(run_script 'app_nicename' "${ENVAPP}" | tr '\n' ' ')"
+                        CommandLine="${APPLICATION_COMMAND} --env-appvars-lines $(run_script 'app_nicename' "${ENVAPP}" | tr '\n' ' ')"
                         for AppName in $(xargs -n1 <<< "${ENVAPP}"); do
                             run_script 'appvars_lines' "${AppName}"
                         done |& dialog_pipe "Variable Lines for Application" "${DC[NC]} ${DC["CommandLine"]}${CommandLine}" ""
@@ -1390,7 +1391,7 @@ main() {
         case "${STATUSMETHOD-}" in
             status)
                 local CommandLine
-                CommandLine="ds --status $(run_script 'app_nicename' "${STATUS}" | tr '\n' ' ')"
+                CommandLine="${APPLICATION_COMMAND} --status $(run_script 'app_nicename' "${STATUS}" | tr '\n' ' ')"
                 run_script_dialog "Application Status" "${DC[NC]} ${DC["CommandLine"]}${CommandLine}" "" \
                     'app_status' "${STATUS}"
                 ;;
@@ -1415,7 +1416,7 @@ main() {
         run_script 'menu_main'
     else
         error "The GUI requires the '${C["Program"]}dialog${NC}' command to be installed."
-        error "'${C["Program"]}dialog${NC}' command not found. Run '${C["UserCommand"]}ds -fiv${NC}' to install all dependencies."
+        error "'${C["Program"]}dialog${NC}' command not found. Run '${C["UserCommand"]}${APPLICATION_COMMAND} -fiv${NC}' to install all dependencies."
         fatal "Unable to start GUI without '${C["Program"]}dialog${NC}' command."
     fi
 


### PR DESCRIPTION
…nd name

# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Introduce a global APPLICATION_COMMAND variable for the CLI alias and update all script references to use it instead of hard-coded 'ds'.

Enhancements:
- Add APPLICATION_COMMAND constant with default 'ds' for CLI invocation.
- Replace hard-coded 'ds' occurrences across main.sh and helper scripts with APPLICATION_COMMAND variable.