### PR TITLE
Add the missing `<__instance>` to all `env_file:` lines in the templates

### DIFF
--- a/compose/.apps/actualbudget/actualbudget.yml
+++ b/compose/.apps/actualbudget/actualbudget.yml
@@ -1,7 +1,7 @@
 services:
   actualbudget<__instance>:
     container_name: ${ACTUALBUDGET<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.actualbudget
+    env_file: .env.app.actualbudget<__instance>
     environment:
       - TZ=${TZ?}
     restart: ${ACTUALBUDGET<__INSTANCE>__RESTART?}

--- a/compose/.apps/adguard/adguard.yml
+++ b/compose/.apps/adguard/adguard.yml
@@ -1,7 +1,7 @@
 services:
   adguard<__instance>:
     container_name: ${ADGUARD<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.adguard
+    env_file: .env.app.adguard<__instance>
     environment:
       - TZ=${TZ?}
     restart: ${ADGUARD<__INSTANCE>__RESTART?}

--- a/compose/.apps/adminer/adminer.yml
+++ b/compose/.apps/adminer/adminer.yml
@@ -1,7 +1,7 @@
 services:
   adminer<__instance>:
     container_name: ${ADMINER<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.adminer
+    env_file: .env.app.adminer<__instance>
     environment:
       - TZ=${TZ?}
     restart: ${ADMINER<__INSTANCE>__RESTART?}

--- a/compose/.apps/airdcpp/airdcpp.yml
+++ b/compose/.apps/airdcpp/airdcpp.yml
@@ -1,7 +1,7 @@
 services:
   airdcpp<__instance>:
     container_name: ${AIRDCPP<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.airdcpp
+    env_file: .env.app.airdcpp<__instance>
     environment:
       - HTTP_PORT=${AIRDCPP<__INSTANCE>__PORT_5600?}
       - HTTPS_PORT=${AIRDCPP<__INSTANCE>__PORT_5601?}

--- a/compose/.apps/airsonic/airsonic.yml
+++ b/compose/.apps/airsonic/airsonic.yml
@@ -1,7 +1,7 @@
 services:
   airsonic<__instance>:
     container_name: ${AIRSONIC<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.airsonic
+    env_file: .env.app.airsonic<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/airsonicadvanced/airsonicadvanced.yml
+++ b/compose/.apps/airsonicadvanced/airsonicadvanced.yml
@@ -1,7 +1,7 @@
 services:
   airsonicadvanced<__instance>:
     container_name: ${AIRSONICADVANCED<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.airsonicadvanced
+    env_file: .env.app.airsonicadvanced<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/amd/amd.yml
+++ b/compose/.apps/amd/amd.yml
@@ -1,7 +1,7 @@
 services:
   amd<__instance>:
     container_name: ${AMD<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.amd
+    env_file: .env.app.amd<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/apcupsd/apcupsd.yml
+++ b/compose/.apps/apcupsd/apcupsd.yml
@@ -1,7 +1,7 @@
 services:
   apcupsd<__instance>:
     container_name: ${APCUPSD<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.apcupsd
+    env_file: .env.app.apcupsd<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/apprise/apprise.yml
+++ b/compose/.apps/apprise/apprise.yml
@@ -1,7 +1,7 @@
 services:
   apprise<__instance>:
     container_name: ${APPRISE<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.apprise
+    env_file: .env.app.apprise<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/audiobookshelf/audiobookshelf.yml
+++ b/compose/.apps/audiobookshelf/audiobookshelf.yml
@@ -1,7 +1,7 @@
 services:
   audiobookshelf<__instance>:
     container_name: ${AUDIOBOOKSHELF<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.audiobookshelf
+    env_file: .env.app.audiobookshelf<__instance>
     environment:
       - CONFIG_PATH=/config
       - HOME=/config/.home

--- a/compose/.apps/autobrr/autobrr.yml
+++ b/compose/.apps/autobrr/autobrr.yml
@@ -1,7 +1,7 @@
 services:
   autobrr<__instance>:
     container_name: ${AUTOBRR<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.autobrr
+    env_file: .env.app.autobrr<__instance>
     environment:
       - TZ=${TZ}
     restart: ${AUTOBRR<__INSTANCE>__RESTART?}

--- a/compose/.apps/azuracast/azuracast.yml
+++ b/compose/.apps/azuracast/azuracast.yml
@@ -1,7 +1,7 @@
 services:
   azuracast<__instance>:
     container_name: ${AZURACAST<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.azuracast
+    env_file: .env.app.azuracast<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/bazarr/bazarr.yml
+++ b/compose/.apps/bazarr/bazarr.yml
@@ -1,7 +1,7 @@
 services:
   bazarr<__instance>:
     container_name: ${BAZARR<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.bazarr
+    env_file: .env.app.bazarr<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/beets/beets.yml
+++ b/compose/.apps/beets/beets.yml
@@ -1,7 +1,7 @@
 services:
   beets<__instance>:
     container_name: ${BEETS<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.beets
+    env_file: .env.app.beets<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/bitwarden/bitwarden.yml
+++ b/compose/.apps/bitwarden/bitwarden.yml
@@ -1,7 +1,7 @@
 services:
   bitwarden<__instance>:
     container_name: ${BITWARDEN<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.bitwarden
+    env_file: .env.app.bitwarden<__instance>
     environment:
       - TZ=${TZ?}
     restart: ${BITWARDEN<__INSTANCE>__RESTART?}

--- a/compose/.apps/booksonic/booksonic.yml
+++ b/compose/.apps/booksonic/booksonic.yml
@@ -1,7 +1,7 @@
 services:
   booksonic<__instance>:
     container_name: ${BOOKSONIC<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.booksonic
+    env_file: .env.app.booksonic<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/booksonicair/booksonicair.yml
+++ b/compose/.apps/booksonicair/booksonicair.yml
@@ -1,7 +1,7 @@
 services:
   booksonicair<__instance>:
     container_name: ${BOOKSONICAIR<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.booksonicair
+    env_file: .env.app.booksonicair<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/bookstack/bookstack.yml
+++ b/compose/.apps/bookstack/bookstack.yml
@@ -1,7 +1,7 @@
 services:
   bookstack<__instance>:
     container_name: ${BOOKSTACK<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.bookstack
+    env_file: .env.app.bookstack<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/calibre/calibre.yml
+++ b/compose/.apps/calibre/calibre.yml
@@ -1,7 +1,7 @@
 services:
   calibre<__instance>:
     container_name: ${CALIBRE<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.calibre
+    env_file: .env.app.calibre<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/calibreweb/calibreweb.yml
+++ b/compose/.apps/calibreweb/calibreweb.yml
@@ -1,7 +1,7 @@
 services:
   calibreweb<__instance>:
     container_name: ${CALIBREWEB<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.calibreweb
+    env_file: .env.app.calibreweb<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/cloudcmd/cloudcmd.yml
+++ b/compose/.apps/cloudcmd/cloudcmd.yml
@@ -1,7 +1,7 @@
 services:
   cloudcmd<__instance>:
     container_name: ${CLOUDCMD<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.cloudcmd
+    env_file: .env.app.cloudcmd<__instance>
     environment:
       - TZ=${TZ?}
     restart: ${CLOUDCMD<__INSTANCE>__RESTART?}

--- a/compose/.apps/cloudflareddns/cloudflareddns.yml
+++ b/compose/.apps/cloudflareddns/cloudflareddns.yml
@@ -1,7 +1,7 @@
 services:
   cloudflareddns<__instance>:
     container_name: ${CLOUDFLAREDDNS<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.cloudflareddns
+    env_file: .env.app.cloudflareddns<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/codeserver/codeserver.yml
+++ b/compose/.apps/codeserver/codeserver.yml
@@ -1,7 +1,7 @@
 services:
   codeserver<__instance>:
     container_name: ${CODESERVER<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.codeserver
+    env_file: .env.app.codeserver<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/couchpotato/couchpotato.yml
+++ b/compose/.apps/couchpotato/couchpotato.yml
@@ -1,7 +1,7 @@
 services:
   couchpotato<__instance>:
     container_name: ${COUCHPOTATO<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.couchpotato
+    env_file: .env.app.couchpotato<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/crossseed/crossseed.yml
+++ b/compose/.apps/crossseed/crossseed.yml
@@ -2,7 +2,7 @@ services:
   crossseed<__instance>:
     command: daemon
     container_name: ${CROSSSEED<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.crossseed
+    env_file: .env.app.crossseed<__instance>
     environment:
       - TZ=${TZ?}
     restart: ${CROSSSEED<__INSTANCE>__RESTART?}

--- a/compose/.apps/dasshio/dasshio.yml
+++ b/compose/.apps/dasshio/dasshio.yml
@@ -1,7 +1,7 @@
 services:
   dasshio<__instance>:
     container_name: ${DASSHIO<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.dasshio
+    env_file: .env.app.dasshio<__instance>
     environment:
       - TZ=${TZ?}
     restart: ${DASSHIO<__INSTANCE>__RESTART?}

--- a/compose/.apps/ddclient/ddclient.yml
+++ b/compose/.apps/ddclient/ddclient.yml
@@ -1,7 +1,7 @@
 services:
   ddclient<__instance>:
     container_name: ${DDCLIENT<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.ddclient
+    env_file: .env.app.ddclient<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/deemix/deemix.yml
+++ b/compose/.apps/deemix/deemix.yml
@@ -1,7 +1,7 @@
 services:
   deemix<__instance>:
     container_name: ${DEEMIX<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.deemix
+    env_file: .env.app.deemix<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/deluge/deluge.yml
+++ b/compose/.apps/deluge/deluge.yml
@@ -1,7 +1,7 @@
 services:
   deluge<__instance>:
     container_name: ${DELUGE<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.deluge
+    env_file: .env.app.deluge<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/delugevpn/delugevpn.yml
+++ b/compose/.apps/delugevpn/delugevpn.yml
@@ -4,7 +4,7 @@ services:
       - NET_ADMIN
       - SYS_MODULE
     container_name: ${DELUGEVPN<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.delugevpn
+    env_file: .env.app.delugevpn<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/doplarr/doplarr.yml
+++ b/compose/.apps/doplarr/doplarr.yml
@@ -1,7 +1,7 @@
 services:
   doplarr<__instance>:
     container_name: ${DOPLARR<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.doplarr
+    env_file: .env.app.doplarr<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/dozzle/dozzle.yml
+++ b/compose/.apps/dozzle/dozzle.yml
@@ -1,7 +1,7 @@
 services:
   dozzle<__instance>:
     container_name: ${DOZZLE<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.dozzle
+    env_file: .env.app.dozzle<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/duckdns/duckdns.yml
+++ b/compose/.apps/duckdns/duckdns.yml
@@ -1,7 +1,7 @@
 services:
   duckdns<__instance>:
     container_name: ${DUCKDNS<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.duckdns
+    env_file: .env.app.duckdns<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/duplicacy/duplicacy.yml
+++ b/compose/.apps/duplicacy/duplicacy.yml
@@ -1,7 +1,7 @@
 services:
   duplicacy<__instance>:
     container_name: ${DUPLICACY<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.duplicacy
+    env_file: .env.app.duplicacy<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/duplicati/duplicati.yml
+++ b/compose/.apps/duplicati/duplicati.yml
@@ -1,7 +1,7 @@
 services:
   duplicati<__instance>:
     container_name: ${DUPLICATI<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.duplicati
+    env_file: .env.app.duplicati<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/emby/emby.yml
+++ b/compose/.apps/emby/emby.yml
@@ -1,7 +1,7 @@
 services:
   emby<__instance>:
     container_name: ${EMBY<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.emby
+    env_file: .env.app.emby<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/fail2ban/fail2ban.yml
+++ b/compose/.apps/fail2ban/fail2ban.yml
@@ -4,7 +4,7 @@ services:
       - NET_ADMIN
       - NET_RAW
     container_name: ${FAIL2BAN<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.fail2ban
+    env_file: .env.app.fail2ban<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/filebot/filebot.yml
+++ b/compose/.apps/filebot/filebot.yml
@@ -1,7 +1,7 @@
 services:
   filebot<__instance>:
     container_name: ${FILEBOT<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.filebot
+    env_file: .env.app.filebot<__instance>
     environment:
       - GROUP_ID=${PGID?}
       - TZ=${TZ?}

--- a/compose/.apps/filebrowser/filebrowser.yml
+++ b/compose/.apps/filebrowser/filebrowser.yml
@@ -1,7 +1,7 @@
 services:
   filebrowser<__instance>:
     container_name: ${FILEBROWSER<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.filebrowser
+    env_file: .env.app.filebrowser<__instance>
     environment:
       - TZ=${TZ?}
     restart: ${FILEBROWSER<__INSTANCE>__RESTART?}

--- a/compose/.apps/fireflyiii/fireflyiii.yml
+++ b/compose/.apps/fireflyiii/fireflyiii.yml
@@ -1,7 +1,7 @@
 services:
   fireflyiii<__instance>:
     container_name: ${FIREFLYIII<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.fireflyiii
+    env_file: .env.app.fireflyiii<__instance>
     environment:
       - TZ=${TZ?}
     restart: ${FIREFLYIII<__INSTANCE>__RESTART?}

--- a/compose/.apps/flame/flame.yml
+++ b/compose/.apps/flame/flame.yml
@@ -1,7 +1,7 @@
 services:
   flame<__instance>:
     container_name: ${FLAME<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.flame
+    env_file: .env.app.flame<__instance>
     restart: ${FLAME<__INSTANCE>__RESTART?}
     volumes:
       - /etc/localtime:/etc/localtime:ro

--- a/compose/.apps/flaresolverr/flaresolverr.yml
+++ b/compose/.apps/flaresolverr/flaresolverr.yml
@@ -1,7 +1,7 @@
 services:
   flaresolverr<__instance>:
     container_name: ${FLARESOLVERR<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.flaresolverr
+    env_file: .env.app.flaresolverr<__instance>
     environment:
       - PORT=${FLARESOLVERR<__INSTANCE>__PORT_8191?}
       - TZ=${TZ?}

--- a/compose/.apps/freshrss/freshrss.yml
+++ b/compose/.apps/freshrss/freshrss.yml
@@ -1,7 +1,7 @@
 services:
   freshrss<__instance>:
     container_name: ${FRESHRSS<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.freshrss
+    env_file: .env.app.freshrss<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/gitea/gitea.yml
+++ b/compose/.apps/gitea/gitea.yml
@@ -1,7 +1,7 @@
 services:
   gitea<__instance>:
     container_name: ${GITEA<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.gitea
+    env_file: .env.app.gitea<__instance>
     environment:
       - USER_UID=${PUID?}
       - USER_GID=${PGID?}

--- a/compose/.apps/glances/glances.yml
+++ b/compose/.apps/glances/glances.yml
@@ -1,7 +1,7 @@
 services:
   glances<__instance>:
     container_name: ${GLANCES<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.glances
+    env_file: .env.app.glances<__instance>
     environment:
       - TZ=${TZ?}
     pid: host

--- a/compose/.apps/gluetun/gluetun.yml
+++ b/compose/.apps/gluetun/gluetun.yml
@@ -3,7 +3,7 @@ services:
     cap_add:
       - NET_ADMIN
     container_name: ${GLUETUN<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.gluetun
+    env_file: .env.app.gluetun<__instance>
     devices:
       - /dev/net/tun
     environment:

--- a/compose/.apps/goaccess/goaccess.yml
+++ b/compose/.apps/goaccess/goaccess.yml
@@ -1,7 +1,7 @@
 services:
   goaccess<__instance>:
     container_name: ${GOACCESS<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.goaccess
+    env_file: .env.app.goaccess<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/grafana/grafana.yml
+++ b/compose/.apps/grafana/grafana.yml
@@ -1,7 +1,7 @@
 services:
   grafana<__instance>:
     container_name: ${GRAFANA<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.grafana
+    env_file: .env.app.grafana<__instance>
     environment:
       - TZ=${TZ?}
     restart: ${GRAFANA<__INSTANCE>__RESTART?}

--- a/compose/.apps/grocy/grocy.yml
+++ b/compose/.apps/grocy/grocy.yml
@@ -1,7 +1,7 @@
 services:
   grocy<__instance>:
     container_name: ${GROCY<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.grocy
+    env_file: .env.app.grocy<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/guacamole/guacamole.yml
+++ b/compose/.apps/guacamole/guacamole.yml
@@ -1,7 +1,7 @@
 services:
   guacamole<__instance>:
     container_name: ${GUACAMOLE<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.guacamole
+    env_file: .env.app.guacamole<__instance>
     environment:
       - TZ=${TZ?}
     restart: ${GUACAMOLE<__INSTANCE>__RESTART?}

--- a/compose/.apps/h5ai/h5ai.yml
+++ b/compose/.apps/h5ai/h5ai.yml
@@ -1,7 +1,7 @@
 services:
   h5ai<__instance>:
     container_name: ${H5AI<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.h5ai
+    env_file: .env.app.h5ai<__instance>
     environment:
       - TZ=${TZ?}
     restart: ${H5AI<__INSTANCE>__RESTART?}

--- a/compose/.apps/handbrake/handbrake.yml
+++ b/compose/.apps/handbrake/handbrake.yml
@@ -1,7 +1,7 @@
 services:
   handbrake<__instance>:
     container_name: ${HANDBRAKE<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.handbrake
+    env_file: .env.app.handbrake<__instance>
     environment:
       - GROUP_ID=${PGID?}
       - USER_ID=${PUID?}

--- a/compose/.apps/headphones/headphones.yml
+++ b/compose/.apps/headphones/headphones.yml
@@ -1,7 +1,7 @@
 services:
   headphones<__instance>:
     container_name: ${HEADPHONES<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.headphones
+    env_file: .env.app.headphones<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/heimdall/heimdall.yml
+++ b/compose/.apps/heimdall/heimdall.yml
@@ -1,7 +1,7 @@
 services:
   heimdall<__instance>:
     container_name: ${HEIMDALL<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.heimdall
+    env_file: .env.app.heimdall<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/homeassistant/homeassistant.yml
+++ b/compose/.apps/homeassistant/homeassistant.yml
@@ -1,7 +1,7 @@
 services:
   homeassistant<__instance>:
     container_name: ${HOMEASSISTANT<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.homeassistant
+    env_file: .env.app.homeassistant<__instance>
     environment:
       - TZ=${TZ?}
     restart: ${HOMEASSISTANT<__INSTANCE>__RESTART?}

--- a/compose/.apps/homebridge/homebridge.yml
+++ b/compose/.apps/homebridge/homebridge.yml
@@ -1,7 +1,7 @@
 services:
   homebridge<__instance>:
     container_name: ${HOMEBRIDGE<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.homebridge
+    env_file: .env.app.homebridge<__instance>
     environment:
       - TZ=${TZ?}
     restart: ${HOMEBRIDGE<__INSTANCE>__RESTART?}

--- a/compose/.apps/homepage/homepage.yml
+++ b/compose/.apps/homepage/homepage.yml
@@ -1,7 +1,7 @@
 services:
   homepage<__instance>:
     container_name: ${HOMEPAGE<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.homepage
+    env_file: .env.app.homepage<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/homer/homer.yml
+++ b/compose/.apps/homer/homer.yml
@@ -1,7 +1,7 @@
 services:
   homer<__instance>:
     container_name: ${HOMER<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.homer
+    env_file: .env.app.homer<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/htpcmanager/htpcmanager.yml
+++ b/compose/.apps/htpcmanager/htpcmanager.yml
@@ -1,7 +1,7 @@
 services:
   htpcmanager<__instance>:
     container_name: ${HTPCMANAGER<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.htpcmanager
+    env_file: .env.app.htpcmanager<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/httpserver/httpserver.yml
+++ b/compose/.apps/httpserver/httpserver.yml
@@ -1,7 +1,7 @@
 services:
   httpserver<__instance>:
     container_name: ${HTTPSERVER<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.httpserver
+    env_file: .env.app.httpserver<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/huginn/huginn.yml
+++ b/compose/.apps/huginn/huginn.yml
@@ -1,7 +1,7 @@
 services:
   huginn<__instance>:
     container_name: ${HUGINN<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.huginn
+    env_file: .env.app.huginn<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/huntarr/huntarr.yml
+++ b/compose/.apps/huntarr/huntarr.yml
@@ -1,7 +1,7 @@
 services:
   huntarr<__instance>:
     container_name: ${HUNTARR<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.huntarr
+    env_file: .env.app.huntarr<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/hydra2/hydra2.yml
+++ b/compose/.apps/hydra2/hydra2.yml
@@ -1,7 +1,7 @@
 services:
   hydra2<__instance>:
     container_name: ${HYDRA2<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.hydra2
+    env_file: .env.app.hydra2<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/influxdb/influxdb.yml
+++ b/compose/.apps/influxdb/influxdb.yml
@@ -1,7 +1,7 @@
 services:
   influxdb<__instance>:
     container_name: ${INFLUXDB<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.influxdb
+    env_file: .env.app.influxdb<__instance>
     environment:
       - TZ=${TZ?}
     restart: ${INFLUXDB<__INSTANCE>__RESTART?}

--- a/compose/.apps/jackett/jackett.yml
+++ b/compose/.apps/jackett/jackett.yml
@@ -1,7 +1,7 @@
 services:
   jackett<__instance>:
     container_name: ${JACKETT<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.jackett
+    env_file: .env.app.jackett<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/jdownloader2/jdownloader2.yml
+++ b/compose/.apps/jdownloader2/jdownloader2.yml
@@ -1,7 +1,7 @@
 services:
   jdownloader2<__instance>:
     container_name: ${JDOWNLOADER2<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.jdownloader2
+    env_file: .env.app.jdownloader2<__instance>
     environment:
       - GROUP_ID=${PGID?}
       - USER_ID=${PUID?}

--- a/compose/.apps/jellyfin/jellyfin.yml
+++ b/compose/.apps/jellyfin/jellyfin.yml
@@ -1,7 +1,7 @@
 services:
   jellyfin<__instance>:
     container_name: ${JELLYFIN<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.jellyfin
+    env_file: .env.app.jellyfin<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/jellyseerr/jellyseerr.yml
+++ b/compose/.apps/jellyseerr/jellyseerr.yml
@@ -1,7 +1,7 @@
 services:
   jellyseerr<__instance>:
     container_name: ${JELLYSEERR<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.jellyseerr
+    env_file: .env.app.jellyseerr<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/jfago/jfago.yml
+++ b/compose/.apps/jfago/jfago.yml
@@ -1,7 +1,7 @@
 services:
   jfago<__instance>:
     container_name: ${JFAGO<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.jfago
+    env_file: .env.app.jfago<__instance>
     environment:
       - TZ=${TZ?}
     restart: ${JFAGO<__INSTANCE>__RESTART?}

--- a/compose/.apps/kanboard/kanboard.yml
+++ b/compose/.apps/kanboard/kanboard.yml
@@ -1,7 +1,7 @@
 services:
   kanboard<__instance>:
     container_name: ${KANBOARD<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.kanboard
+    env_file: .env.app.kanboard<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/kavita/kavita.yml
+++ b/compose/.apps/kavita/kavita.yml
@@ -1,7 +1,7 @@
 services:
   kavita<__instance>:
     container_name: ${KAVITA<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.kavita
+    env_file: .env.app.kavita<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/kitana/kitana.yml
+++ b/compose/.apps/kitana/kitana.yml
@@ -2,7 +2,7 @@ services:
   kitana<__instance>:
     command: -B 0.0.0.0:31337 -P
     container_name: ${KITANA<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.kitana
+    env_file: .env.app.kitana<__instance>
     environment:
       - TZ=${TZ?}
     restart: ${KITANA<__INSTANCE>__RESTART?}

--- a/compose/.apps/kiwixserve/kiwixserve.yml
+++ b/compose/.apps/kiwixserve/kiwixserve.yml
@@ -1,7 +1,7 @@
 services:
   kiwixserve<__instance>:
     container_name: ${KIWIXSERVE<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.kiwixserve
+    env_file: .env.app.kiwixserve<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/komga/komga.yml
+++ b/compose/.apps/komga/komga.yml
@@ -1,7 +1,7 @@
 services:
   komga<__instance>:
     container_name: ${KOMGA<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.komga
+    env_file: .env.app.komga<__instance>
     environment:
       - TZ=${TZ?}
     restart: ${KOMGA<__INSTANCE>__RESTART?}

--- a/compose/.apps/lazylibrarian/lazylibrarian.yml
+++ b/compose/.apps/lazylibrarian/lazylibrarian.yml
@@ -1,7 +1,7 @@
 services:
   lazylibrarian<__instance>:
     container_name: ${LAZYLIBRARIAN<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.lazylibrarian
+    env_file: .env.app.lazylibrarian<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/ldapauth/ldapauth.yml
+++ b/compose/.apps/ldapauth/ldapauth.yml
@@ -1,7 +1,7 @@
 services:
   ldapauth<__instance>:
     container_name: ${LDAPAUTH<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.ldapauth
+    env_file: .env.app.ldapauth<__instance>
     environment:
       - TZ=${TZ?}
     restart: ${LDAPAUTH<__INSTANCE>__RESTART?}

--- a/compose/.apps/letsencrypt/letsencrypt.yml
+++ b/compose/.apps/letsencrypt/letsencrypt.yml
@@ -3,7 +3,7 @@ services:
     cap_add:
       - NET_ADMIN
     container_name: ${LETSENCRYPT<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.letsencrypt
+    env_file: .env.app.letsencrypt<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/librespeed/librespeed.yml
+++ b/compose/.apps/librespeed/librespeed.yml
@@ -1,7 +1,7 @@
 services:
   librespeed<__instance>:
     container_name: ${LIBRESPEED<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.librespeed
+    env_file: .env.app.librespeed<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/lidarr/lidarr.yml
+++ b/compose/.apps/lidarr/lidarr.yml
@@ -1,7 +1,7 @@
 services:
   lidarr<__instance>:
     container_name: ${LIDARR<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.lidarr
+    env_file: .env.app.lidarr<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/limnoria/limnoria.yml
+++ b/compose/.apps/limnoria/limnoria.yml
@@ -1,7 +1,7 @@
 services:
   limnoria<__instance>:
     container_name: ${LIMNORIA<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.limnoria
+    env_file: .env.app.limnoria<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/logarr/logarr.yml
+++ b/compose/.apps/logarr/logarr.yml
@@ -1,7 +1,7 @@
 services:
   logarr<__instance>:
     container_name: ${LOGARR<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.logarr
+    env_file: .env.app.logarr<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/logitechmediaserver/logitechmediaserver.yml
+++ b/compose/.apps/logitechmediaserver/logitechmediaserver.yml
@@ -1,7 +1,7 @@
 services:
   logitechmediaserver<__instance>:
     container_name: ${LOGITECHMEDIASERVER<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.logitechmediaserver
+    env_file: .env.app.logitechmediaserver<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/lyrionmusicserver/lyrionmusicserver.yml
+++ b/compose/.apps/lyrionmusicserver/lyrionmusicserver.yml
@@ -1,7 +1,7 @@
 services:
   lyrionmusicserver<__instance>:
     container_name: ${LYRIONMUSICSERVER<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.lyrionmusicserver
+    env_file: .env.app.lyrionmusicserver<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/maintainerr/maintainerr.yml
+++ b/compose/.apps/maintainerr/maintainerr.yml
@@ -1,7 +1,7 @@
 services:
   maintainerr<__instance>:
     container_name: ${MAINTAINERR<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.maintainerr
+    env_file: .env.app.maintainerr<__instance>
     environment:
       - TZ=${TZ}
     restart: ${MAINTAINERR<__INSTANCE>__RESTART?}

--- a/compose/.apps/makemkv/makemkv.yml
+++ b/compose/.apps/makemkv/makemkv.yml
@@ -1,7 +1,7 @@
 services:
   makemkv<__instance>:
     container_name: ${MAKEMKV<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.makemkv
+    env_file: .env.app.makemkv<__instance>
     environment:
       - GROUP_ID=${PGID?}
       - USER_ID=${PUID?}

--- a/compose/.apps/mariadb/mariadb.yml
+++ b/compose/.apps/mariadb/mariadb.yml
@@ -1,7 +1,7 @@
 services:
   mariadb<__instance>:
     container_name: ${MARIADB<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.mariadb
+    env_file: .env.app.mariadb<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/mcmyadmin2/mcmyadmin2.yml
+++ b/compose/.apps/mcmyadmin2/mcmyadmin2.yml
@@ -1,7 +1,7 @@
 services:
   mcmyadmin2<__instance>:
     container_name: ${MCMYADMIN2<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.mcmyadmin2
+    env_file: .env.app.mcmyadmin2<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/medusa/medusa.yml
+++ b/compose/.apps/medusa/medusa.yml
@@ -1,7 +1,7 @@
 services:
   medusa<__instance>:
     container_name: ${MEDUSA<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.medusa
+    env_file: .env.app.medusa<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/minecraftbedrockserver/minecraftbedrockserver.yml
+++ b/compose/.apps/minecraftbedrockserver/minecraftbedrockserver.yml
@@ -1,7 +1,7 @@
 services:
   minecraftbedrockserver<__instance>:
     container_name: ${MINECRAFTBEDROCKSERVER<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.minecraftbedrockserver
+    env_file: .env.app.minecraftbedrockserver<__instance>
     environment:
       - GID=${PGID?}
       - TZ=${TZ?}

--- a/compose/.apps/minecraftserver/minecraftserver.yml
+++ b/compose/.apps/minecraftserver/minecraftserver.yml
@@ -1,7 +1,7 @@
 services:
   minecraftserver<__instance>:
     container_name: ${MINECRAFTSERVER<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.minecraftserver
+    env_file: .env.app.minecraftserver<__instance>
     environment:
       - GID=${PGID?}
       - TZ=${TZ?}

--- a/compose/.apps/monitorr/monitorr.yml
+++ b/compose/.apps/monitorr/monitorr.yml
@@ -1,7 +1,7 @@
 services:
   monitorr<__instance>:
     container_name: ${MONITORR<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.monitorr
+    env_file: .env.app.monitorr<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/mosquitto/mosquitto.yml
+++ b/compose/.apps/mosquitto/mosquitto.yml
@@ -1,7 +1,7 @@
 services:
   mosquitto<__instance>:
     container_name: ${MOSQUITTO<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.mosquitto
+    env_file: .env.app.mosquitto<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/moviematch/moviematch.yml
+++ b/compose/.apps/moviematch/moviematch.yml
@@ -1,7 +1,7 @@
 services:
   moviematch<__instance>:
     container_name: ${MOVIEMATCH<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.moviematch
+    env_file: .env.app.moviematch<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/murmur/murmur.yml
+++ b/compose/.apps/murmur/murmur.yml
@@ -1,7 +1,7 @@
 services:
   murmur<__instance>:
     container_name: ${MURMUR<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.murmur
+    env_file: .env.app.murmur<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/muximux/muximux.yml
+++ b/compose/.apps/muximux/muximux.yml
@@ -1,7 +1,7 @@
 services:
   muximux<__instance>:
     container_name: ${MUXIMUX<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.muximux
+    env_file: .env.app.muximux<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/mylar/mylar.yml
+++ b/compose/.apps/mylar/mylar.yml
@@ -1,7 +1,7 @@
 services:
   mylar<__instance>:
     container_name: ${MYLAR<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.mylar
+    env_file: .env.app.mylar<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/mylar3/mylar3.yml
+++ b/compose/.apps/mylar3/mylar3.yml
@@ -1,7 +1,7 @@
 services:
   mylar3<__instance>:
     container_name: ${MYLAR3<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.mylar3
+    env_file: .env.app.mylar3<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/navidrome/navidrome.yml
+++ b/compose/.apps/navidrome/navidrome.yml
@@ -1,7 +1,7 @@
 services:
   navidrome<__instance>:
     container_name: ${NAVIDROME<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.navidrome
+    env_file: .env.app.navidrome<__instance>
     environment:
       - ND_DATAFOLDER=/data
       - ND_PORT=${NAVIDROME<__INSTANCE>__PORT_4533?}

--- a/compose/.apps/netdata/netdata.yml
+++ b/compose/.apps/netdata/netdata.yml
@@ -3,7 +3,7 @@ services:
     cap_add:
       - SYS_PTRACE
     container_name: ${NETDATA<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.netdata
+    env_file: .env.app.netdata<__instance>
     environment:
       - PGID=${DOCKER_GID?}
       - TZ=${TZ?}

--- a/compose/.apps/nextcloud/nextcloud.yml
+++ b/compose/.apps/nextcloud/nextcloud.yml
@@ -1,7 +1,7 @@
 services:
   nextcloud<__instance>:
     container_name: ${NEXTCLOUD<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.nextcloud
+    env_file: .env.app.nextcloud<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/nginx/nginx.yml
+++ b/compose/.apps/nginx/nginx.yml
@@ -1,7 +1,7 @@
 services:
   nginx<__instance>:
     container_name: ${NGINX<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.nginx
+    env_file: .env.app.nginx<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/nodered/nodered.yml
+++ b/compose/.apps/nodered/nodered.yml
@@ -1,7 +1,7 @@
 services:
   nodered<__instance>:
     container_name: ${NODERED<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.nodered
+    env_file: .env.app.nodered<__instance>
     environment:
       - TZ=${TZ?}
     restart: ${NODERED<__INSTANCE>__RESTART?}

--- a/compose/.apps/nzbget/nzbget.yml
+++ b/compose/.apps/nzbget/nzbget.yml
@@ -1,7 +1,7 @@
 services:
   nzbget<__instance>:
     container_name: ${NZBGET<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.nzbget
+    env_file: .env.app.nzbget<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/nzbgetvpn/nzbgetvpn.yml
+++ b/compose/.apps/nzbgetvpn/nzbgetvpn.yml
@@ -4,7 +4,7 @@ services:
       - NET_ADMIN
       - SYS_MODULE
     container_name: ${NZBGETVPN<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.nzbgetvpn
+    env_file: .env.app.nzbgetvpn<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/nzbhydra2/nzbhydra2.yml
+++ b/compose/.apps/nzbhydra2/nzbhydra2.yml
@@ -1,7 +1,7 @@
 services:
   nzbhydra2<__instance>:
     container_name: ${NZBHYDRA2<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.nzbhydra2
+    env_file: .env.app.nzbhydra2<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/omadacontroller/omadacontroller.yml
+++ b/compose/.apps/omadacontroller/omadacontroller.yml
@@ -1,7 +1,7 @@
 services:
   omadacontroller<__instance>:
     container_name: ${OMADACONTROLLER<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.omadacontroller
+    env_file: .env.app.omadacontroller<__instance>
     environment:
       - MANAGE_HTTP_PORT=${OMADACONTROLLER<__INSTANCE>__PORT_8088?}
       - MANAGE_HTTPS_PORT=${OMADACONTROLLER<__INSTANCE>__PORT_8043?}

--- a/compose/.apps/ombi/ombi.yml
+++ b/compose/.apps/ombi/ombi.yml
@@ -1,7 +1,7 @@
 services:
   ombi<__instance>:
     container_name: ${OMBI<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.ombi
+    env_file: .env.app.ombi<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/openldap/openldap.yml
+++ b/compose/.apps/openldap/openldap.yml
@@ -1,7 +1,7 @@
 services:
   openldap<__instance>:
     container_name: ${OPENLDAP<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.openldap
+    env_file: .env.app.openldap<__instance>
     environment:
       - LDAP_OPENLDAP<__INSTANCE>_GID=${PGID?}
       - LDAP_OPENLDAP<__INSTANCE>_UID=${PUID?}

--- a/compose/.apps/openspeedtest/openspeedtest.yml
+++ b/compose/.apps/openspeedtest/openspeedtest.yml
@@ -1,7 +1,7 @@
 services:
   openspeedtest<__instance>:
     container_name: ${OPENSPEEDTEST<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.openspeedtest
+    env_file: .env.app.openspeedtest<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/openvpnas/openvpnas.yml
+++ b/compose/.apps/openvpnas/openvpnas.yml
@@ -3,7 +3,7 @@ services:
     cap_add:
       - NET_ADMIN
     container_name: ${OPENVPNAS<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.openvpnas
+    env_file: .env.app.openvpnas<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/organizr/organizr.yml
+++ b/compose/.apps/organizr/organizr.yml
@@ -1,7 +1,7 @@
 services:
   organizr<__instance>:
     container_name: ${ORGANIZR<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.organizr
+    env_file: .env.app.organizr<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/ouroboros/ouroboros.yml
+++ b/compose/.apps/ouroboros/ouroboros.yml
@@ -1,7 +1,7 @@
 services:
   ouroboros<__instance>:
     container_name: ${OUROBOROS<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.ouroboros
+    env_file: .env.app.ouroboros<__instance>
     environment:
       - TZ=${TZ?}
     restart: ${OUROBOROS<__INSTANCE>__RESTART?}

--- a/compose/.apps/overseerr/overseerr.yml
+++ b/compose/.apps/overseerr/overseerr.yml
@@ -1,7 +1,7 @@
 services:
   overseerr<__instance>:
     container_name: ${OVERSEERR<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.overseerr
+    env_file: .env.app.overseerr<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/petio/petio.yml
+++ b/compose/.apps/petio/petio.yml
@@ -1,7 +1,7 @@
 services:
   petio<__instance>:
     container_name: ${PETIO<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.petio
+    env_file: .env.app.petio<__instance>
     environment:
       - TZ=${TZ?}
     restart: ${PETIO<__INSTANCE>__RESTART?}

--- a/compose/.apps/pgadmin/pgadmin.yml
+++ b/compose/.apps/pgadmin/pgadmin.yml
@@ -1,7 +1,7 @@
 services:
   pgadmin<__instance>:
     container_name: ${PGADMIN<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.pgadmin
+    env_file: .env.app.pgadmin<__instance>
     environment:
       - TZ=${TZ?}
     restart: ${PGADMIN<__INSTANCE>__RESTART?}

--- a/compose/.apps/pgbackup/pgbackup.yml
+++ b/compose/.apps/pgbackup/pgbackup.yml
@@ -1,7 +1,7 @@
 services:
   pgbackup<__instance>:
     container_name: ${PGBACKUP<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.pgbackup
+    env_file: .env.app.pgbackup<__instance>
     environment:
       - TZ=${TZ?}
     restart: ${PGBACKUP<__INSTANCE>__RESTART?}

--- a/compose/.apps/photoshow/photoshow.yml
+++ b/compose/.apps/photoshow/photoshow.yml
@@ -1,7 +1,7 @@
 services:
   photoshow<__instance>:
     container_name: ${PHOTOSHOW<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.photoshow
+    env_file: .env.app.photoshow<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/photostructure/photostructure.yml
+++ b/compose/.apps/photostructure/photostructure.yml
@@ -1,7 +1,7 @@
 services:
   photostructure<__instance>:
     container_name: ${PHOTOSTRUCTURE<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.photostructure
+    env_file: .env.app.photostructure<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/phpmyadmin/phpmyadmin.yml
+++ b/compose/.apps/phpmyadmin/phpmyadmin.yml
@@ -1,7 +1,7 @@
 services:
   phpmyadmin<__instance>:
     container_name: ${PHPMYADMIN<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.phpmyadmin
+    env_file: .env.app.phpmyadmin<__instance>
     environment:
       - TZ=${TZ?}
     restart: ${PHPMYADMIN<__INSTANCE>__RESTART?}

--- a/compose/.apps/picard/picard.yml
+++ b/compose/.apps/picard/picard.yml
@@ -1,7 +1,7 @@
 services:
   picard<__instance>:
     container_name: ${PICARD<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.picard
+    env_file: .env.app.picard<__instance>
     environment:
       - GROUP_ID=${PGID?}
       - TZ=${TZ?}

--- a/compose/.apps/pihole/pihole.yml
+++ b/compose/.apps/pihole/pihole.yml
@@ -3,7 +3,7 @@ services:
     cap_add:
       - NET_ADMIN
     container_name: ${PIHOLE<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.pihole
+    env_file: .env.app.pihole<__instance>
     environment:
       - TZ=${TZ?}
     restart: ${PIHOLE<__INSTANCE>__RESTART?}

--- a/compose/.apps/piwigo/piwigo.yml
+++ b/compose/.apps/piwigo/piwigo.yml
@@ -1,7 +1,7 @@
 services:
   piwigo<__instance>:
     container_name: ${PIWIGO<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.piwigo
+    env_file: .env.app.piwigo<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/plex/plex.yml
+++ b/compose/.apps/plex/plex.yml
@@ -1,7 +1,7 @@
 services:
   plex<__instance>:
     container_name: ${PLEX<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.plex
+    env_file: .env.app.plex<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/plexanisync/plexanisync.yml
+++ b/compose/.apps/plexanisync/plexanisync.yml
@@ -1,7 +1,7 @@
 services:
   plexanisync<__instance>:
     container_name: ${PLEXANISYNC<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.plexanisync
+    env_file: .env.app.plexanisync<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/plexrequests/plexrequests.yml
+++ b/compose/.apps/plexrequests/plexrequests.yml
@@ -1,7 +1,7 @@
 services:
   plexrequests<__instance>:
     container_name: ${PLEXREQUESTS<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.plexrequests
+    env_file: .env.app.plexrequests<__instance>
     environment:
       - URL_BASE=/plexrequests
       - PGID=${PGID?}

--- a/compose/.apps/portainer/portainer.yml
+++ b/compose/.apps/portainer/portainer.yml
@@ -2,7 +2,7 @@ services:
   portainer<__instance>:
     command: "-H unix:///var/run/docker.sock"
     container_name: ${PORTAINER<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.portainer
+    env_file: .env.app.portainer<__instance>
     environment:
       - TZ=${TZ?}
     restart: ${PORTAINER<__INSTANCE>__RESTART?}

--- a/compose/.apps/portaineragent/portaineragent.yml
+++ b/compose/.apps/portaineragent/portaineragent.yml
@@ -1,7 +1,7 @@
 services:
   portaineragent<__instance>:
     container_name: ${PORTAINERAGENT<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.portaineragent
+    env_file: .env.app.portaineragent<__instance>
     environment:
       - TZ=${TZ?}
     restart: ${PORTAINERAGENT<__INSTANCE>__RESTART?}

--- a/compose/.apps/postgres/postgres.yml
+++ b/compose/.apps/postgres/postgres.yml
@@ -1,7 +1,7 @@
 services:
   postgres<__instance>:
     container_name: ${POSTGRES<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.postgres
+    env_file: .env.app.postgres<__instance>
     environment:
       - TZ=${TZ?}
     restart: ${POSTGRES<__INSTANCE>__RESTART?}

--- a/compose/.apps/privoxyvpn/privoxyvpn.yml
+++ b/compose/.apps/privoxyvpn/privoxyvpn.yml
@@ -4,7 +4,7 @@ services:
       - NET_ADMIN
       - SYS_MODULE
     container_name: ${PRIVOXYVPN<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.privoxyvpn
+    env_file: .env.app.privoxyvpn<__instance>
     devices:
       - /dev/net/tun
     environment:

--- a/compose/.apps/prometheus/prometheus.yml
+++ b/compose/.apps/prometheus/prometheus.yml
@@ -1,7 +1,7 @@
 services:
   prometheus<__instance>:
     container_name: ${PROMETHEUS<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.prometheus
+    env_file: .env.app.prometheus<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/prowlarr/prowlarr.yml
+++ b/compose/.apps/prowlarr/prowlarr.yml
@@ -1,7 +1,7 @@
 services:
   prowlarr<__instance>:
     container_name: ${PROWLARR<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.prowlarr
+    env_file: .env.app.prowlarr<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/pyload/pyload.yml
+++ b/compose/.apps/pyload/pyload.yml
@@ -1,7 +1,7 @@
 services:
   pyload<__instance>:
     container_name: ${PYLOAD<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.pyload
+    env_file: .env.app.pyload<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/qbittorrent/qbittorrent.yml
+++ b/compose/.apps/qbittorrent/qbittorrent.yml
@@ -1,7 +1,7 @@
 services:
   qbittorrent<__instance>:
     container_name: ${QBITTORRENT<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.qbittorrent
+    env_file: .env.app.qbittorrent<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/qbittorrentvpn/qbittorrentvpn.yml
+++ b/compose/.apps/qbittorrentvpn/qbittorrentvpn.yml
@@ -4,7 +4,7 @@ services:
       - NET_ADMIN
       - SYS_MODULE
     container_name: ${QBITTORRENTVPN<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.qbittorrentvpn
+    env_file: .env.app.qbittorrentvpn<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/quasselcore/quasselcore.yml
+++ b/compose/.apps/quasselcore/quasselcore.yml
@@ -1,7 +1,7 @@
 services:
   quasselcore<__instance>:
     container_name: ${QUASSELCORE<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.quasselcore
+    env_file: .env.app.quasselcore<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/quasselweb/quasselweb.yml
+++ b/compose/.apps/quasselweb/quasselweb.yml
@@ -1,7 +1,7 @@
 services:
   quasselweb<__instance>:
     container_name: ${QUASSELWEB<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.quasselweb
+    env_file: .env.app.quasselweb<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/radarr/radarr.yml
+++ b/compose/.apps/radarr/radarr.yml
@@ -1,7 +1,7 @@
 services:
   radarr<__instance>:
     container_name: ${RADARR<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.radarr
+    env_file: .env.app.radarr<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/readarr/readarr.yml
+++ b/compose/.apps/readarr/readarr.yml
@@ -1,7 +1,7 @@
 services:
   readarr<__instance>:
     container_name: ${READARR<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.readarr
+    env_file: .env.app.readarr<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/recyclarr/recyclarr.yml
+++ b/compose/.apps/recyclarr/recyclarr.yml
@@ -1,7 +1,7 @@
 services:
   recyclarr<__instance>:
     container_name: ${RECYCLARR<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.recyclarr
+    env_file: .env.app.recyclarr<__instance>
     environment:
       - TZ=${TZ?}
     restart: ${RECYCLARR<__INSTANCE>__RESTART?}

--- a/compose/.apps/requestrr/requestrr.yml
+++ b/compose/.apps/requestrr/requestrr.yml
@@ -1,7 +1,7 @@
 services:
   requestrr<__instance>:
     container_name: ${REQUESTRR<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.requestrr
+    env_file: .env.app.requestrr<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/resiliosync/resiliosync.yml
+++ b/compose/.apps/resiliosync/resiliosync.yml
@@ -1,7 +1,7 @@
 services:
   resiliosync<__instance>:
     container_name: ${RESILIOSYNC<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.resiliosync
+    env_file: .env.app.resiliosync<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/rsnapshot/rsnapshot.yml
+++ b/compose/.apps/rsnapshot/rsnapshot.yml
@@ -1,7 +1,7 @@
 services:
   rsnapshot<__instance>:
     container_name: ${RSNAPSHOT<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.rsnapshot
+    env_file: .env.app.rsnapshot<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/rtorrentvpn/rtorrentvpn.yml
+++ b/compose/.apps/rtorrentvpn/rtorrentvpn.yml
@@ -4,7 +4,7 @@ services:
       - NET_ADMIN
       - SYS_MODULE
     container_name: ${RTORRENTVPN<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.rtorrentvpn
+    env_file: .env.app.rtorrentvpn<__instance>
     environment:
       - PGID=${PGID?}
       - PHP_TZ=${TZ?}

--- a/compose/.apps/rustdesk/rustdesk.yml
+++ b/compose/.apps/rustdesk/rustdesk.yml
@@ -1,7 +1,7 @@
 services:
   rustdesk<__instance>:
     container_name: ${RUSTDESK<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.rustdesk
+    env_file: .env.app.rustdesk<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/rutorrent/rutorrent.yml
+++ b/compose/.apps/rutorrent/rutorrent.yml
@@ -1,7 +1,7 @@
 services:
   rutorrent<__instance>:
     container_name: ${RUTORRENT<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.rutorrent
+    env_file: .env.app.rutorrent<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/sabnzbd/sabnzbd.yml
+++ b/compose/.apps/sabnzbd/sabnzbd.yml
@@ -1,7 +1,7 @@
 services:
   sabnzbd<__instance>:
     container_name: ${SABNZBD<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.sabnzbd
+    env_file: .env.app.sabnzbd<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/sabnzbdvpn/sabnzbdvpn.yml
+++ b/compose/.apps/sabnzbdvpn/sabnzbdvpn.yml
@@ -4,7 +4,7 @@ services:
       - NET_ADMIN
       - SYS_MODULE
     container_name: ${SABNZBDVPN<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.sabnzbdvpn
+    env_file: .env.app.sabnzbdvpn<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/samba/samba.yml
+++ b/compose/.apps/samba/samba.yml
@@ -1,7 +1,7 @@
 services:
   samba<__instance>:
     container_name: ${SAMBA<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.samba
+    env_file: .env.app.samba<__instance>
     environment:
       - GROUPID=${PGID?}
       - SHARE=${SAMBA<__INSTANCE>__ENVIRONMENT_SHARENAME?};/${SAMBA<__INSTANCE>__ENVIRONMENT_SHARENAME?};yes;no;no;all;${SAMBA<__INSTANCE>__ENVIRONMENT_USERNAME?}

--- a/compose/.apps/sickchill/sickchill.yml
+++ b/compose/.apps/sickchill/sickchill.yml
@@ -1,7 +1,7 @@
 services:
   sickchill<__instance>:
     container_name: ${SICKCHILL<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.sickchill
+    env_file: .env.app.sickchill<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/smokeping/smokeping.yml
+++ b/compose/.apps/smokeping/smokeping.yml
@@ -1,7 +1,7 @@
 services:
   smokeping<__instance>:
     container_name: ${SMOKEPING<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.smokeping
+    env_file: .env.app.smokeping<__instance>
     dns:
       - ${SMOKEPING<__INSTANCE>__ENVIRONMENT_DNS1?}
       - ${SMOKEPING<__INSTANCE>__ENVIRONMENT_DNS2?}

--- a/compose/.apps/sonarr/sonarr.yml
+++ b/compose/.apps/sonarr/sonarr.yml
@@ -1,7 +1,7 @@
 services:
   sonarr<__instance>:
     container_name: ${SONARR<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.sonarr
+    env_file: .env.app.sonarr<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/speedtest/speedtest.yml
+++ b/compose/.apps/speedtest/speedtest.yml
@@ -1,7 +1,7 @@
 services:
   speedtest<__instance>:
     container_name: ${SPEEDTEST<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.speedtest
+    env_file: .env.app.speedtest<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/swag/swag.yml
+++ b/compose/.apps/swag/swag.yml
@@ -3,7 +3,7 @@ services:
     cap_add:
       - NET_ADMIN
     container_name: ${SWAG<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.swag
+    env_file: .env.app.swag<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/synclounge/synclounge.yml
+++ b/compose/.apps/synclounge/synclounge.yml
@@ -1,7 +1,7 @@
 services:
   synclounge<__instance>:
     container_name: ${SYNCLOUNGE<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.synclounge
+    env_file: .env.app.synclounge<__instance>
     environment:
       - TZ=${TZ?}
     restart: ${SYNCLOUNGE<__INSTANCE>__RESTART?}

--- a/compose/.apps/syncthing/syncthing.yml
+++ b/compose/.apps/syncthing/syncthing.yml
@@ -1,7 +1,7 @@
 services:
   syncthing<__instance>:
     container_name: ${SYNCTHING<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.syncthing
+    env_file: .env.app.syncthing<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/tandoor/tandoor.yml
+++ b/compose/.apps/tandoor/tandoor.yml
@@ -1,7 +1,7 @@
 services:
   tandoor<__instance>:
     container_name: ${TANDOOR<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.tandoor
+    env_file: .env.app.tandoor<__instance>
     environment:
       - TZ=${TZ?}
     restart: ${TANDOOR<__INSTANCE>__RESTART?}

--- a/compose/.apps/tautulli/tautulli.yml
+++ b/compose/.apps/tautulli/tautulli.yml
@@ -1,7 +1,7 @@
 services:
   tautulli<__instance>:
     container_name: ${TAUTULLI<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.tautulli
+    env_file: .env.app.tautulli<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/tdarr/tdarr.yml
+++ b/compose/.apps/tdarr/tdarr.yml
@@ -1,7 +1,7 @@
 services:
   tdarr<__instance>:
     container_name: ${TDARR<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.tdarr
+    env_file: .env.app.tdarr<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/tdarrnode/tdarrnode.yml
+++ b/compose/.apps/tdarrnode/tdarrnode.yml
@@ -1,7 +1,7 @@
 services:
   tdarrnode<__instance>:
     container_name: ${TDARRNODE<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.tdarrnode
+    env_file: .env.app.tdarrnode<__instance>
     environment:
       - nodePort=${TDARRNODE<__INSTANCE>__PORT_8267?}
       - PGID=${PGID?}

--- a/compose/.apps/telegraf/telegraf.yml
+++ b/compose/.apps/telegraf/telegraf.yml
@@ -1,7 +1,7 @@
 services:
   telegraf<__instance>:
     container_name: ${TELEGRAF<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.telegraf
+    env_file: .env.app.telegraf<__instance>
     environment:
       - HOST_ETC=/host/etc
       - HOST_MOUNT_PREFIX=/host

--- a/compose/.apps/thelounge/thelounge.yml
+++ b/compose/.apps/thelounge/thelounge.yml
@@ -1,7 +1,7 @@
 services:
   thelounge<__instance>:
     container_name: ${THELOUNGE<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.thelounge
+    env_file: .env.app.thelounge<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/timemachine/timemachine.yml
+++ b/compose/.apps/timemachine/timemachine.yml
@@ -1,7 +1,7 @@
 services:
   timemachine<__instance>:
     container_name: ${TIMEMACHINE<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.timemachine
+    env_file: .env.app.timemachine<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/traefik/traefik.yml
+++ b/compose/.apps/traefik/traefik.yml
@@ -1,7 +1,7 @@
 services:
   traefik<__instance>:
     container_name: ${TRAEFIK<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.traefik
+    env_file: .env.app.traefik<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/traktarr/traktarr.yml
+++ b/compose/.apps/traktarr/traktarr.yml
@@ -1,7 +1,7 @@
 services:
   traktarr<__instance>:
     container_name: ${TRAKTARR<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.traktarr
+    env_file: .env.app.traktarr<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/transmission/transmission.yml
+++ b/compose/.apps/transmission/transmission.yml
@@ -1,7 +1,7 @@
 services:
   transmission<__instance>:
     container_name: ${TRANSMISSION<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.transmission
+    env_file: .env.app.transmission<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/transmissionvpn/transmissionvpn.yml
+++ b/compose/.apps/transmissionvpn/transmissionvpn.yml
@@ -3,7 +3,7 @@ services:
     cap_add:
       - NET_ADMIN
     container_name: ${TRANSMISSIONVPN<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.transmissionvpn
+    env_file: .env.app.transmissionvpn<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/tsdproxy/tsdproxy.yml
+++ b/compose/.apps/tsdproxy/tsdproxy.yml
@@ -1,7 +1,7 @@
 services:
   tsdproxy<__instance>:
     container_name: ${TSDPROXY<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.tsdproxy
+    env_file: .env.app.tsdproxy<__instance>
     environment:
       - TZ=${TZ?}
     restart: ${TSDPROXY<__INSTANCE>__RESTART?}

--- a/compose/.apps/tvheadend/tvheadend.yml
+++ b/compose/.apps/tvheadend/tvheadend.yml
@@ -1,7 +1,7 @@
 services:
   tvheadend<__instance>:
     container_name: ${TVHEADEND<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.tvheadend
+    env_file: .env.app.tvheadend<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/ubooquity/ubooquity.yml
+++ b/compose/.apps/ubooquity/ubooquity.yml
@@ -1,7 +1,7 @@
 services:
   ubooquity<__instance>:
     container_name: ${UBOOQUITY<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.ubooquity
+    env_file: .env.app.ubooquity<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/unifi/unifi.yml
+++ b/compose/.apps/unifi/unifi.yml
@@ -1,7 +1,7 @@
 services:
   unifi<__instance>:
     container_name: ${UNIFI<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.unifi
+    env_file: .env.app.unifi<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/unificontroller/unificontroller.yml
+++ b/compose/.apps/unificontroller/unificontroller.yml
@@ -1,7 +1,7 @@
 services:
   unificontroller<__instance>:
     container_name: ${UNIFICONTROLLER<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.unificontroller
+    env_file: .env.app.unificontroller<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/unmanic/unmanic.yml
+++ b/compose/.apps/unmanic/unmanic.yml
@@ -1,7 +1,7 @@
 services:
   unmanic<__instance>:
     container_name: ${UNMANIC<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.unmanic
+    env_file: .env.app.unmanic<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/unpackerr/unpackerr.yml
+++ b/compose/.apps/unpackerr/unpackerr.yml
@@ -1,7 +1,7 @@
 services:
   unpackerr<__instance>:
     container_name: ${UNPACKERR<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.unpackerr
+    env_file: .env.app.unpackerr<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/uptimekuma/uptimekuma.yml
+++ b/compose/.apps/uptimekuma/uptimekuma.yml
@@ -1,7 +1,7 @@
 services:
   uptimekuma<__instance>:
     container_name: ${UPTIMEKUMA<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.uptimekuma
+    env_file: .env.app.uptimekuma<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/varken/varken.yml
+++ b/compose/.apps/varken/varken.yml
@@ -1,7 +1,7 @@
 services:
   varken<__instance>:
     container_name: ${VARKEN<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.varken
+    env_file: .env.app.varken<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/vaultwarden/vaultwarden.yml
+++ b/compose/.apps/vaultwarden/vaultwarden.yml
@@ -1,7 +1,7 @@
 services:
   vaultwarden<__instance>:
     container_name: ${VAULTWARDEN<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.vaultwarden
+    env_file: .env.app.vaultwarden<__instance>
     environment:
       - TZ=${TZ?}
     restart: ${VAULTWARDEN<__INSTANCE>__RESTART?}

--- a/compose/.apps/vsftpd/vsftpd.yml
+++ b/compose/.apps/vsftpd/vsftpd.yml
@@ -1,7 +1,7 @@
 services:
   vsftpd<__instance>:
     container_name: ${VSFTPD<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.vsftpd
+    env_file: .env.app.vsftpd<__instance>
     environment:
       - TZ=${TZ?}
     restart: ${VSFTPD<__INSTANCE>__RESTART?}

--- a/compose/.apps/watchtower/watchtower.yml
+++ b/compose/.apps/watchtower/watchtower.yml
@@ -1,7 +1,7 @@
 services:
   watchtower<__instance>:
     container_name: ${WATCHTOWER<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.watchtower
+    env_file: .env.app.watchtower<__instance>
     environment:
       - TZ=${TZ?}
     restart: ${WATCHTOWER<__INSTANCE>__RESTART?}

--- a/compose/.apps/wireguard/wireguard.yml
+++ b/compose/.apps/wireguard/wireguard.yml
@@ -4,7 +4,7 @@ services:
       - NET_ADMIN
       - SYS_MODULE
     container_name: ${WIREGUARD<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.wireguard
+    env_file: .env.app.wireguard<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/xbackbone/xbackbone.yml
+++ b/compose/.apps/xbackbone/xbackbone.yml
@@ -1,7 +1,7 @@
 services:
   xbackbone<__instance>:
     container_name: ${XBACKBONE<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.xbackbone
+    env_file: .env.app.xbackbone<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/xteve/xteve.yml
+++ b/compose/.apps/xteve/xteve.yml
@@ -1,7 +1,7 @@
 services:
   xteve<__instance>:
     container_name: ${XTEVE<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.xteve
+    env_file: .env.app.xteve<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/yacht/yacht.yml
+++ b/compose/.apps/yacht/yacht.yml
@@ -1,7 +1,7 @@
 services:
   yacht<__instance>:
     container_name: ${YACHT<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.yacht
+    env_file: .env.app.yacht<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/youtubedl/youtubedl.yml
+++ b/compose/.apps/youtubedl/youtubedl.yml
@@ -1,7 +1,7 @@
 services:
   youtubedl<__instance>:
     container_name: ${YOUTUBEDL<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.youtubedl
+    env_file: .env.app.youtubedl<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}

--- a/compose/.apps/znc/znc.yml
+++ b/compose/.apps/znc/znc.yml
@@ -1,7 +1,7 @@
 services:
   znc<__instance>:
     container_name: ${ZNC<__INSTANCE>__CONTAINER_NAME?}
-    env_file: .env.app.znc
+    env_file: .env.app.znc<__instance>
     environment:
       - PGID=${PGID?}
       - PUID=${PUID?}


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Enhancements:
- Append `<__instance>` placeholder to all `env_file:` entries in service templates to ensure per-instance environment file usage