### PR TITLE
Abort `yml_merge` on missing template files

### DIFF
--- a/.scripts/app_instance_file.sh
+++ b/.scripts/app_instance_file.sh
@@ -30,6 +30,8 @@ app_instance_file() {
     local InstanceTemplateFile="${InstanceTemplateFolder}/${FilenameTemplate//"*"/"${appname}"}"
     local InstanceFile="${InstanceFolder}/${FilenameTemplate//"*"/"${appname}"}"
 
+    echo "${InstanceFile}"
+
     if [[ ! -d ${TemplateFolder} ]]; then
         # Template folder doesn't exist, remove any instance folders associated with it and return
         for Folder in "${InstanceTemplateFolder}" "${InstanceFolder}"; do
@@ -53,8 +55,6 @@ app_instance_file() {
         done
         return
     fi
-
-    echo "${InstanceFile}"
 
     if [[ -f ${InstanceFile} && -f ${InstanceTemplateFile} ]] && cmp -s "${TemplateFile}" "${InstanceTemplateFile}"; then
         # The instance file exists, and the template file has not changed, nothing to do.

--- a/.scripts/yml_merge.sh
+++ b/.scripts/yml_merge.sh
@@ -34,7 +34,7 @@ commands_yml_merge() {
                 arch_yml="$(run_script 'app_instance_file' "${appname}" "*.${ARCH}.yml")"
                 if [[ ! -f ${arch_yml} ]]; then
                     error "'${C["File"]}${arch_yml}${NC}' does not exist."
-                    continue
+                    return 1
                 fi
                 COMPOSE_FILE="${COMPOSE_FILE}:${arch_yml}"
                 local AppNetMode
@@ -101,11 +101,13 @@ commands_yml_merge() {
                 COMPOSE_FILE="${COMPOSE_FILE}:${main_yml}"
                 info "All configurations for '${C["App"]}${AppName}${NC}' are included."
             else
-                warn "'${C["File"]}${main_yml}${NC}' does not exist."
+                error "'${C["File"]}${main_yml}${NC}' does not exist."
+                return 1
             fi
             run_script 'appfolders_create' "${APPNAME}"
         else
-            error "'${C["File"]}${APP_FOLDER}/${NC}' does not exist."
+            error "'${C["Folder"]}${APP_FOLDER}/${NC}' does not exist."
+            return 1
         fi
     done
     if [[ -z ${COMPOSE_FILE} ]]; then


### PR DESCRIPTION
Abort `yml_merge` on missing template files

Fix `app_instance_file` to always return a filename, even if the file doesn't exist.

# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).
