### PR TITLE
Switch from using the `DIALOGOPTS` var to a temp file to store global…

### DIFF
--- a/.scripts/apply_theme.sh
+++ b/.scripts/apply_theme.sh
@@ -51,7 +51,7 @@ apply_theme() {
     local _NU_='\ZU'  # No Underline
     local _NC_='\Zn'  # No Color
 
-    DC=()
+    declare -Agx DC=()
     DC+=( # Dialog colors
         ["B"]="${_B_}"
         ["C"]="${_C_}"
@@ -89,7 +89,7 @@ apply_theme() {
         DC["${VarName}"]="${Value}"
     done
     DC["ThemeName"]="${ThemeName}"
-    DIALOGOPTS="--colors --output-fd 1 --no-trim --cr-wrap --no-collapse"
+    local DialogOptions="--colors --output-fd 1 --cr-wrap --no-collapse"
 
     local LineCharacters Borders Scrollbar Shadow
     if run_script 'env_var_exists' Scrollbar "${MENU_INI_FILE}"; then
@@ -124,28 +124,33 @@ apply_theme() {
         run_script 'env_set' LineCharacters "${LineCharacters}" "${MENU_INI_FILE}"
     fi
     if [[ ${Borders^^} =~ ON|TRUE|YES ]]; then
-        DIALOGOPTS+=" --lines"
+        DialogOptions+=" --lines"
         if [[ ${LineCharacters^^} =~ ON|TRUE|YES ]]; then
-            DIALOGOPTS+=" --no-ascii-lines"
+            DialogOptions+=" --no-ascii-lines"
         else
-            DIALOGOPTS+=" --ascii-lines"
+            DialogOptions+=" --ascii-lines"
         fi
     else
-        DIALOGOPTS+=" --no-lines"
+        DialogOptions+=" --no-lines"
     fi
     if [[ ${Scrollbar^^} =~ ON|TRUE|YES ]]; then
-        DIALOGOPTS+=" --scrollbar"
+        DialogOptions+=" --scrollbar"
     else
-        DIALOGOPTS+=" --no-scrollbar"
+        DialogOptions+=" --no-scrollbar"
     fi
     if [[ ${Shadow^^} =~ ON|TRUE|YES ]]; then
-        DIALOGOPTS+=" --shadow"
+        DialogOptions+=" --shadow"
         DC["WindowColsAdjust"]=$((DC["WindowColsAdjust"] + 2))
         DC["WindowRowsAdjust"]=$((DC["WindowRowsAdjust"] + 1))
     else
-        DIALOGOPTS+=" --no-shadow"
+        DialogOptions+=" --no-shadow"
     fi
-    export DIALOGOPTS DC
+    if [[ -z ${DIALOG_OPTIONS_FILE-} ]]; then
+        declare -gx DIALOG_OPTIONS_FILE
+        DIALOG_OPTIONS_FILE=$(mktemp -t "${APPLICATION_NAME}.${FUNCNAME[0]}.DIALOG_OPTIONS_FILE.XXXXXXXXXX")
+    fi
+    echo "${DialogOptions}" > "${DIALOG_OPTIONS_FILE}"
+
     cp "${DialogFile}" "${DIALOGRC}"
     run_script 'env_set' Theme "${ThemeName}" "${MENU_INI_FILE}"
     sort -o "${MENU_INI_FILE}" "${MENU_INI_FILE}"

--- a/.scripts/menu_app_select.sh
+++ b/.scripts/menu_app_select.sh
@@ -247,10 +247,8 @@ show_gauge() {
 
     _dialog_backtitle_
     local -a GlobalDialogOptions=(
+        --file "${DIALOG_OPTIONS_FILE}"
         --backtitle "${BACKTITLE}"
-        --no-collapse
-        --cr-wrap
-        --colors
     )
 
     local -i ScreenRows=${LINES}

--- a/main.sh
+++ b/main.sh
@@ -165,9 +165,7 @@ readonly -a DIALOG_BUTTONS=(
 )
 export DIALOG_BUTTONS
 
-declare -Ax DC=()
-declare -x DIALOGOPTS
-declare -x BACKTITLE
+declare -x BACKTITLE=''
 
 # Log Functions
 MKTEMP_LOG=$(mktemp -t "${APPLICATION_NAME}.log.XXXXXXXXXX") || echo -e "Failed to create temporary log file.\nFailing command: ${C["FailingCommand"]}mktemp -t \"${APPLICATION_NAME}.log.XXXXXXXXXX\""
@@ -328,7 +326,7 @@ _dialog_backtitle_() {
 
 _dialog_() {
     _dialog_backtitle_
-    ${DIALOG} --backtitle "${BACKTITLE}" "$@"
+    ${DIALOG} --file "${DIALOG_OPTIONS_FILE}" --backtitle "${BACKTITLE}" "$@"
 }
 
 # Check to see if we should use a dialog box
@@ -654,6 +652,10 @@ cleanup() {
     sudo rm -f "${MKTEMP_LOG-}" || true
     sudo sh -c "echo \"$(tail -1000 "${SCRIPTPATH}/dockstarter.log")\" > ${SCRIPTPATH}/dockstarter.log" || true
     sudo -E chmod +x "${SCRIPTNAME}" > /dev/null 2>&1 || true
+
+    if [[ -n ${DIALOG_OPTIONS_FILE-} && -f ${DIALOG_OPTIONS_FILE} ]]; then
+        rm -f "${DIALOG_OPTIONS_FILE}" || true
+    fi
 
     if [[ ${CI-} == true ]] && [[ ${TRAVIS_SECURE_ENV_VARS-} == false ]]; then
         echo "TRAVIS_SECURE_ENV_VARS is false for Pull Requests from remote branches. Please retry failed builds!"


### PR DESCRIPTION
… `dialog` options

# Pull request

**Purpose**
It appears that a recent `dialog` update broke it's reading from the `DIALOGOPTS` variable for it's default options.

**Approach**
We now define a global variable `DIALOG_OPTIONS_FILE` pointing to a temporary file where the default `dialog` options are written into, and use `dialog --file "${DIALOG_OPTIONS_FILE}"` to load them into the `dialog` command-line.

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Switch from using the DIALOGOPTS variable to a temporary file for storing and loading global dialog options

Bug Fixes:
- Fix dialog failures caused by recent versions no longer reading options from DIALOGOPTS

Enhancements:
- Replace the DIALOGOPTS environment variable with a temporary file (DIALOG_OPTIONS_FILE) for global dialog options
- Refactor apply_theme.sh and main.sh to generate and consume dialog options via --file instead of using DIALOGOPTS
- Remove old DIALOGOPTS declarations and backtitle export in favor of file-based options
- Add cleanup logic to remove the temporary DIALOG_OPTIONS_FILE on script exit
- Update menu_app_select.sh to reference DIALOG_OPTIONS_FILE and drop redundant inline dialog flags