### PR TITLE
Only allow `A-`Z`, a-`z, `0-`9, `_` and ` ` in the status tags in the…

### DIFF
--- a/.scripts/menu_app_select.sh
+++ b/.scripts/menu_app_select.sh
@@ -379,7 +379,7 @@ init_gauge_text() {
             EndHighlight="${EndHighlight//\\/\\\\}"
 
             # Highlight each app name
-            FormattedAppNames="$(sed -E "s/\<([A-Za-z0-9]+)\>/${BeginHighlight}\1${EndHighlight}/g" <<< "${FormattedAppNames}")"
+            FormattedAppNames="$(sed -E "s/\<([A-Za-z0-9_]+)\>/${BeginHighlight}\1${EndHighlight}/g" <<< "${FormattedAppNames}")"
 
             # Add the command name to the first line
             DialogGaugeText+="${Indent}${WaitingHighlight}${Command[index]}${DC["NC"]}${Space}${FormattedAppNames:AppsColumnStart}\n"
@@ -417,9 +417,9 @@ update_gauge_text() {
         local OldString="${OldHighlight}${SearchItem}${EndHighlight}"
         local NewString="${NewHighlight}${SearchItem}${EndHighlight}"
         # Escape the [ and ] to use in a sed serach string
-        local OldStatusString="${OldHighlight}\\[.*\\]${EndHighlight}"
+        local OldStatusString="${OldHighlight}\\[[A-Za-z0-9_ ]\\+\\]${EndHighlight}"
         local NewStatusString="${NewHighlight}[${NewStatusTag}]${EndHighlight}"
-        DialogGaugeText="$(sed "s/^\(${OldString}[[:space:]]\+\)${OldStatusString}/\1${NewStatusString}/ ; s/${OldString}/${NewString}/" <<< "${DialogGaugeText}")"
+        DialogGaugeText="$(sed "s/\(^${OldString}[ ]\+\)${OldStatusString}/\1${NewStatusString}/ ; s/${OldString}/${NewString}/" <<< "${DialogGaugeText}")"
 
         FullDialogGaugeText="${DialogGaugeText}"
     fi


### PR DESCRIPTION
… `menu_app_select` progress dialogs

# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Restrict status tag and app name highlighting in menu_app_select progress dialogs to only alphanumeric characters, underscores, and spaces by updating the sed regex patterns.

Enhancements:
- Include underscores in the word-boundary regex for app name highlighting
- Constrain status tag matching to A–Z, a–z, 0–9, underscores, and spaces
- Replace POSIX space class with literal space matching for consistency in sed patterns