### PR TITLE
Split detecting installed apps in `menu_app_select` into four steps f…

### DIFF
--- a/.scripts/menu_app_select.sh
+++ b/.scripts/menu_app_select.sh
@@ -40,19 +40,21 @@ menu_app_select() {
 
     init_gauge "${Title}" "${ProcessInfo[@]}"
     {
-        ProgressSteps=1
+        ProgressSteps=4
         ProgressStepNumber=0
         update_gauge 0 "${FindAddedApps}" "_Waiting_" "_InProgress_"
 
         local -a AppList AddedApps BuiltinApps
         local AddedAppsRegex=''
 
-        readarray -t AddedApps < <(
-            run_script 'app_list_added' |
-                run_script 'app_filter_runnable_pipe' |
-                sort -f -u |
-                run_script 'app_nicename_pipe'
-        )
+        readarray -t AddedApps < <(run_script 'app_list_added')
+        update_gauge 1
+
+        readarray -t AddedApps < <(run_script 'app_filter_runnable' "${AddedApps[@]-}" | sort -f -u)
+        update_gauge 1
+
+        readarray -t AddedApps < <(run_script 'app_nicename' "${AddedApps[@]-}")
+        update_gauge 1
 
         if [[ -n ${AddedApps[*]-} ]]; then
             local old_IFS="${IFS}"


### PR DESCRIPTION
…or the progress bar

# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Split app detection into four discrete steps and update the progress gauge after each phase

Enhancements:
- Increase progress gauge total steps from 1 to 4 for finer-grained feedback
- Separate the app discovery pipeline into list, filter, sort & unique, and nicename formatting stages with intermediate gauge updates