### PR TITLE
Strip dialog color codes from warning in `appvars_purge`

### DIFF
--- a/.scripts/appvars_purge.sh
+++ b/.scripts/appvars_purge.sh
@@ -49,11 +49,13 @@ appvars_purge() {
 
         if [[ -z ${GlobalVarsToRemove[*]-} && -z ${AppEnvVarsToRemove[*]-} ]]; then
             local WarningText="'${DC["Highlight"]}${C["App"]}${APPNAME}${NC}${DC[NC]}' has no variables to remove."
+            local WarningTextNotice
+            WarningTextNotice="$(strip_dialog_colors "${WarningText}")"
             if use_dialog_box; then
                 dialog_warning "{Title}" "${WarningText}"
-                warn "${WarningText}" &> /dev/null
+                warn "${WarningTextNotice}" &> /dev/null
             else
-                warn "${WarningText}"
+                warn "${WarningTextNotice}"
             fi
             continue
         fi


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Bug Fixes:
- Strip dialog color codes from the warning text before passing it to warn to produce clean, unformatted log output