### PR TITLE
Change from using `dialog` options `--lines` and `--no-ascii-lines` t…

### DIFF
--- a/.scripts/apply_theme.sh
+++ b/.scripts/apply_theme.sh
@@ -124,10 +124,7 @@ apply_theme() {
         run_script 'env_set' LineCharacters "${LineCharacters}" "${MENU_INI_FILE}"
     fi
     if [[ ${Borders^^} =~ ON|TRUE|YES ]]; then
-        DialogOptions+=" --lines"
-        if [[ ${LineCharacters^^} =~ ON|TRUE|YES ]]; then
-            DialogOptions+=" --no-ascii-lines"
-        else
+        if [[ ! ${LineCharacters^^} =~ ON|TRUE|YES ]]; then
             DialogOptions+=" --ascii-lines"
         fi
     else


### PR DESCRIPTION
…o omitting the options.

# Pull request

**Purpose**
There was a report on on a Raspberry Pi, `dialog` complained that dialog option `--lines` was invalid.

**Approach**
Change the logic to never use the `--lines` option, instead either using no option if displaying borders, or `--no-lines` if not displaying the borders.  If displaying the borders and not using line-drawing characters, use the `--ascii-lines` option.,

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).
