### PR TITLE
Skip processing for tasks that are already done.

### DIFF
--- a/.scripts/apply_theme.sh
+++ b/.scripts/apply_theme.sh
@@ -16,7 +16,7 @@ apply_theme() {
         if [[ ! -f ${MENU_INI_FILE} ]]; then
             cp "${DefaultMenuIniFile}" "${MENU_INI_FILE}"
         fi
-        ThemeName="$(run_script 'env_get' Theme "${MENU_INI_FILE}")"
+        ThemeName="$(run_script 'config_get' Theme "${MENU_INI_FILE}")"
         if ! run_script 'theme_exists' "${ThemeName}"; then
             for Name in "${DefaultThemes[@]}"; do
                 if run_script 'theme_exists' "${Name}"; then
@@ -80,7 +80,7 @@ apply_theme() {
     readarray -t VarList < <(run_script 'env_var_list' "${ThemeFile}")
     for VarName in "${VarList[@]-}"; do
         local Value
-        Value="$(run_script 'env_get' "${VarName}" "${ThemeFile}")"
+        Value="$(run_script 'config_get' "${VarName}" "${ThemeFile}")"
         Value="$(
             _B_="${_B_}" _C_="${_C_}" _G_="${_G_}" _K_="${_K_}" _M_="${_M_}" _R_="${_R_}" _W_="${_W_}" _Y_="${_Y_}" \
                 _RV_="${_RV_}" _NRV_="${_NRV_}" _BD_="${_BD_}" _NBD_="${_NBD_}" _U_="${_U_}" _NU_="${_NU_}" _NC_="${_NC_}" \
@@ -93,35 +93,35 @@ apply_theme() {
 
     local LineCharacters Borders Scrollbar Shadow
     if run_script 'env_var_exists' Scrollbar "${MENU_INI_FILE}"; then
-        Scrollbar="$(run_script 'env_get' Scrollbar "${MENU_INI_FILE}")"
+        Scrollbar="$(run_script 'config_get' Scrollbar "${MENU_INI_FILE}")"
     else
-        Scrollbar="$(run_script 'env_get' Scrollbar "${DefaultMenuIniFile}")"
-        run_script 'env_set' Scrollbar "${Scrollbar}" "${MENU_INI_FILE}"
+        Scrollbar="$(run_script 'config_get' Scrollbar "${DefaultMenuIniFile}")"
+        run_script 'config_set' Scrollbar "${Scrollbar}" "${MENU_INI_FILE}"
     fi
     if run_script 'env_var_exists' Shadow "${MENU_INI_FILE}"; then
-        Shadow="$(run_script 'env_get' Shadow "${MENU_INI_FILE}")"
+        Shadow="$(run_script 'config_get' Shadow "${MENU_INI_FILE}")"
     else
-        Shadow="$(run_script 'env_get' Shadow "${DefaultMenuIniFile}")"
-        run_script 'env_set' Shadow "${Shadow}" "${MENU_INI_FILE}"
+        Shadow="$(run_script 'config_get' Shadow "${DefaultMenuIniFile}")"
+        run_script 'config_set' Shadow "${Shadow}" "${MENU_INI_FILE}"
     fi
     # Migrate old LineCharacters variable to Borders if Borders doesn't exist
     if run_script 'env_var_exists' Borders "${MENU_INI_FILE}"; then
-        Borders="$(run_script 'env_get' Borders "${MENU_INI_FILE}")"
+        Borders="$(run_script 'config_get' Borders "${MENU_INI_FILE}")"
         if run_script 'env_var_exists' LineCharacters "${MENU_INI_FILE}"; then
-            LineCharacters="$(run_script 'env_get' LineCharacters "${MENU_INI_FILE}")"
+            LineCharacters="$(run_script 'config_get' LineCharacters "${MENU_INI_FILE}")"
         else
-            LineCharacters="$(run_script 'env_get' LineCharacters "${DefaultMenuIniFile}")"
-            run_script 'env_set' LineCharacters "${LineCharacters}" "${MENU_INI_FILE}"
+            LineCharacters="$(run_script 'config_get' LineCharacters "${DefaultMenuIniFile}")"
+            run_script 'config_set' LineCharacters "${LineCharacters}" "${MENU_INI_FILE}"
         fi
     else
         if run_script 'env_var_exists' LineCharacters "${MENU_INI_FILE}"; then
-            Borders="$(run_script 'env_get' LineCharacters "${MENU_INI_FILE}")"
+            Borders="$(run_script 'config_get' LineCharacters "${MENU_INI_FILE}")"
         else
-            Borders="$(run_script 'env_get' Borders "${DefaultMenuIniFile}")"
+            Borders="$(run_script 'config_get' Borders "${DefaultMenuIniFile}")"
         fi
-        run_script 'env_set' Borders "${Borders}" "${MENU_INI_FILE}"
-        LineCharacters="$(run_script 'env_get' LineCharacters "${DefaultMenuIniFile}")"
-        run_script 'env_set' LineCharacters "${LineCharacters}" "${MENU_INI_FILE}"
+        run_script 'config_set' Borders "${Borders}" "${MENU_INI_FILE}"
+        LineCharacters="$(run_script 'config_get' LineCharacters "${DefaultMenuIniFile}")"
+        run_script 'config_set' LineCharacters "${LineCharacters}" "${MENU_INI_FILE}"
     fi
     if [[ ${Borders^^} =~ ON|TRUE|YES ]]; then
         if [[ ! ${LineCharacters^^} =~ ON|TRUE|YES ]]; then
@@ -149,7 +149,7 @@ apply_theme() {
     echo "${DialogOptions}" > "${DIALOG_OPTIONS_FILE}"
 
     cp "${DialogFile}" "${DIALOGRC}"
-    run_script 'env_set' Theme "${ThemeName}" "${MENU_INI_FILE}"
+    run_script 'config_set' Theme "${ThemeName}" "${MENU_INI_FILE}"
     sort -o "${MENU_INI_FILE}" "${MENU_INI_FILE}"
 }
 

--- a/.scripts/appvars_create_all.sh
+++ b/.scripts/appvars_create_all.sh
@@ -3,6 +3,10 @@ set -Eeuo pipefail
 IFS=$'\n\t'
 
 appvars_create_all() {
+    if [[ -z ${PROCESS_APPVARS_CREATE_ALL} ]]; then
+        # Application variables have already been created, nothing to do
+        return
+    fi
     run_script 'env_create'
     run_script 'appvars_migrate_enabled_lines'
     local AddedApps
@@ -14,6 +18,7 @@ appvars_create_all() {
         notice "${C["File"]}${COMPOSE_ENV}${NC} does not contain any added apps."
     fi
     run_script 'env_update'
+    declare -gx PROCESS_APPVARS_CREATE_ALL=''
 }
 
 test_appvars_create_all() {

--- a/.scripts/appvars_purge.sh
+++ b/.scripts/appvars_purge.sh
@@ -92,6 +92,9 @@ appvars_purge() {
                 sed -i -E "/^\s*(${AppEnvVarsRegex})\s*=/d" "${AppEnvFile}" ||
                     fatal "Failed to purge ${C["App"]}${AppName}${NC} variables.\nFailing command: ${C["FailingCommand"]}sed -i -E \"/^\\\*(${AppEnvVarsRegex})\\\*/d\" \"${AppEnvFile}\""
             fi
+            declare -gx PROCESS_APPVARS_CREATE_ALL=1
+            declare -gx PROCESS_ENV_UPDATE=1
+            declare -gx PROCESS_YML_MERGE=1
         else
             info "Keeping ${C["App"]}${AppName}${NC} variables."
         fi

--- a/.scripts/config_get.sh
+++ b/.scripts/config_get.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+config_get() {
+    # config_get GET_VAR [VAR_FILE]
+    local GET_VAR=${1-}
+    local VAR_FILE=${2:-}
+
+    if [[ -f ${VAR_FILE} ]]; then
+        grep --color=never -Po "^\s*${GET_VAR}\s*=\K.*" "${VAR_FILE}" | tail -1 | xargs || true
+    else
+        # VAR_FILE does not exist, give a warning
+        warn "File ${C["File"]}${VAR_FILE}${NC} does not exist."
+    fi
+
+}
+
+test_config_get() {
+    warn "CI does not test config_get."
+}

--- a/.scripts/config_set.sh
+++ b/.scripts/config_set.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+config_set() {
+    # config_set SET_VAR NEW_VAL [VAR_FILE]
+    local SET_VAR=${1-}
+    local NEW_VAL=${2-}
+    local VAR_FILE=${3-}
+
+    # https://unix.stackexchange.com/questions/422165/escape-double-quotes-in-variable/422170#422170
+    NEW_VAL="$(printf "%s\n" "${NEW_VAL-}" | sed -e "s/'/'\"'\"'/g" -e "1s/^/'/" -e "\$s/\$/'/")"
+
+    if [[ ! -f ${VAR_FILE} ]]; then
+        # VAR_FILE does not exist, create it
+        mkdir -p "${VAR_FILE%/*}" && touch "${VAR_FILE}"
+    fi
+    sed -i "/^\s*${SET_VAR}\s*=/d" "${VAR_FILE}" || true
+    echo "${SET_VAR}=${NEW_VAL}" >> "${VAR_FILE}" || fatal "Failed to set ${C["Var"]}${SET_VAR}=${NEW_VAL}${NC}\nFailing command: ${C["FailingCommand"]} \"echo ${SET_VAR}=${NEW_VAL}\" >> \"${VAR_FILE}\""
+}
+
+test_config_set() {
+    warn "CI does not test config_set."
+}

--- a/.scripts/env_copy.sh
+++ b/.scripts/env_copy.sh
@@ -44,6 +44,9 @@ env_copy() {
     fi
     printf '\n%s\n' "${NEW_VAR_LINE}" >> "${TO_VAR_FILE}" ||
         fatal "Failed to add '${C["Var"]}${NEW_VAR_LINE}${NC}' in ${C["File"]}${TO_VAR_FILE}${NC}\nFailing command: ${C["FailingCommand"]}printf '\n%s\n' \"${NEW_VAR_LINE}\" >> \"${TO_VAR_FILE}\""
+    declare -gx PROCESS_APPVARS_CREATE_ALL=1
+    declare -gx PROCESS_ENV_UPDATE=1
+    declare -gx PROCESS_YML_MERGE=1
 }
 
 test_env_copy() {

--- a/.scripts/env_merge_newonly.sh
+++ b/.scripts/env_merge_newonly.sh
@@ -31,6 +31,9 @@ env_merge_newonly() {
                     unset 'MergeFromLines[$index]' 2> /dev/null
                 fi
             done
+            declare -gx PROCESS_APPVARS_CREATE_ALL=1
+            declare -gx PROCESS_ENV_UPDATE=1
+            declare -gx PROCESS_YML_MERGE=1
         fi
         if [[ ${#MergeFromLines[@]} != 0 ]]; then
             notice "Adding variables to ${C["File"]}${MergeToFile}${NC}:"
@@ -41,6 +44,9 @@ env_merge_newonly() {
                 env -i line="${line}" MergeToFile="${MergeToFile}" \
                     printf '%s\n' "${line}" >> "${MergeToFile}" 2> /dev/null || fatal "Failed to add variable to ${C["File"]}${MergeToFile}${NC}"
             done
+            declare -gx PROCESS_APPVARS_CREATE_ALL=1
+            declare -gx PROCESS_ENV_UPDATE=1
+            declare -gx PROCESS_YML_MERGE=1
         fi
     fi
 }

--- a/.scripts/env_rename.sh
+++ b/.scripts/env_rename.sh
@@ -46,6 +46,9 @@ env_rename() {
         fatal "Failed to add '${C["Var"]}${NEW_VAR_LINE}${NC}' in ${C["File"]}${TO_VAR_FILE}${NC}\nFailing command: ${C["FailingCommand"]}printf '\n%s\n' \"${NEW_VAR_LINE}\" >> \"${TO_VAR_FILE}\""
     sed -i "/^\s*${FROM_VAR}\s*=/d" "${FROM_VAR_FILE}" ||
         fatal "Failed to remove var ${C["Var"]}${FROM_VAR}${NC} in ${C["File"]}${FROM_VAR_FILE}${NC}\nFailing command: ${C["FailingCommand"]}sed -i \"/^\\s*${FROM_VAR}\\s*=/d\" \"${FROM_VAR_FILE}\""
+    declare -gx PROCESS_APPVARS_CREATE_ALL=1
+    declare -gx PROCESS_ENV_UPDATE=1
+    declare -gx PROCESS_YML_MERGE=1
 }
 
 test_env_rename() {

--- a/.scripts/env_set.sh
+++ b/.scripts/env_set.sh
@@ -33,6 +33,9 @@ env_set() {
     fi
     sed -i "/^\s*${SET_VAR}\s*=/d" "${VAR_FILE}" || true
     echo "${SET_VAR}=${NEW_VAL}" >> "${VAR_FILE}" || fatal "Failed to set ${C["Var"]}${SET_VAR}=${NEW_VAL}${NC}\nFailing command: ${C["FailingCommand"]} \"echo ${SET_VAR}=${NEW_VAL}\" >> \"${VAR_FILE}\""
+    declare -gx PROCESS_APPVARS_CREATE_ALL=1
+    declare -gx PROCESS_ENV_UPDATE=1
+    declare -gx PROCESS_YML_MERGE=1
 }
 
 test_env_set() {

--- a/.scripts/env_set_literal.sh
+++ b/.scripts/env_set_literal.sh
@@ -29,6 +29,9 @@ env_set_literal() {
     fi
     sed -i "/^\s*${SET_VAR}\s*=/d" "${VAR_FILE}" || true
     echo "${SET_VAR}=${NEW_VAL}" >> "${VAR_FILE}" || fatal "Failed to set ${C["Var"]}${SET_VAR}=${NEW_VAL}${NC}\nFailing command: ${C["FailingCommand"]} \"echo ${SET_VAR}=${NEW_VAL}\" >> \"${VAR_FILE}\""
+    declare -gx PROCESS_APPVARS_CREATE_ALL=1
+    declare -gx PROCESS_ENV_UPDATE=1
+    declare -gx PROCESS_YML_MERGE=1
 }
 
 test_env_set_literal() {

--- a/.scripts/env_update.sh
+++ b/.scripts/env_update.sh
@@ -3,6 +3,10 @@ set -Eeuo pipefail
 IFS=$'\n\t'
 
 env_update() {
+    if [[ -z ${PROCESS_ENV_UPDATE} ]]; then
+        # Env files have already been updated, nothing to do
+        return
+    fi
     local ENV_LINES_FILE
     ENV_LINES_FILE=$(mktemp -t "${APPLICATION_NAME}.${FUNCNAME[0]}.ENV_LINES_FILE.XXXXXXXXXX")
     run_script 'appvars_lines' "" > "${ENV_LINES_FILE}"
@@ -67,6 +71,7 @@ env_update() {
 
     #run_script 'env_sanitize'
     info "Environment file update complete."
+    declare -gx PROCESS_ENV_UPDATE=''
 }
 
 test_env_update() {

--- a/.scripts/menu_add_app.sh
+++ b/.scripts/menu_add_app.sh
@@ -95,11 +95,18 @@ menu_add_app() {
                     case ${DIALOG_BUTTONS[YesNoDialogButtonPressed]-} in
                         OK) # Built In
                             Heading="$(run_script 'menu_heading' "${AppNameHeading}")"
+                            coproc {
+                                dialog_pipe "${DC[TitleSuccess]}Adding Built In Application" "${Heading}\n\n${DC[Subtitle]}Adding application:\n${DC[CommandLine]} ${APPLICATION_COMMAND} --add ${AppName}" "${DIALOGTIMEOUT}"
+                            }
+                            local -i DialogBox_PID=${COPROC_PID}
+                            local -i DialogBox_FD="${COPROC[1]}"
                             {
                                 run_script 'env_backup'
                                 run_script 'appvars_create' "${AppName}"
                                 run_script 'env_update'
-                            } |& dialog_pipe "${DC[TitleSuccess]}Adding Built In Application" "${Heading}\n\n${DC[Subtitle]}Adding application:\n${DC[CommandLine]} ${APPLICATION_COMMAND} --add ${AppName}" "${DIALOGTIMEOUT}"
+                            } >&${DialogBox_FD} 2>&1
+                            exec {DialogBox_FD}<&-
+                            wait ${DialogBox_PID}
                             return
                             ;;
                         EXTRA) # User Defined

--- a/.scripts/menu_add_var.sh
+++ b/.scripts/menu_add_var.sh
@@ -203,6 +203,11 @@ menu_add_var() {
                             Heading="$(run_script 'menu_heading' ":${AppName}")"
                             if run_script 'question_prompt' N "${Heading}\n\n${Question}" "Create Stock Variables" "" "Create" "Back"; then
                                 Heading="$(run_script 'menu_heading' ":${AppName}" "${VarNameHeading}")"
+                                coproc {
+                                    dialog_pipe "${DC["TitleSuccess"]}Creating Stock Variables" "${Heading}"
+                                }
+                                local -i DialogBox_PID=${COPROC_PID}
+                                local -i DialogBox_FD="${COPROC[1]}"
                                 {
                                     notice "Adding variables to ${C["File"]}${COMPOSE_ENV}${NC}:"
                                     for Option in "${ValidStockOptions[@]}"; do
@@ -211,7 +216,9 @@ menu_add_var() {
                                         notice "   ${C["Var"]}${Option// /}=${DefaultValue}${NC}"
                                         run_script 'env_set_literal' "${Option// /}" "${DefaultValue}"
                                     done
-                                } |& dialog_pipe "${DC["TitleSuccess"]}Creating Stock Variables" "${Heading}" "${DIALOGTIMEOUT}"
+                                } >&${DialogBox_FD} 2>&1
+                                exec {DialogBox_FD}<&-
+                                wait ${DialogBox_PID}
                             fi
                             continue
                         elif [[ ${SelectedOption} =~ ${APPNAME__ENABLED}|${StockOptionsRegex} ]]; then

--- a/.scripts/menu_config_vars.sh
+++ b/.scripts/menu_config_vars.sh
@@ -191,6 +191,11 @@ menu_config_vars() {
                         local Question="Do you really want to delete ${DC[Highlight]}${CleanVarName}${DC[NC]}?"
                         if run_script 'question_prompt' N "${DialogHeading}\n\n${Question}\n" "Delete Variable" "" "Delete" "Back"; then
                             DialogHeading="$(run_script 'menu_heading' "${APPNAME-}" "${VarName}")"
+                            coproc {
+                                dialog_pipe "${DC["TitleSuccess"]}Deleting Variable" "${DialogHeading}" "${DIALOGTIMEOUT}"
+                            }
+                            local -i DialogBox_PID=${COPROC_PID}
+                            local -i DialogBox_FD="${COPROC[1]}"
                             {
                                 run_script 'env_delete' "${VarName}"
                                 if [[ -n ${APPNAME-} ]]; then
@@ -207,7 +212,9 @@ menu_config_vars() {
                                     run_script 'env_sanitize'
                                     run_script 'env_update'
                                 fi
-                            } |& dialog_pipe "${DC["TitleSuccess"]}Deleting Variable" "${DialogHeading}" "${DIALOGTIMEOUT}"
+                            } >&${DialogBox_FD} 2>&1
+                            exec {DialogBox_FD}<&-
+                            wait ${DialogBox_PID}
                             break
                         fi
                     fi

--- a/.scripts/menu_display_options_general.sh
+++ b/.scripts/menu_display_options_general.sh
@@ -33,7 +33,7 @@ menu_display_options_general() {
         local Opts=()
         for Option in "${DrawLineOption}" "${ShowBordersOption}" "${ShowScrollbarOption}" "${ShowShadowOption}"; do
             local Value
-            Value="$(run_script 'env_get' "${OptionVariable["${Option}"]}" "${MENU_INI_FILE}")"
+            Value="$(run_script 'config_get' "${OptionVariable["${Option}"]}" "${MENU_INI_FILE}")"
             if [[ ${Value^^} =~ ON|TRUE|YES ]]; then
                 EnabledOptions+=("${Option}")
                 Opts+=("${Option}" "${OptionDescription["${Option}"]}" ON)
@@ -66,12 +66,12 @@ menu_display_options_general() {
                 if [[ -n ${OptionsToTurnOff[*]-} || ${OptionsToTurnOn[*]-} ]]; then
                     if [[ -n ${OptionsToTurnOff[*]-} ]]; then
                         for Option in "${OptionsToTurnOff[@]}"; do
-                            run_script 'env_set' "${OptionVariable["${Option}"]}" OFF "${MENU_INI_FILE}"
+                            run_script 'config_set' "${OptionVariable["${Option}"]}" OFF "${MENU_INI_FILE}"
                         done
                     fi
                     if [[ -n ${OptionsToTurnOn[*]-} ]]; then
                         for Option in "${OptionsToTurnOn[@]}"; do
-                            run_script 'env_set' "${OptionVariable["${Option}"]}" ON "${MENU_INI_FILE}"
+                            run_script 'config_set' "${OptionVariable["${Option}"]}" ON "${MENU_INI_FILE}"
                         done
                     fi
                     run_script 'apply_theme'

--- a/.scripts/menu_value_prompt.sh
+++ b/.scripts/menu_value_prompt.sh
@@ -446,6 +446,11 @@ menu_value_prompt() {
                     if [[ -z ${OptionValue["${CurrentValueOption}"]-} ]]; then
                         if run_script 'question_prompt' N "${DialogHeading}\n\nDo you really want to delete ${DC[Highlight]}${CleanVarName}${DC[NC]}?\n" "Delete Variable" "" "Delete" "Back"; then
                             # Value is empty, delete the variable
+                            coproc {
+                                dialog_pipe "${DC["TitleSuccess"]}Deleting Variable" "${DialogHeading}" "${DIALOGTIMEOUT}"
+                            }
+                            local -i DialogBox_PID=${COPROC_PID}
+                            local -i DialogBox_FD="${COPROC[1]}"
                             {
                                 run_script 'env_delete' "${VarName}"
                                 if [[ -n ${APPNAME-} ]]; then
@@ -461,12 +466,19 @@ menu_value_prompt() {
                                     run_script 'env_sanitize'
                                     run_script 'env_update'
                                 fi
-                            } |& dialog_pipe "${DC["TitleSuccess"]}Deleting Variable" "${DialogHeading}" "${DIALOGTIMEOUT}"
+                            } >&${DialogBox_FD} 2>&1
+                            exec {DialogBox_FD}<&-
+                            wait ${DialogBox_PID}
                             return 0
                         fi
                     elif [[ ${OptionValue["${CurrentValueOption}"]-} == "${OptionValue["${OriginalValueOption}"]-}" ]]; then
                         if run_script 'question_prompt' N "${DialogHeading}\n\nThe value of ${DC[Highlight]}${CleanVarName}${DC[NC]} has not been changed, exit anyways?\n" "Save Variable" "" "Done" "Back"; then
                             # Value has not changed, confirm exiting
+                            coproc {
+                                dialog_pipe "${DC["TitleSuccess"]}Canceling Variable Edit" "${DialogHeading}" "${DIALOGTIMEOUT}"
+                            }
+                            local -i DialogBox_PID=${COPROC_PID}
+                            local -i DialogBox_FD="${COPROC[1]}"
                             {
                                 if [[ -n ${APPNAME-} ]]; then
                                     if ! run_script 'app_is_user_defined' "${APPNAME}"; then
@@ -481,12 +493,19 @@ menu_value_prompt() {
                                     run_script 'env_update'
                                     run_script 'env_sanitize'
                                 fi
-                            } |& dialog_pipe "${DC["TitleSuccess"]}Canceling Variable Edit" "${DialogHeading}" "${DIALOGTIMEOUT}"
+                            } >&${DialogBox_FD} 2>&1
+                            exec {DialogBox_FD}<&-
+                            wait ${DialogBox_PID}
                             return 0
                         fi
                     else
                         if run_script 'question_prompt' N "${DialogHeading}\n\nWould you like to save ${DC[Highlight]}${CleanVarName}${DC[NC]}?\n" "Save Variable" "" "Save" "Back"; then
                             # Value is valid, save it and exit
+                            coproc {
+                                dialog_pipe "${DC["TitleSuccess"]}Saving Variable" "${DialogHeading}" "${DIALOGTIMEOUT}"
+                            }
+                            local -i DialogBox_PID=${COPROC_PID}
+                            local -i DialogBox_FD="${COPROC[1]}"
                             {
                                 run_script 'env_set_literal' "${VarName}" "${OptionValue["${CurrentValueOption}"]}"
                                 if [[ -n ${APPNAME-} ]]; then
@@ -501,7 +520,9 @@ menu_value_prompt() {
                                     run_script 'env_update'
                                     run_script 'env_sanitize'
                                 fi
-                            } |& dialog_pipe "${DC["TitleSuccess"]}Saving Variable" "${DialogHeading}" "${DIALOGTIMEOUT}"
+                            } >&${DialogBox_FD} 2>&1
+                            exec {DialogBox_FD}<&-
+                            wait ${DialogBox_PID}
                             return 0
                         fi
                     fi

--- a/.scripts/merge_and_compose.sh
+++ b/.scripts/merge_and_compose.sh
@@ -5,7 +5,14 @@ IFS=$'\n\t'
 merge_and_compose() {
     Title="Merge and run Docker Compose"
     if use_dialog_box; then
-        commands_merge_and_compose "$@" |& dialog_pipe "${Title}" "$@"
+        coproc {
+            dialog_pipe "${Title}" "$@"
+        }
+        local -i DialogBox_PID=${COPROC_PID}
+        local -i DialogBox_FD="${COPROC[1]}"
+        commands_merge_and_compose "$@" >&${DialogBox_FD} 2>&1
+        exec {DialogBox_FD}<&-
+        wait ${DialogBox_PID}
     else
         commands_merge_and_compose "$@"
     fi

--- a/.scripts/override_var_rename.sh
+++ b/.scripts/override_var_rename.sh
@@ -16,6 +16,8 @@ override_var_rename() {
         # Replace $FromVar or ${FromVar followed by a word break to $ToVar or ${ToVar
         sed -i -E "s/([$]\{?)${FromVar}\b/\1${ToVar}/g" "${COMPOSE_OVERRIDE}" ||
             fatal "Failed to rename variable in override file.\nFailing command: ${C["FailingCommand"]} sed -i -E \"s/([$]\\{?)${FromVar}\\\\b/\\\\1${ToVar}/g\" \"${COMPOSE_OVERRIDE}\""
+        declare -gx PROCESS_YML_MERGE=1
+
     fi
 }
 

--- a/.scripts/update_self.sh
+++ b/.scripts/update_self.sh
@@ -78,6 +78,10 @@ update_self() {
         return 1
     fi
 
+    declare -gx PROCESS_APPVARS_CREATE_ALL=1
+    declare -gx PROCESS_ENV_UPDATE=1
+    declare -gx PROCESS_YML_MERGE=1
+
     if use_dialog_box; then
         commands_update_self "${BRANCH}" "${YesNotice}" "$@" |&
             dialog_pipe "${DC[TitleSuccess]}${Title}" "${YesNotice}\n${DC[CommandLine]} ${APPLICATION_COMMAND} --update $*"

--- a/.scripts/yml_merge.sh
+++ b/.scripts/yml_merge.sh
@@ -7,6 +7,10 @@ yml_merge() {
 }
 
 commands_yml_merge() {
+    if [[ -z ${PROCESS_YML_MERGE} && -f ${COMPOSE_FOLDER}/docker-compose.yml ]]; then
+        # Compose file has already been created, nothing to do
+        return
+    fi
     run_script 'appvars_create_all'
     local COMPOSE_FILE=""
     notice "Adding enabled app templates to merge ${C["File"]}docker-compose.yml${NC}. Please be patient, this can take a while."
@@ -111,6 +115,7 @@ commands_yml_merge() {
     export COMPOSE_FILE="${COMPOSE_FILE#:}"
     eval "docker compose --project-directory ${COMPOSE_FOLDER}/ config > ${COMPOSE_FOLDER}/docker-compose.yml" || fatal "Failed to output compose config.\nFailing command: ${C["FailingCommand"]}docker compose --project-directory ${COMPOSE_FOLDER}/ config > \"${COMPOSE_FOLDER}/docker-compose.yml\""
     info "Merging ${C["File"]}docker-compose.yml${NC} complete."
+    declare -gx PROCESS_YML_MERGE=''
 }
 test_yml_merge() {
     run_script 'appvars_create' WATCHTOWER


### PR DESCRIPTION
Set up global variables to indicate if `appvars_create_all`, `env_update` or `yml_merge` have already been done.  If they have been, skip those processes.  Reset the variables to force them to be done again if a variable has been updated.

This currently only affects the menu system, where these functions might be called multiple times.

There are plans to allow multiple commands to be put on the command-line to be run in sequence where this will also apply.

# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Introduce global flags to bypass redundant processing of environment and compose tasks, standardize config operations with new utilities, and refactor dialog piping for cleaner I/O handling across the menu and scripting workflows.

New Features:
- Add config_get and config_set helper scripts for reading and writing configuration variables.

Enhancements:
- Introduce PROCESS_APPVARS_CREATE_ALL, PROCESS_ENV_UPDATE, and PROCESS_YML_MERGE flags to skip already completed tasks and reset them when configurations change.
- Replace env_get/env_set calls with config_get/config_set across theming, menu, and merge scripts for consistent config handling.
- Refactor dialog output handling to use Bash coprocesses and explicit file descriptors instead of direct piping.
- Update compose, merge, add-app, and environment manipulation scripts to respect the new skip flags and leverage the config utilities.