### PR TITLE
Change from using `PROCESS_*` vars to `PROCESSED_*` vars to check if …

### DIFF
--- a/.scripts/appvars_create_all.sh
+++ b/.scripts/appvars_create_all.sh
@@ -3,7 +3,7 @@ set -Eeuo pipefail
 IFS=$'\n\t'
 
 appvars_create_all() {
-    if [[ -z ${PROCESS_APPVARS_CREATE_ALL} ]]; then
+    if [[ -n ${PROCESSSED_APPVARS_CREATE_ALL-} ]]; then
         # Application variables have already been created, nothing to do
         return
     fi
@@ -18,7 +18,7 @@ appvars_create_all() {
         notice "'${C["File"]}${COMPOSE_ENV}${NC}' does not contain any added apps."
     fi
     run_script 'env_update'
-    declare -gx PROCESS_APPVARS_CREATE_ALL=''
+    declare -gx PROCESSED_APPVARS_CREATE_ALL=1
 }
 
 test_appvars_create_all() {

--- a/.scripts/appvars_purge.sh
+++ b/.scripts/appvars_purge.sh
@@ -92,9 +92,9 @@ appvars_purge() {
                 sed -i -E "/^\s*(${AppEnvVarsRegex})\s*=/d" "${AppEnvFile}" ||
                     fatal "Failed to purge '${C["App"]}${AppName}${NC}' variables.\nFailing command: ${C["FailingCommand"]}sed -i -E \"/^\\\*(${AppEnvVarsRegex})\\\*/d\" \"${AppEnvFile}\""
             fi
-            declare -gx PROCESS_APPVARS_CREATE_ALL=1
-            declare -gx PROCESS_ENV_UPDATE=1
-            declare -gx PROCESS_YML_MERGE=1
+            unset PROCESSED_APPVARS_CREATE_ALL
+            unset PROCESSED_ENV_UPDATE
+            unset PROCESSED_YML_MERGE
         else
             info "Keeping '${C["App"]}${AppName}${NC}' variables."
         fi

--- a/.scripts/env_copy.sh
+++ b/.scripts/env_copy.sh
@@ -44,9 +44,9 @@ env_copy() {
     fi
     printf '\n%s\n' "${NEW_VAR_LINE}" >> "${TO_VAR_FILE}" ||
         fatal "Failed to add '${C["Var"]}${NEW_VAR_LINE}${NC}' in '${C["File"]}${TO_VAR_FILE}${NC}'\nFailing command: ${C["FailingCommand"]}printf '\n%s\n' \"${NEW_VAR_LINE}\" >> \"${TO_VAR_FILE}\""
-    declare -gx PROCESS_APPVARS_CREATE_ALL=1
-    declare -gx PROCESS_ENV_UPDATE=1
-    declare -gx PROCESS_YML_MERGE=1
+    unset PROCESSED_APPVARS_CREATE_ALL
+    unset PROCESSED_ENV_UPDATE
+    unset PROCESSED_YML_MERGE
 }
 
 test_env_copy() {

--- a/.scripts/env_merge_newonly.sh
+++ b/.scripts/env_merge_newonly.sh
@@ -31,9 +31,9 @@ env_merge_newonly() {
                     unset 'MergeFromLines[$index]' 2> /dev/null
                 fi
             done
-            declare -gx PROCESS_APPVARS_CREATE_ALL=1
-            declare -gx PROCESS_ENV_UPDATE=1
-            declare -gx PROCESS_YML_MERGE=1
+            unset PROCESSED_APPVARS_CREATE_ALL
+            unset PROCESSED_ENV_UPDATE
+            unset PROCESSED_YML_MERGE
         fi
         if [[ ${#MergeFromLines[@]} != 0 ]]; then
             notice "Adding variables to ${C["File"]}${MergeToFile}${NC}:"
@@ -44,9 +44,9 @@ env_merge_newonly() {
                 env -i line="${line}" MergeToFile="${MergeToFile}" \
                     printf '%s\n' "${line}" >> "${MergeToFile}" 2> /dev/null || fatal "Failed to add variable to '${C["File"]}${MergeToFile}${NC}'\nFailing command: ${C["FailingCommand"]}printf '%s\n' \"${line}\" >> \"${MergeToFile}\""
             done
-            declare -gx PROCESS_APPVARS_CREATE_ALL=1
-            declare -gx PROCESS_ENV_UPDATE=1
-            declare -gx PROCESS_YML_MERGE=1
+            unset PROCESSED_APPVARS_CREATE_ALL
+            unset PROCESSED_ENV_UPDATE
+            unset PROCESSED_YML_MERGE
         fi
     fi
 }

--- a/.scripts/env_set.sh
+++ b/.scripts/env_set.sh
@@ -33,9 +33,9 @@ env_set() {
     fi
     sed -i "/^\s*${SET_VAR}\s*=/d" "${VAR_FILE}" || true
     echo "${SET_VAR}=${NEW_VAL}" >> "${VAR_FILE}" || fatal "Failed to set ${C["Var"]}${SET_VAR}=${NEW_VAL}${NC}\nFailing command: ${C["FailingCommand"]} echo \"${SET_VAR}=${NEW_VAL}\" >> \"${VAR_FILE}\""
-    declare -gx PROCESS_APPVARS_CREATE_ALL=1
-    declare -gx PROCESS_ENV_UPDATE=1
-    declare -gx PROCESS_YML_MERGE=1
+    unset PROCESSED_APPVARS_CREATE_ALL
+    unset PROCESSED_ENV_UPDATE
+    unset PROCESSED_YML_MERGE
 }
 
 test_env_set() {

--- a/.scripts/env_set_literal.sh
+++ b/.scripts/env_set_literal.sh
@@ -29,9 +29,9 @@ env_set_literal() {
     fi
     sed -i "/^\s*${SET_VAR}\s*=/d" "${VAR_FILE}" || true
     echo "${SET_VAR}=${NEW_VAL}" >> "${VAR_FILE}" || fatal "Failed to set ${C["Var"]}${SET_VAR}=${NEW_VAL}${NC}\nFailing command: ${C["FailingCommand"]} echo \"${SET_VAR}=${NEW_VAL}\" >> \"${VAR_FILE}\""
-    declare -gx PROCESS_APPVARS_CREATE_ALL=1
-    declare -gx PROCESS_ENV_UPDATE=1
-    declare -gx PROCESS_YML_MERGE=1
+    unset PROCESSED_APPVARS_CREATE_ALL
+    unset PROCESSED_ENV_UPDATE
+    unset PROCESSED_YML_MERGE
 }
 
 test_env_set_literal() {

--- a/.scripts/env_update.sh
+++ b/.scripts/env_update.sh
@@ -3,7 +3,7 @@ set -Eeuo pipefail
 IFS=$'\n\t'
 
 env_update() {
-    if [[ -z ${PROCESS_ENV_UPDATE} ]]; then
+    if [[ -n ${PROCESSED_ENV_UPDATE-} ]]; then
         # Env files have already been updated, nothing to do
         return
     fi
@@ -71,7 +71,7 @@ env_update() {
 
     #run_script 'env_sanitize'
     info "Environment file update complete."
-    declare -gx PROCESS_ENV_UPDATE=''
+    declare -gx PROCESSED_ENV_UPDATE=1
 }
 
 test_env_update() {

--- a/.scripts/menu_config.sh
+++ b/.scripts/menu_config.sh
@@ -9,7 +9,7 @@ menu_config() {
 
     local Title="Configuration Menu"
 
-    if [[ -n ${PROCESS_APPVARS_CREATE_ALL} ]]; then
+    if [[ -z ${PROCESSED_APPVARS_CREATE_ALL-} ]]; then
         coproc {
             dialog_pipe "${DC[TitleSuccess]}Creating environment variables for added apps" "Please be patient, this can take a while.\n${DC[CommandLine]} ${APPLICATION_COMMAND} --env" "${DIALOGTIMEOUT}"
         }

--- a/.scripts/update_self.sh
+++ b/.scripts/update_self.sh
@@ -78,9 +78,9 @@ update_self() {
         return 1
     fi
 
-    declare -gx PROCESS_APPVARS_CREATE_ALL=1
-    declare -gx PROCESS_ENV_UPDATE=1
-    declare -gx PROCESS_YML_MERGE=1
+    unset PROCESSED_APPVARS_CREATE_ALL
+    unset PROCESSED_ENV_UPDATE
+    unset PROCESSED_YML_MERGE
 
     if use_dialog_box; then
         commands_update_self "${BRANCH}" "${YesNotice}" "$@" |&

--- a/.scripts/yml_merge.sh
+++ b/.scripts/yml_merge.sh
@@ -7,7 +7,7 @@ yml_merge() {
 }
 
 commands_yml_merge() {
-    if [[ -z ${PROCESS_YML_MERGE} && -f ${COMPOSE_FOLDER}/docker-compose.yml ]]; then
+    if [[ -n ${PROCESSED_YML_MERGE-} && -f ${COMPOSE_FOLDER}/docker-compose.yml ]]; then
         # Compose file has already been created, nothing to do
         return 0
     fi
@@ -124,7 +124,7 @@ commands_yml_merge() {
         return ${result}
     fi
     info "Merging '${C["File"]}docker-compose.yml${NC}' complete."
-    declare -gx PROCESS_YML_MERGE=''
+    declare -gx PROCESSED_YML_MERGE=1
     return 0
 }
 test_yml_merge() {

--- a/main.sh
+++ b/main.sh
@@ -11,9 +11,6 @@ declare -rx TARGET_BRANCH='main'
 export LC_ALL=C
 export PROMPT="CLI"
 export MENU=false
-declare -x PROCESS_APPVARS_CREATE_ALL=1
-declare -x PROCESS_ENV_UPDATE=1
-declare -x PROCESS_YML_MERGE=1
 
 # Script Information
 # https://stackoverflow.com/questions/59895/get-the-source-directory-of-a-bash-script-from-within-the-script-itself/246128#246128


### PR DESCRIPTION
…actions need to be done

# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Standardize processing state tracking by renaming and handling the PROCESS_* flags as PROCESSED_* across all related scripts.

Enhancements:
- Replace PROCESS_* environment flags with PROCESSED_* equivalents across shell scripts
- Update guard conditions to use PROCESSED_* variables before executing environment, appvars, and YAML merge actions
- Unset PROCESSED_* flags after each action to reset the processing state for subsequent runs
- Remove legacy PROCESS_* declarations from the main script entrypoint