### PR TITLE
Remove the `-m` option from `column` in `menu_app_select`

### DIFF
--- a/.scripts/menu_app_select.sh
+++ b/.scripts/menu_app_select.sh
@@ -70,7 +70,7 @@ menu_app_select() {
             readarray -t AddedAppsTable < <(printf "%s\n" "${AddedApps[@]}")
             readarray -t AddedAppsTable < <(
                 printf "%s\n" "${AddedAppsTable[@]}" |
-                    column -m -c "$((TextCols - ${#Indent}))" |
+                    column -c "$((TextCols - ${#Indent}))" |
                     pr -e -t -o "${#Indent}"
             )
         fi


### PR DESCRIPTION
Remove the `-m` option from `column` in `menu_app_select`, for combability with version of `column` without that option.

# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).
