### PR TITLE
Make `docker_compose` and `yml_merge` return status values for succes…

### DIFF
--- a/.scripts/docker_compose.sh
+++ b/.scripts/docker_compose.sh
@@ -103,6 +103,8 @@ docker_compose() {
             ComposeCommand[1]="up -d --remove-orphans"
             ;;
     esac
+
+    local -i result=0
     if run_script 'question_prompt' Y "${Question}" "${Title}" "${FORCE:+Y}"; then
         if use_dialog_box; then
             coproc {
@@ -113,26 +115,38 @@ docker_compose() {
             {
                 [[ -n ${YesNotice-} ]] && notice "${YesNotice}"
                 run_script 'require_docker'
-                run_script 'yml_merge'
-                for index in "${!ComposeCommand[@]}"; do
-                    local Command="docker compose --project-directory ${COMPOSE_FOLDER}/ ${ComposeCommand[index]}"
-                    notice "Running: ${C["RunningCommand"]}${Command}${NC}"
-                    eval "${Command}" ||
-                        fatal "Failed to run compose.\nFailing command: ${C["FailingCommand"]}${Command}"
-                done
+                if run_script 'yml_merge'; then
+                    for index in "${!ComposeCommand[@]}"; do
+                        local Command="docker compose --project-directory ${COMPOSE_FOLDER}/ ${ComposeCommand[index]}"
+                        notice "Running: ${C["RunningCommand"]}${Command}${NC}"
+                        eval "${Command}" || result=$?
+                        if [[ ${result} != 0 ]]; then
+                            error "Failed to run compose.\nFailing command: ${C["FailingCommand"]}${Command}"
+                            break
+                        fi
+                    done
+                else
+                    result=1
+                fi
             } >&${DialogBox_FD} 2>&1
             exec {DialogBox_FD}<&-
             wait ${DialogBox_PID}
         else
             [[ -n ${YesNotice-} ]] && notice "${YesNotice}"
             run_script 'require_docker'
-            run_script 'yml_merge'
-            for index in "${!ComposeCommand[@]}"; do
-                local Command="docker compose --project-directory ${COMPOSE_FOLDER}/ ${ComposeCommand[index]}"
-                notice "Running: ${C["RunningCommand"]}${Command}${NC}"
-                eval "${Command}" ||
-                    fatal "Failed to run compose.\nFailing command: ${C["FailingCommand"]}${Command}"
-            done
+            if run_script 'yml_merge'; then
+                for index in "${!ComposeCommand[@]}"; do
+                    local Command="docker compose --project-directory ${COMPOSE_FOLDER}/ ${ComposeCommand[index]}"
+                    notice "Running: ${C["RunningCommand"]}${Command}${NC}"
+                    eval "${Command}" || result=$?
+                    if [[ ${result} != 0 ]]; then
+                        error "Failed to run compose.\nFailing command: ${C["FailingCommand"]}${Command}"
+                        break
+                    fi
+                done
+            else
+                result=1
+            fi
         fi
     else
         if use_dialog_box; then
@@ -141,6 +155,7 @@ docker_compose() {
             [[ -n ${NoNotice-} ]] && notice "${NoNotice}"
         fi
     fi
+    return ${result}
 }
 
 test_docker_compose() {


### PR DESCRIPTION
…s/faiilure

# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Ensure the docker_compose and yml_merge scripts return proper exit status codes and handle errors gracefully instead of invoking fatal exits.

Enhancements:
- Track and return exit statuses in docker_compose.sh, replacing immediate fatal calls with error reporting and propagation.
- Add explicit success (0) and failure (non-zero) return codes in yml_merge.sh and replace fatal errors with error logging.