### PR TITLE
Change `dialog --stdout` to `dialog --output-fd 1`, and add `--no-tri…

### DIFF
--- a/.scripts/apply_theme.sh
+++ b/.scripts/apply_theme.sh
@@ -89,7 +89,7 @@ apply_theme() {
         DC["${VarName}"]="${Value}"
     done
     DC["ThemeName"]="${ThemeName}"
-    DIALOGOPTS="--colors --cr-wrap --no-collapse"
+    DIALOGOPTS="--colors --output-fd 1 --no-trim --cr-wrap --no-collapse"
 
     local LineCharacters Borders Scrollbar Shadow
     if run_script 'env_var_exists' Scrollbar "${MENU_INI_FILE}"; then

--- a/.scripts/menu_config.sh
+++ b/.scripts/menu_config.sh
@@ -32,7 +32,7 @@ menu_config() {
     local LastConfigChoice=""
     while true; do
         local -a ConfigChoiceDialog=(
-            --stdout
+            --output-fd 1
             --title "${DC["Title"]}${Title}"
             --ok-label "Select"
             --cancel-label "Back"

--- a/.scripts/menu_config_apps.sh
+++ b/.scripts/menu_config_apps.sh
@@ -16,7 +16,7 @@ menu_config_apps() {
         local WindowRows WindowCols WindowListRows
         local MenuTextSize MenuTextRows MenuTextCols
         #local ScreenSize
-        #ScreenSize="$(_dialog_ --stdout --print-maxsize)"
+        #ScreenSize="$(_dialog_ --output-fd 1 --print-maxsize)"
         #ScreenRows="$(echo "${ScreenSize}" | cut -d ' ' -f 2 | cut -d ',' -f 1)"
         #ScreenCols="$(echo "${ScreenSize}" | cut -d ' ' -f 3)"
         ScreenRows="${LINES}"
@@ -26,7 +26,7 @@ menu_config_apps() {
 
         local MenuText="Select the application to configure"
         local -a AppChoiceParams=(
-            --stdout
+            --output-fd 1
         )
         local MenuTextSize
         MenuTextSize="$(_dialog_ "${AppChoiceParams[@]}" --print-text-size "${MenuText}" "${WindowRowsMax}" "${WindowColsMax}")"

--- a/.scripts/menu_config_vars.sh
+++ b/.scripts/menu_config_vars.sh
@@ -148,7 +148,7 @@ menu_config_vars() {
             local DialogHeading
             DialogHeading="$(run_script 'menu_heading' "${APPNAME-}")"
             local -a LineDialog=(
-                --stdout
+                --output-fd 1
                 --extra-button
                 --ok-label "Select"
                 --extra-label "Remove"

--- a/.scripts/menu_dialog_example.sh
+++ b/.scripts/menu_dialog_example.sh
@@ -48,7 +48,7 @@ menu_dialog_example() {
     local -i MenuTextLines
     MenuTextLines="$(
         _dialog_ \
-            --stdout \
+            --output-fd 1 \
             --print-text-size \
             "${DialogText}" \
             "$((LINES - DC["WindowRowsAdjust"]))" "$((COLUMNS - DC["WindowColsAdjust"]))" |
@@ -77,7 +77,7 @@ menu_dialog_example() {
         "" "" "${Helpline}"
     )
     local -a MenuDialog=(
-        --stdout
+        --output-fd 1
         --title "${Title}"
         --ok-label "Select"
         --cancel-label "Done"

--- a/.scripts/menu_display_options.sh
+++ b/.scripts/menu_display_options.sh
@@ -18,7 +18,7 @@ menu_display_options() {
     local LastChoice=""
     while true; do
         local -a ChoiceDialog=(
-            --stdout
+            --output-fd 1
             --title "${DC["Title"]}${Title}"
             --ok-label "Select"
             --cancel-label "Back"

--- a/.scripts/menu_display_options_general.sh
+++ b/.scripts/menu_display_options_general.sh
@@ -42,7 +42,7 @@ menu_display_options_general() {
             fi
         done
         local -a ChoiceDialog=(
-            --stdout
+            --output-fd 1
             --title "${DC["Title"]}${Title}"
             --ok-label "Select"
             --cancel-label "Back"

--- a/.scripts/menu_display_options_theme.sh
+++ b/.scripts/menu_display_options_theme.sh
@@ -37,7 +37,7 @@ menu_display_options_theme() {
             fi
         done
         local -a ChoiceDialog=(
-            --stdout
+            --output-fd 1
             --title "${DC["Title"]}${Title}"
             --ok-label "Select"
             --cancel-label "Back"

--- a/.scripts/menu_main.sh
+++ b/.scripts/menu_main.sh
@@ -22,7 +22,7 @@ menu_main() {
     local LastMainChoice=""
     while true; do
         local -a MainChoiceDialog=(
-            --stdout
+            --output-fd 1
             --title "${DC["Title"]}${Title}"
             --ok-label "Select"
             --cancel-label "Exit"

--- a/.scripts/menu_value_prompt.sh
+++ b/.scripts/menu_value_prompt.sh
@@ -293,7 +293,7 @@ menu_value_prompt() {
         DialogHeading="$(run_script 'menu_heading' "${APPNAME}" "${VarName}" "${OptionValue["${OriginalValueOption}"]-}" "${CurrentValueHeading}")"
         local SelectValueMenuText="${DialogHeading}\n\nWhat would you like set for ${DC[Highlight]}${CleanVarName}${DC[NC]}?${ValueDescription}"
         local SelectValueDialogParams=(
-            --stdout
+            --output-fd 1
             --title "${DC["Title"]}${Title}"
             --item-help
         )

--- a/.scripts/question_prompt.sh
+++ b/.scripts/question_prompt.sh
@@ -46,7 +46,7 @@ question_prompt() {
             notice "${YNPrompt}" &> /dev/null
             # shellcheck disable=SC2206 # (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.
             local -a YesNoDialog=(
-                --stdout
+                --output-fd 1
                 --no-collapse
                 --yes-label "${YesButton}"
                 --no-label "${NoButton}"


### PR DESCRIPTION
…m` to the default options

# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Replace dialog’s `--stdout` flag with `--output-fd 1` and include `--no-trim` in default options

Enhancements:
- Replace `--stdout` with `--output-fd 1` in all dialog calls across scripts
- Add `--no-trim` to the default DIALOGOPTS to preserve whitespace in dialog output