### PR TITLE
Change `fatal` to `error` when unable to clean up filesystem in `app_…

### DIFF
--- a/.scripts/app_instance_file.sh
+++ b/.scripts/app_instance_file.sh
@@ -35,8 +35,8 @@ app_instance_file() {
         for Folder in "${InstanceTemplateFolder}" "${InstanceFolder}"; do
             if [[ -d ${Folder} ]]; then
                 run_script 'set_permissions' "${Folder}"
-                rm -rf "${Folder}" ||
-                    fatal "Failed to remove directory.\nFailing command: ${C["FailingCommand"]}rm -rf \"${Folder}\""
+                rm -rf "${Folder}" &> /dev/null ||
+                    error "Failed to remove directory.\nFailing command: ${C["FailingCommand"]}rm -rf \"${Folder}\""
             fi
         done
         return
@@ -47,8 +47,8 @@ app_instance_file() {
         for File in "${InstanceTemplateFile}" "${InstanceFile}"; do
             if [[ -f ${File} ]]; then
                 run_script 'set_permissions' "${File}"
-                rm -f "${File}" ||
-                    fatal "Failed to remove file.\nFailing command: ${C["FailingCommand"]}rm -f \"${File}\""
+                rm -f "${File}" &> /dev/null ||
+                    error "Failed to remove file.\nFailing command: ${C["FailingCommand"]}rm -f \"${File}\""
             fi
         done
         return


### PR DESCRIPTION
…instance_files`

# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Update cleanup logic in app_instance_file script to handle removal failures gracefully and suppress rm output

Enhancements:
- Redirect rm command output to /dev/null during instance file and folder cleanup
- Use error logging instead of fatal to report failed removals without aborting execution