### PR TITLE
Remove remaining hard-coded reference to `DockSTARTer`

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -1028,7 +1028,7 @@ main() {
         else
             local Branch
             Branch="${VERSION:-$(ds_branch)}"
-            error "DockSTARTer branch '${C["Branch"]}${Branch}${NC}' does not exist."
+            error "${APPLICATION_NAME} branch '${C["Branch"]}${Branch}${NC}' does not exist."
         fi
         exit
     fi


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Enhancements:
- Replace hard-coded 'DockSTARTer' reference in main.sh error output with the APPLICATION_NAME variable