### PR TITLE
Use a global `APPLICATION_REPO` variable instead of hard-coding the URL

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -4,6 +4,7 @@ IFS=$'\n\t'
 
 declare -rx APPLICATION_NAME='DockSTARTer'
 declare -rx APPLICATION_COMMAND='ds'
+declare -rx APPLICATION_REPO='https://github.com/GhostWriters/DockSTARTer'
 declare -rx SOURCE_BRANCH='master'
 declare -rx TARGET_BRANCH='main'
 
@@ -969,7 +970,7 @@ main() {
     else
         if ! check_repo; then
             warn "Attempting to clone ${APPLICATION_NAME} repo to ${C["Folder"]}'${DETECTED_HOMEDIR}/.docker${NC}' location."
-            git clone https://github.com/GhostWriters/DockSTARTer "${DETECTED_HOMEDIR}/.docker" || fatal "Failed to clone ${APPLICATION_NAME} repo.\nFailing command: ${C["FailingCommand"]}git clone https://github.com/GhostWriters/DockSTARTer \"${DETECTED_HOMEDIR}/.docker\""
+            git clone "${APPLICATION_REPO}" "${DETECTED_HOMEDIR}/.docker" || fatal "Failed to clone ${APPLICATION_NAME} repo.\nFailing command: ${C["FailingCommand"]}git clone \"${APPLICATION_REPO}\" \"${DETECTED_HOMEDIR}/.docker\""
             notice "Performing first run install."
             exec bash "${DETECTED_HOMEDIR}/.docker/main.sh" "-fvi"
         fi


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Centralize the repository URL by introducing a global APPLICATION_REPO variable and replacing hard-coded URLs

Enhancements:
- Declare a new APPLICATION_REPO constant for the repository URL
- Replace hard-coded repository URLs with APPLICATION_REPO in git clone commands and related error messages