### PR TITLE
Declare variables using `-l` and `-u` instead of using `,,` and `^^` …

### DIFF
--- a/.scripts/app_description.sh
+++ b/.scripts/app_description.sh
@@ -4,8 +4,7 @@ IFS=$'\n\t'
 
 app_description() {
     # Return the description of the appname passed.
-    local appname=${1-}
-    appname="${appname,,}"
+    local -l appname=${1-}
     appname="${appname%:*}"
     if run_script 'app_is_user_defined' "${appname}"; then
         local AppName

--- a/.scripts/app_env_file.sh
+++ b/.scripts/app_env_file.sh
@@ -3,8 +3,7 @@ set -Eeuo pipefail
 IFS=$'\n\t'
 
 app_env_file() {
-    local appname=${1:-}
-    appname="${appname,,}"
+    local -l appname=${1:-}
 
     local AppEnvFilename=".env.app.${appname}"
     local OldAppEnvFilename="${appname}.env"

--- a/.scripts/app_filter_runnable.sh
+++ b/.scripts/app_filter_runnable.sh
@@ -6,10 +6,8 @@ app_filter_runnable() {
     local AppList
     AppList="$(xargs -n 1 <<< "$*")"
     for AppName in ${AppList}; do
-        #if run_script 'app_is_runnable' "${AppName}"; then
-        local basename
+        local -l basename
         basename=$(run_script 'appname_to_baseappname' "${AppName}")
-        basename=${basename,,}
         local main_yml="${TEMPLATES_FOLDER}/${basename}/${basename}.yml"
         local arch_yml="${TEMPLATES_FOLDER}/${basename}/${basename}.${ARCH}.yml"
         if [[ -f ${main_yml} && -f ${arch_yml} ]]; then

--- a/.scripts/app_instance_file.sh
+++ b/.scripts/app_instance_file.sh
@@ -9,9 +9,8 @@ app_instance_file() {
     # app_instance_file "radarr" "*.labels.yml" will return a string similar to "/home/user/.docker/compose/.instances/radarr/radarr.labels.yml"
     # If the file does not exist, it is created from the matching file in the "templates" folder.
 
-    local appname=${1:-}
+    local -l appname=${1:-}
     local FilenameTemplate=${2:-}
-    local appname=${appname,,}
 
     if [[ ! -d ${INSTANCES_FOLDER} ]]; then
         mkdir -p "${INSTANCES_FOLDER}" ||
@@ -19,7 +18,7 @@ app_instance_file() {
         run_script 'set_permissions' "${INSTANCES_FOLDER}"
     fi
 
-    local baseapp
+    local -l baseapp
     baseapp="$(run_script 'appname_to_baseappname' "${appname}")"
 
     local TemplateFolder="${TEMPLATES_FOLDER}/${baseapp}"

--- a/.scripts/app_instance_folder.sh
+++ b/.scripts/app_instance_folder.sh
@@ -10,7 +10,7 @@ app_instance_folder() {
     # If the folder does not exist, it is created from the matching folder in the "templates" folder.
 
     local AppName=${1:-}
-    local appname=${AppName,,}
+    local -l appname=${AppName}
 
     local baseapp TemplateFolder InstanceFolder
     baseapp="$(run_script 'appname_to_baseappname' "${appname}")"

--- a/.scripts/app_is_added.sh
+++ b/.scripts/app_is_added.sh
@@ -4,8 +4,8 @@ IFS=$'\n\t'
 
 app_is_added() {
     # Returns if the passed app is both built in and an APPNAME__ENABLED variable exists
-    local APPNAME=${1-}
-    local ENABLED_VAR="${APPNAME^^}__ENABLED"
+    local -u APPNAME=${1-}
+    local ENABLED_VAR="${APPNAME}__ENABLED"
     run_script 'app_is_builtin' "${APPNAME}" && run_script 'env_var_exists' "${ENABLED_VAR}"
 }
 

--- a/.scripts/app_is_builtin.sh
+++ b/.scripts/app_is_builtin.sh
@@ -3,11 +3,11 @@ set -Eeuo pipefail
 IFS=$'\n\t'
 
 app_is_builtin() {
-    local APPNAME=${1-}
+    local -l appname=${1-}
 
-    local BaseApp
-    BaseApp="$(run_script 'appname_to_baseappname' "${APPNAME}")"
-    [[ -d "${TEMPLATES_FOLDER}/${BaseApp,,}" ]]
+    local -l baseapp
+    baseapp="$(run_script 'appname_to_baseappname' "${appname}")"
+    [[ -d "${TEMPLATES_FOLDER}/${baseapp}" ]]
 }
 
 test_app_is_builtin() {

--- a/.scripts/app_is_deprecated.sh
+++ b/.scripts/app_is_deprecated.sh
@@ -3,10 +3,9 @@ set -Eeuo pipefail
 IFS=$'\n\t'
 
 app_is_deprecated() {
-    local AppName=${1-}
-    local baseappname
-    baseappname=$(run_script 'appname_to_baseappname' "${AppName}")
-    baseappname="${baseappname,,}"
+    local -l appname=${1-}
+    local -l baseappname
+    baseappname=$(run_script 'appname_to_baseappname' "${appname}")
     local labels_yml
     labels_yml="$(run_script 'app_template_file' "${baseappname}" "*.labels.yml")"
     local APP_DEPRECATED

--- a/.scripts/app_is_disabled.sh
+++ b/.scripts/app_is_disabled.sh
@@ -3,15 +3,14 @@ set -Eeuo pipefail
 IFS=$'\n\t'
 
 app_is_disabled() {
-    local APPNAME=${1-}
-    APPNAME=${APPNAME^^}
+    local -u APPNAME=${1-}
     if ! run_script 'app_is_builtin' "${APPNAME}"; then
         false
         return
     fi
-    local APP_ENABLED
+    local -u APP_ENABLED
     APP_ENABLED="$(run_script 'env_get' "${APPNAME}__ENABLED")"
-    [[ ! ${APP_ENABLED^^} =~ ON|TRUE|YES ]]
+    [[ ! ${APP_ENABLED} =~ ON|TRUE|YES ]]
 }
 
 test_app_is_disabled() {

--- a/.scripts/app_is_enabled.sh
+++ b/.scripts/app_is_enabled.sh
@@ -3,15 +3,14 @@ set -Eeuo pipefail
 IFS=$'\n\t'
 
 app_is_enabled() {
-    local APPNAME=${1-}
-    APPNAME=${APPNAME^^}
+    local -u APPNAME=${1-}
     if ! run_script 'app_is_builtin' "${APPNAME}"; then
         false
         return
     fi
-    local APP_ENABLED
+    local -u APP_ENABLED
     APP_ENABLED="$(run_script 'env_get' "${APPNAME}__ENABLED")"
-    [[ ${APP_ENABLED^^} =~ ON|TRUE|YES ]]
+    [[ ${APP_ENABLED} =~ ON|TRUE|YES ]]
 }
 
 test_app_is_enabled() {

--- a/.scripts/app_is_nondeprecated.sh
+++ b/.scripts/app_is_nondeprecated.sh
@@ -3,10 +3,9 @@ set -Eeuo pipefail
 IFS=$'\n\t'
 
 app_is_nondeprecated() {
-    local AppName=${1-}
-    local baseappname
-    baseappname=$(run_script 'appname_to_baseappname' "${AppName}")
-    baseappname="${baseappname,,}"
+    local -l appname=${1-}
+    local -l baseappname
+    baseappname=$(run_script 'appname_to_baseappname' "${appname}")
     local labels_yml
     labels_yml="$(run_script 'app_template_file' "${baseappname}" "*.labels.yml")"
     local APP_DEPRECATED

--- a/.scripts/app_is_runnable.sh
+++ b/.scripts/app_is_runnable.sh
@@ -3,10 +3,9 @@ set -Eeuo pipefail
 IFS=$'\n\t'
 
 app_is_runnable() {
-    local appname=${1-}
-    local basename
+    local -l appname=${1-}
+    local -l basename
     basename=$(run_script 'appname_to_baseappname' "${appname}")
-    basename=${basename,,}
     local main_yml
     main_yml="$(run_script 'app_template_file' "${basename}" "*.yml")"
     local arch_yml

--- a/.scripts/app_is_user_defined.sh
+++ b/.scripts/app_is_user_defined.sh
@@ -3,13 +3,13 @@ set -Eeuo pipefail
 IFS=$'\n\t'
 
 app_is_user_defined() {
-    local APPNAME=${1-}
+    local -u APPNAME=${1-}
 
     if ! run_script 'app_is_builtin' "${APPNAME}"; then
         true
         return
     fi
-    if ! run_script 'env_var_exists' "${APPNAME^^}__ENABLED"; then
+    if ! run_script 'env_var_exists' "${APPNAME}__ENABLED"; then
         true
         return
     fi

--- a/.scripts/app_nicename_from_template.sh
+++ b/.scripts/app_nicename_from_template.sh
@@ -8,7 +8,7 @@ app_nicename_from_template() {
     AppList="$(xargs -n 1 <<< "$*")"
     for APPNAME in ${AppList}; do
         local AppName="${APPNAME%:*}"
-        local appname=${AppName,,}
+        local -l appname=${AppName}
         local LABELS_FILE
         LABELS_FILE="$(run_script 'app_instance_file' "${appname}" "*.labels.yml")"
         if [[ -f ${LABELS_FILE} ]]; then

--- a/.scripts/app_template_file.sh
+++ b/.scripts/app_template_file.sh
@@ -8,9 +8,8 @@ app_template_file() {
     #
     # app_template_file "radarr" "*.labels.yml" will return a string similar to "/home/user/.docker/compose/.apps/radarr/radarr.labels.yml"
 
-    local appname=${1:-}
+    local -l appname=${1:-}
     local FilenameTemplate=${2:-}
-    local appname=${appname,,}
 
     echo "${TEMPLATES_FOLDER}/${appname}/${FilenameTemplate//"*"/"${appname}"}"
 }

--- a/.scripts/appfolders_create.sh
+++ b/.scripts/appfolders_create.sh
@@ -3,12 +3,11 @@ set -Eeuo pipefail
 IFS=$'\n\t'
 
 appfolders_create() {
-    local APPNAME=${1-}
-    APPNAME=${APPNAME^^}
-
-    local appname=${APPNAME,,}
+    local -u APPNAME=${1-}
+    local -l appname=${APPNAME}
     local AppName
     AppName="$(run_script 'app_nicename' "${APPNAME}")"
+
     local APP_FOLDERS_FILE
     APP_FOLDERS_FILE="$(run_script 'app_instance_file' "${appname}" "*.folders")"
 

--- a/.scripts/appname_is_valid.sh
+++ b/.scripts/appname_is_valid.sh
@@ -3,13 +3,13 @@ set -Eeuo pipefail
 IFS=$'\n\t'
 
 appname_is_valid() {
-    local AppName=${1-}
-    if [[ ${AppName-} == *":" ]]; then
-        AppName="${AppName%:*}"
-    elif [[ ${AppName-} == ":"* ]]; then
-        AppName="${AppName#:*}"
+    local -u APPNAME=${1-}
+    if [[ ${APPNAME-} == *":" ]]; then
+        APPNAME="${APPNAME%:*}"
+    elif [[ ${APPNAME-} == ":"* ]]; then
+        APPNAME="${APPNAME#:*}"
     fi
-    if [[ ${AppName} =~ ^[a-zA-Z][a-zA-Z0-9]*(__[a-zA-Z0-9]+)?$ ]]; then
+    if [[ ${APPNAME} =~ ^[A-Z][A-Z0-9]*(__[A-Z0-9]+)?$ ]]; then
         local -a InvalidInstanceNames=(
             CONTAINER
             DEVICE
@@ -31,9 +31,9 @@ appname_is_valid() {
             IFS='|'
             InvalidInstanceNamesRegex="${InvalidInstanceNames[*]}"
         }
-        local InstanceName
+        local -u InstanceName
         InstanceName="$(run_script 'appname_to_instancename' "${AppName}")"
-        [[ ! ${InstanceName^^} =~ ${InvalidInstanceNamesRegex} ]]
+        [[ ! ${InstanceName} =~ ${InvalidInstanceNamesRegex} ]]
         return
     fi
     false

--- a/.scripts/appvars_create.sh
+++ b/.scripts/appvars_create.sh
@@ -6,7 +6,7 @@ appvars_create() {
     local AppList
     AppList="$(xargs -n 1 <<< "$*")"
     for APPNAME in ${AppList^^}; do
-        local appname=${APPNAME,,}
+        local -l appname=${APPNAME}
         local AppName
         AppName="$(run_script 'app_nicename' "${APPNAME}")"
 

--- a/.scripts/appvars_lines.sh
+++ b/.scripts/appvars_lines.sh
@@ -6,8 +6,7 @@ appvars_lines() {
     # Return all lines in `.env` file for app APPNAME
     # If APPNAME ends in a ':', returns all lines in `.env.app.appname'
     # If APPNAME is empty, return all lines in `.env` file that are not for an app
-    local APPNAME=${1-}
-    APPNAME=${APPNAME^^}
+    local -u APPNAME=${1-}
     local VAR_FILE=${2:-$COMPOSE_ENV}
 
     if [[ -z ${APPNAME} ]]; then
@@ -15,7 +14,7 @@ appvars_lines() {
         local VAR_REGEX='[A-Z][A-Z0-9]*(__[A-Z0-9]+)+\w+'
         local APP_VARS_REGEX="^\s*${VAR_REGEX}\s*="
         grep -v -P '^\s*$|^\s*\#' "${VAR_FILE}" | grep --color=never -v -P "${APP_VARS_REGEX}" || true
-    elif [[ ${APPNAME} =~ ^[A-Za-z0-9_]+: ]]; then
+    elif [[ ${APPNAME} =~ ^[A-Z0-9_]+: ]]; then
         # APPNAME is in the form of "APPNAME:", list all variable lines in "appname.env"
         APPNAME=${APPNAME%%:*}
         VAR_FILE="$(run_script 'app_env_file' "${APPNAME}")"

--- a/.scripts/appvars_migrate.sh
+++ b/.scripts/appvars_migrate.sh
@@ -3,9 +3,8 @@ set -Eeuo pipefail
 IFS=$'\n\t'
 
 appvars_migrate() {
-    local APPNAME=${1-}
-    APPNAME=${APPNAME^^}
-    local appname=${APPNAME,,}
+    local -u APPNAME=${1-}
+    local -l appname=${APPNAME}
 
     local MIGRATE_FILE
     MIGRATE_FILE="$(run_script 'app_instance_file' "${appname}" "*.migrate")"

--- a/.scripts/disable_app.sh
+++ b/.scripts/disable_app.sh
@@ -6,15 +6,17 @@ disable_app() {
     # Disable the list of apps given.  Apps will be seperate arguments and/or seperated by spaces
     local AppList
     AppList="$(xargs -n 1 <<< "$*")"
-    for AppName in ${AppList}; do
-        if run_script 'app_is_builtin' "${AppName}"; then
-            EnabledVar="${AppName^^}__ENABLED"
-            info "Disabling application '${C["App"]}${AppName^^}${NC}'"
+    for APPNAME in ${AppList^^}; do
+        local AppName
+        AppName="$(run_script app_nicename "${APPNAME}")"
+        if run_script 'app_is_builtin' "${APPNAME}"; then
+            EnabledVar="${APPNAME}__ENABLED"
+            info "Disabling application '${C["App"]}${AppName}${NC}'"
             notice "Setting variable in ${C["File"]}${COMPOSE_ENV}${NC}:"
             notice "   ${C["Var"]}${EnabledVar}='false'${NC}"
             run_script 'env_set' "${EnabledVar}" false
         else
-            warn "Application '${C["App"]}${AppName^^}${NC}' does not exist."
+            warn "Application '${C["App"]}${AppName}${NC}' does not exist."
         fi
     done
 }

--- a/.scripts/enable_app.sh
+++ b/.scripts/enable_app.sh
@@ -6,15 +6,17 @@ enable_app() {
     # Enable the list of apps given.  Apps will be seperate arguments and/or seperated by spaces
     local AppList
     AppList="$(xargs -n 1 <<< "$*")"
-    for AppName in ${AppList}; do
-        if run_script 'app_is_builtin' "${AppName}"; then
-            EnabledVar="${AppName^^}__ENABLED"
-            info "Enabling application '${C["App"]}${AppName^^}${NC}'"
+    for APPNAME in ${AppList^^}; do
+        local AppName
+        AppName="$(run_script app_nicename "${APPNAME}")"
+        if run_script 'app_is_builtin' "${APPNAME}"; then
+            EnabledVar="${APPNAME}__ENABLED"
+            info "Enabling application '${C["App"]}${AppName}${NC}'"
             notice "Setting variable in ${C["File"]}${COMPOSE_ENV}${NC}:"
             notice "   ${C["Var"]}${EnabledVar}='true'${NC}"
             run_script 'env_set' "${EnabledVar}" true
         else
-            warn "Application '${C["App"]}${AppName^^}${NC}' does not exist."
+            warn "Application '${C["App"]}${AppName}${NC}' does not exist."
         fi
     done
 }

--- a/.scripts/env_list_app_env_defaults.sh
+++ b/.scripts/env_list_app_env_defaults.sh
@@ -3,8 +3,7 @@ set -Eeuo pipefail
 IFS=$'\n\t'
 
 env_list_app_env_defaults() {
-    local APPNAME=${1-}
-    local appname=${APPNAME,,}
+    local -l appname=${1-}
     run_script 'env_var_list' "$(run_script 'app_instance_file' "${appname}" ".env.app.*")"
 }
 

--- a/.scripts/env_list_app_global_defaults.sh
+++ b/.scripts/env_list_app_global_defaults.sh
@@ -3,8 +3,7 @@ set -Eeuo pipefail
 IFS=$'\n\t'
 
 env_list_app_global_defaults() {
-    local APPNAME=${1-}
-    local appname=${APPNAME,,}
+    local -l appname=${1-}
     run_script 'env_var_list' "$(run_script 'app_instance_file' "${appname}" ".env")"
 }
 

--- a/.scripts/yml_merge.sh
+++ b/.scripts/yml_merge.sh
@@ -17,7 +17,7 @@ commands_yml_merge() {
     local ENABLED_APPS
     ENABLED_APPS="$(run_script 'app_list_enabled')"
     for APPNAME in ${ENABLED_APPS-}; do
-        local appname=${APPNAME,,}
+        local -l appname=${APPNAME}
         local AppName
         AppName="$(run_script 'app_nicename' "${APPNAME}")"
         local APP_FOLDER


### PR DESCRIPTION
…to switch case

# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Standardize case normalization in shell scripts by leveraging bash's local -l/-u variable attributes instead of manual parameter expansions, and update patterns and usages to align with the new approach.

Enhancements:
- Replace manual ${var,,}/${var^^} conversions with local -l/-u declarations across multiple .scripts functions
- Update regex patterns and conditional checks to operate on the normalized case values