### PR TITLE
Fix regular expressions to search from the beginning of strings

### DIFF
--- a/.scripts/app_list_added.sh
+++ b/.scripts/app_list_added.sh
@@ -3,8 +3,8 @@ set -Eeuo pipefail
 IFS=$'\n\t'
 
 app_list_added() {
-    local APPNAME_REGEX='^[A-Z][A-Z0-9]*(__[A-Z0-9]+)?'
-    local ADDED_APPS_REGEX="${APPNAME_REGEX}(?=__ENABLED\s*=)"
+    local APPNAME_REGEX='[A-Z][A-Z0-9]*(__[A-Z0-9]+)?'
+    local ADDED_APPS_REGEX="^${APPNAME_REGEX}(?=__ENABLED\s*=)"
     local -a AddedApps
 
     readarray -t AddedApps < <(grep --color=never -o -P "${ADDED_APPS_REGEX}" "${COMPOSE_ENV}" || true)

--- a/.scripts/app_list_disabled.sh
+++ b/.scripts/app_list_disabled.sh
@@ -3,13 +3,12 @@ set -Eeuo pipefail
 IFS=$'\n\t'
 
 app_list_disabled() {
-    local APPNAME_REGEX='^[A-Z][A-Z0-9]*(__[A-Z0-9]+)?'
+    local APPNAME_REGEX='[A-Z][A-Z0-9]*(__[A-Z0-9]+)?'
     local -a DISABLED_APPS
     local -a BUILTIN_APPS
 
-    #notice "DISABLED_APPS_REGEX [ ${DISABLED_APPS_REGEX} ]"
     readarray -t DISABLED_APPS < <(
-        grep --color=never -o -P "${APPNAME_REGEX}(?=__ENABLED\s*=(?!(?<quote>['|\"]?)(?i:on|true|yes)\k<quote>))" "${COMPOSE_ENV}" | sort || true
+        grep --color=never -o -P "^${APPNAME_REGEX}(?=__ENABLED\s*=(?!(?<quote>['|\"]?)(?i:on|true|yes)\k<quote>))" "${COMPOSE_ENV}" | sort || true
     )
     readarray -t BUILTIN_APPS < <(run_script 'app_list_builtin')
     local -a COMBINED=("${DISABLED_APPS[@]}" "${BUILTIN_APPS[@]}")

--- a/.scripts/app_list_enabled.sh
+++ b/.scripts/app_list_enabled.sh
@@ -3,12 +3,11 @@ set -Eeuo pipefail
 IFS=$'\n\t'
 
 app_list_enabled() {
-    local APPNAME_REGEX='^[A-Z][A-Z0-9]*(__[A-Z0-9]+)?'
+    local APPNAME_REGEX='[A-Z][A-Z0-9]*(__[A-Z0-9]+)?'
     local -a ENABLED_APPS
 
-    #notice "ENABLED_APPS_REGEX [ ${ENABLED_APPS_REGEX} ]"
     readarray -t ENABLED_APPS < <(
-        grep --color=never -o -P "${APPNAME_REGEX}(?=__ENABLED\s*=(?<quote>['|\"]?)(?i:on|true|yes)\k<quote>)" "${COMPOSE_ENV}" | sort || true
+        grep --color=never -o -P "^${APPNAME_REGEX}(?=__ENABLED\s*=(?<quote>['|\"]?)(?i:on|true|yes)\k<quote>)" "${COMPOSE_ENV}" | sort || true
     )
     for AppName in "${ENABLED_APPS[@]}"; do
         if [[ -d "$(run_script 'app_instance_folder' "${AppName}")" ]]; then

--- a/.scripts/app_list_referenced.sh
+++ b/.scripts/app_list_referenced.sh
@@ -19,7 +19,7 @@ app_list_referenced() {
     done
 
     # Add the list of referenced apps in the global .env file
-    local REFERENCED_APPS_REGEX="${APPNAME_REGEX}(?=__[A-Za-z0-9]\w*\s*=)"
+    local REFERENCED_APPS_REGEX="^${APPNAME_REGEX}(?=__[A-Za-z0-9]\w*\s*=)"
     readarray -O ${#ReferencedApps[@]} ReferencedApps <<< "$(
         grep --color=never -o -P "${REFERENCED_APPS_REGEX}" "${COMPOSE_ENV}" 2> /dev/null || true
     )"

--- a/.scripts/appvars_lines.sh
+++ b/.scripts/appvars_lines.sh
@@ -12,7 +12,7 @@ appvars_lines() {
 
     if [[ -z ${APPNAME} ]]; then
         # Search for all variables not for an app
-        local VAR_REGEX='^[A-Z][A-Z0-9]*(__[A-Z0-9]+)+\w+'
+        local VAR_REGEX='[A-Z][A-Z0-9]*(__[A-Z0-9]+)+\w+'
         local APP_VARS_REGEX="^\s*${VAR_REGEX}\s*="
         grep -v -P '^\s*$|^\s*\#' "${VAR_FILE}" | grep --color=never -v -P "${APP_VARS_REGEX}" || true
     elif [[ ${APPNAME} =~ ^[A-Za-z0-9_]+: ]]; then
@@ -23,7 +23,7 @@ appvars_lines() {
     else
         # Search for all variables for app "APPNAME"
         local VAR_REGEX="${APPNAME}__(?![A-Za-z0-9]+__)\w+"
-        local APP_VARS_REGEX="\s*${VAR_REGEX}\s*="
+        local APP_VARS_REGEX="^\s*${VAR_REGEX}\s*="
         grep --color=never -P "${APP_VARS_REGEX}" "${VAR_FILE}" || true
     fi
 }

--- a/.scripts/appvars_list.sh
+++ b/.scripts/appvars_list.sh
@@ -12,7 +12,7 @@ appvars_list() {
         run_script 'env_var_list' "${VAR_FILE}"
     else
         local VAR_REGEX="${APPNAME}__(?![A-Za-z0-9]+__)\w+"
-        local APP_VARS_REGEX="\s*\K${VAR_REGEX}(?=\s*=)"
+        local APP_VARS_REGEX="^\s*\K${VAR_REGEX}(?=\s*=)"
         grep --color=never -o -P "${APP_VARS_REGEX}" "${COMPOSE_ENV}" || true
     fi
 }

--- a/.scripts/menu_value_prompt.sh
+++ b/.scripts/menu_value_prompt.sh
@@ -329,7 +329,7 @@ menu_value_prompt() {
                 fi
                 ;;
             EXTRA) # EDIT button
-                OptionValue["${CurrentValueOption}"]=$(grep -o -P "RENAMED (${ValidOptionsRegex}) \K.*" <<< "${SelectedValue}")
+                OptionValue["${CurrentValueOption}"]=$(grep -o -P "^RENAMED (${ValidOptionsRegex}) \K.*" <<< "${SelectedValue}")
                 ;;
             CANCEL | ESC) # DONE button
                 local ValueValid


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Anchor regex patterns at the start of lines in multiple shell scripts to ensure accurate matching of app names and variables.

Bug Fixes:
- Fix app list scripts (app_list_disabled, app_list_enabled, app_list_added, app_list_referenced) by anchoring regex patterns at the beginning of lines for correct app name detection.
- Fix variable listing scripts (appvars_lines, appvars_list) by adding start-of-line anchors to regex patterns to avoid unintended matches.
- Fix menu_value_prompt by anchoring the grep pattern for renamed menu values at the start of the line.