### PR TITLE
Add a `sanitize_path` to remove `~` from paths, and use it in functions.

### DIFF
--- a/.scripts/appvars_sanitize.sh
+++ b/.scripts/appvars_sanitize.sh
@@ -29,11 +29,11 @@ appvars_sanitize() {
         # Get the value including quotes
         local Value
         Value="$(run_script 'env_get_literal' "${VarName}")"
-        if [[ ${Value} == *~* ]]; then
-            # Value contains a "~", repace it with the user's home directory
-            Value="${Value//\~/"${DETECTED_HOMEDIR}"}"
+        local UpdatedValue
+        UpdatedValue="$(run_script 'sanitize_path' "${Value}")"
+        if [[ ${Value} != "${UpdatedValue}" ]]; then
             VarsToUpdate+=("${VarName}")
-            UpdatedVarValue["${VarName}"]="${Value}"
+            UpdatedVarValue["${VarName}"]="${UpdatedValue}"
         fi
     done
 

--- a/.scripts/env_backup.sh
+++ b/.scripts/env_backup.sh
@@ -20,10 +20,7 @@ env_backup() {
     if [[ -z ${DOCKER_VOLUME_CONFIG-} ]]; then
         fatal "Variable ${C["Var"]}DOCKER_VOLUME_CONFIG${NC} is not set in the ${C["File"]}.env${NC} file"
     fi
-    if [[ ${DOCKER_VOLUME_CONFIG-} == *~* ]]; then
-        # Value contains a "~", repace it with the user's home directory
-        DOCKER_VOLUME_CONFIG="${DOCKER_VOLUME_CONFIG//\~/"${DETECTED_HOMEDIR}"}"
-    fi
+    DOCKER_VOLUME_CONFIG="$(run_script 'sanitize_path' "${DOCKER_VOLUME_CONFIG}")"
 
     info "Taking ownership of ${C["Folder"]}${DOCKER_VOLUME_CONFIG}${NC} (non-recursive)."
     sudo chown "${DETECTED_PUID}":"${DETECTED_PGID}" "${DOCKER_VOLUME_CONFIG}" > /dev/null 2>&1 || true

--- a/.scripts/env_sanitize.sh
+++ b/.scripts/env_sanitize.sh
@@ -62,11 +62,11 @@ env_sanitize() {
         # Get the value including quotes
         local Value
         Value="$(run_script 'env_get_literal' "${VarName}")"
-        if [[ ${Value} == *~* ]]; then
-            # Value contains a "~", repace it with the user's home directory
-            Value="${Value//\~/"${DETECTED_HOMEDIR}"}"
+        local UpdatedValue
+        UpdatedValue="$(run_script 'sanitize_path' "${Value}")"
+        if [[ ${Value} != "${UpdatedValue}" ]]; then
             VarsToUpdate+=("${VarName}")
-            UpdatedVarValue["${VarName}"]="${Value}"
+            UpdatedVarValue["${VarName}"]="${UpdatedValue}"
         fi
     done
 

--- a/.scripts/sanitize_path.sh
+++ b/.scripts/sanitize_path.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+sanitize_path() {
+    local Value=${1-}
+    if [[ ${Value} == *~* ]]; then
+        # Value contains a "~", repace it with the user's home directory
+        Value="${Value//\~/"${DETECTED_HOMEDIR}"}"
+    fi
+    echo "${Value}"
+}
+test_sanitize_path() {
+    warn "CI does not test menu_app_select."
+}


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Centralize path sanitization by adding a `sanitize_path` function and updating existing scripts to use it for expanding `~` to the detected home directory.

Enhancements:
- Add a `sanitize_path` helper to unify tilde-expansion across scripts
- Refactor appvars_sanitize, env_sanitize, and env_backup to use `sanitize_path` instead of inline logic