### PR TITLE
Check if the original app template file has changed before create an …

### DIFF
--- a/.scripts/update_self.sh
+++ b/.scripts/update_self.sh
@@ -96,11 +96,6 @@ commands_update_self() {
     if [[ -z ${VERBOSE-} ]]; then
         QUIET='--quiet'
     fi
-    if [[ -d ${INSTANCES_FOLDER:?} ]]; then
-        notice "Clearing instances folder"
-        run_script 'set_permissions' "${INSTANCES_FOLDER:?}"
-        rm -fR "${INSTANCES_FOLDER:?}/"* &> /dev/null || fatal "Failed to clear instances folder.\nFailing command: ${C["FailingCommand"]}rm -fR \"${INSTANCES_FOLDER:?}/\"*"
-    fi
     notice "${Notice}"
     cd "${SCRIPTPATH}" || fatal "Failed to change directory.\nFailing command: ${C["FailingCommand"]}cd \"${SCRIPTPATH}\""
     info "Setting file ownership on current repository files"

--- a/main.sh
+++ b/main.sh
@@ -37,28 +37,21 @@ readonly ARCH
 export ARCH
 
 # Environment Information
-readonly COMPOSE_FOLDER_NAME="compose"
-export COMPOSE_FOLDER_NAME
-readonly COMPOSE_FOLDER="${SCRIPTPATH}/${COMPOSE_FOLDER_NAME}"
-export COMPOSE_FOLDER
-readonly COMPOSE_OVERRIDE_NAME="docker-compose.override.yml"
-export COMPOSE_OVERRIDE_NAME
-readonly COMPOSE_OVERRIDE="${COMPOSE_FOLDER}/${COMPOSE_OVERRIDE_NAME}"
-export COMPOSE_OVERRIDE
-readonly COMPOSE_ENV="${COMPOSE_FOLDER}/.env"
-export COMPOSE_ENV
-readonly COMPOSE_ENV_DEFAULT_FILE="${COMPOSE_FOLDER}/.env.example"
-export COMPOSE_ENV_DEFAULT_FILE
-readonly APP_ENV_FOLDER_NAME="env_files"
-export APP_ENV_FOLDER_NAME
-readonly APP_ENV_FOLDER="${COMPOSE_FOLDER}/env_files"
-export APP_ENV_FOLDER
-readonly TEMPLATES_FOLDER="${COMPOSE_FOLDER}/.apps"
-export TEMPLATES_FOLDER
-readonly INSTANCES_FOLDER="${COMPOSE_FOLDER}/.instances"
-export INSTANCES_FOLDER
-readonly THEME_FOLDER="${SCRIPTPATH}/.themes"
-export THEME_FOLDER
+declare -rx COMPOSE_FOLDER_NAME="compose"
+declare -rx THEME_FOLDER_NAME=".themes"
+declare -rx COMPOSE_FOLDER="${SCRIPTPATH}/${COMPOSE_FOLDER_NAME}"
+declare -rx THEME_FOLDER="${SCRIPTPATH}/${THEME_FOLDER_NAME}"
+
+declare -rx INSTANCES_FOLDER_NAME=".instances"
+declare -rx TEMPLATES_FOLDER_NAME=".apps"
+declare -rx APP_ENV_FOLDER_NAME="env_files"
+declare -rx COMPOSE_OVERRIDE_NAME="docker-compose.override.yml"
+declare -rx COMPOSE_ENV="${COMPOSE_FOLDER}/.env"
+declare -rx COMPOSE_ENV_DEFAULT_FILE="${COMPOSE_FOLDER}/.env.example"
+declare -rx COMPOSE_OVERRIDE="${COMPOSE_FOLDER}/${COMPOSE_OVERRIDE_NAME}"
+declare -rx APP_ENV_FOLDER="${COMPOSE_FOLDER}/${APP_ENV_FOLDER_NAME}"
+declare -rx TEMPLATES_FOLDER="${COMPOSE_FOLDER}/${TEMPLATES_FOLDER_NAME}"
+declare -rx INSTANCES_FOLDER="${COMPOSE_FOLDER}/${INSTANCES_FOLDER_NAME}"
 
 # User/Group Information
 readonly DETECTED_PUID=${SUDO_UID:-$UID}


### PR DESCRIPTION
…instance file

Remove the clearing of the instances folder in `update_self`. In `app_instance_file`, check for file `.instances/.apps/baseappname/baseappname.extension` .  If it doesn't exist, or is not the same as the original file in `.apps/baseappname/baseappname.extension`, then copy the original file there, and create the new instance file in `.instances/appname/appname.extension`.

This loses a bit of time in general to compare files, but avoids having to recreate all instance files after an update.

# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Improve instance file management by preserving existing instances during updates and only regenerating instance files when their templates change. Refactor environment path constants for consistency.

New Features:
- Copy and store base app templates in .instances/.apps and only regenerate instance files when the template has changed
- Retain existing instance files by comparing template snapshots instead of unconditionally recreating them

Bug Fixes:
- Remove clearing of the instances folder in update_self to prevent unintended deletion of user instance files during updates

Enhancements:
- Refactor environment and path constants in main.sh to use declare -rx with separate name and path variables for consistency