### PR TITLE
Skip tasks that have already been done.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ compose/.instances/
 # Environment files directory - created by .scripts/env_setup.sh for storing environment configurations
 compose/env_files/
 
+# Timestamp files directory - for storing timestamps of the user's override and environment files
+compose/.timestamps/
+
 # Docker Compose environment variables file - created by main.sh and referenced in .scripts/compose_setup.sh
 compose/.env
 

--- a/.scripts/appvars_create.sh
+++ b/.scripts/appvars_create.sh
@@ -9,11 +9,17 @@ appvars_create() {
         local -l appname=${APPNAME}
         local AppName
         AppName="$(run_script 'app_nicename' "${APPNAME}")"
-
         if ! run_script 'appname_is_valid' "${appname}"; then
             error "'${C["App"]}${AppName}${NC}' is not a valid application name."
             continue
         fi
+
+        if ! run_script 'needs_appvars_create' "${appname}"; then
+            # Variables for app have already been created, nothing to do
+            notice "Environment variables already created for '${C["App"]}${AppName}${NC}'"
+            continue
+        fi
+
         if run_script 'app_is_builtin' "${AppName}"; then
             local AppDefaultGlobalEnvFile AppDefaultAppEnvFile AppEnvFile
             AppDefaultGlobalEnvFile="$(run_script 'app_instance_file' "${appname}" ".env")"
@@ -35,6 +41,7 @@ appvars_create() {
         else
             warn "Application '${C["App"]}${AppName}${NC}' does not exist."
         fi
+        run_script 'unset_needs_appvars_create' "${appname}"
     done
 }
 

--- a/.scripts/appvars_create_all.sh
+++ b/.scripts/appvars_create_all.sh
@@ -3,8 +3,9 @@ set -Eeuo pipefail
 IFS=$'\n\t'
 
 appvars_create_all() {
-    if [[ -n ${PROCESSED_APPVARS_CREATE_ALL-} ]]; then
+    if ! run_script 'needs_appvars_create'; then
         # Application variables have already been created, nothing to do
+        notice "Environment variables already created for all added apps."
         return
     fi
     run_script 'env_create'
@@ -18,7 +19,7 @@ appvars_create_all() {
         notice "'${C["File"]}${COMPOSE_ENV}${NC}' does not contain any added apps."
     fi
     run_script 'env_update'
-    declare -gx PROCESSED_APPVARS_CREATE_ALL=1
+    run_script 'unset_needs_appvars_create'
 }
 
 test_appvars_create_all() {

--- a/.scripts/appvars_list.sh
+++ b/.scripts/appvars_list.sh
@@ -3,7 +3,7 @@ set -Eeuo pipefail
 IFS=$'\n\t'
 
 appvars_list() {
-    local APPNAME=${1-}
+    local -u APPNAME=${1-}
     if [[ ${APPNAME} == *":" ]]; then
         # APPNAME is in the form of "APPNAME:", list all variable in ".env.app.appname"
         APPNAME=${APPNAME%%:*}

--- a/.scripts/docker_compose.sh
+++ b/.scripts/docker_compose.sh
@@ -18,9 +18,9 @@ docker_compose() {
     local -a ComposeCommand
     case ${Command} in
         merge | generate)
-            Question="Merge enabled app templates to docker-compose.yml?"
-            NoNotice="Not merging enabled app templates to docker-compose.yml."
-            YesNotice="Merging enabled app templates to docker-compose.yml."
+            Question="Merge enabled app templates to '${C["File"]}docker-compose.yml${NC}'?"
+            NoNotice="Not merging enabled app templates to '${C["File"]}docker-compose.yml${NC}'."
+            YesNotice="Merging enabled app templates to '${C["File"]}docker-compose.yml${NC}'."
             ;;
         down)
             if [[ -n ${AppName-} ]]; then

--- a/.scripts/env_copy.sh
+++ b/.scripts/env_copy.sh
@@ -44,9 +44,6 @@ env_copy() {
     fi
     printf '\n%s\n' "${NEW_VAR_LINE}" >> "${TO_VAR_FILE}" ||
         fatal "Failed to add '${C["Var"]}${NEW_VAR_LINE}${NC}' in '${C["File"]}${TO_VAR_FILE}${NC}'\nFailing command: ${C["FailingCommand"]}printf '\n%s\n' \"${NEW_VAR_LINE}\" >> \"${TO_VAR_FILE}\""
-    unset PROCESSED_APPVARS_CREATE_ALL
-    unset PROCESSED_ENV_UPDATE
-    unset PROCESSED_YML_MERGE
 }
 
 test_env_copy() {

--- a/.scripts/env_delete.sh
+++ b/.scripts/env_delete.sh
@@ -8,9 +8,9 @@ env_delete() {
 
     if [[ ${DELETE_VAR} =~ ^[A-Za-z0-9_]+: ]]; then
         # SET_VAR is in the form of "APPNAME:VARIABLE", set new file to use
-        local APPNAME=${DELETE_VAR%%:*}
-        VAR_FILE="$(run_script 'app_env_file' "${APPNAME}")"
-        DELETE_VAR=${DELETE_VAR#"${APPNAME}:"}
+        local AppName=${DELETE_VAR%%:*}
+        VAR_FILE="$(run_script 'app_env_file' "${AppName}")"
+        DELETE_VAR=${DELETE_VAR#"${AppName}:"}
     fi
     if [[ ! -f ${VAR_FILE} ]]; then
         # Variable file does not exist, warn and return

--- a/.scripts/env_merge_newonly.sh
+++ b/.scripts/env_merge_newonly.sh
@@ -31,9 +31,6 @@ env_merge_newonly() {
                     unset 'MergeFromLines[$index]' 2> /dev/null
                 fi
             done
-            unset PROCESSED_APPVARS_CREATE_ALL
-            unset PROCESSED_ENV_UPDATE
-            unset PROCESSED_YML_MERGE
         fi
         if [[ ${#MergeFromLines[@]} != 0 ]]; then
             notice "Adding variables to ${C["File"]}${MergeToFile}${NC}:"
@@ -44,9 +41,6 @@ env_merge_newonly() {
                 env -i line="${line}" MergeToFile="${MergeToFile}" \
                     printf '%s\n' "${line}" >> "${MergeToFile}" 2> /dev/null || fatal "Failed to add variable to '${C["File"]}${MergeToFile}${NC}'\nFailing command: ${C["FailingCommand"]}printf '%s\n' \"${line}\" >> \"${MergeToFile}\""
             done
-            unset PROCESSED_APPVARS_CREATE_ALL
-            unset PROCESSED_ENV_UPDATE
-            unset PROCESSED_YML_MERGE
         fi
     fi
 }

--- a/.scripts/env_rename.sh
+++ b/.scripts/env_rename.sh
@@ -46,9 +46,6 @@ env_rename() {
         fatal "Failed to add '${C["Var"]}${NEW_VAR_LINE}${NC}' in '${C["File"]}${TO_VAR_FILE}${NC}'\nFailing command: ${C["FailingCommand"]}printf '\n%s\n' \"${NEW_VAR_LINE}\" >> \"${TO_VAR_FILE}\""
     sed -i "/^\s*${FROM_VAR}\s*=/d" "${FROM_VAR_FILE}" ||
         fatal "Failed to remove var '${C["Var"]}${FROM_VAR}${NC}' in '${C["File"]}${FROM_VAR_FILE}${NC}'\nFailing command: ${C["FailingCommand"]}sed -i \"/^\\s*${FROM_VAR}\\s*=/d\" \"${FROM_VAR_FILE}\""
-    unset PROCESSED_APPVARS_CREATE_ALL
-    unset PROCESSED_ENV_UPDATE
-    unset PROCESSED_YML_MERGE
 }
 
 test_env_rename() {

--- a/.scripts/env_set.sh
+++ b/.scripts/env_set.sh
@@ -33,9 +33,6 @@ env_set() {
     fi
     sed -i "/^\s*${SET_VAR}\s*=/d" "${VAR_FILE}" || true
     echo "${SET_VAR}=${NEW_VAL}" >> "${VAR_FILE}" || fatal "Failed to set ${C["Var"]}${SET_VAR}=${NEW_VAL}${NC}\nFailing command: ${C["FailingCommand"]} echo \"${SET_VAR}=${NEW_VAL}\" >> \"${VAR_FILE}\""
-    unset PROCESSED_APPVARS_CREATE_ALL
-    unset PROCESSED_ENV_UPDATE
-    unset PROCESSED_YML_MERGE
 }
 
 test_env_set() {

--- a/.scripts/env_set_literal.sh
+++ b/.scripts/env_set_literal.sh
@@ -29,9 +29,6 @@ env_set_literal() {
     fi
     sed -i "/^\s*${SET_VAR}\s*=/d" "${VAR_FILE}" || true
     echo "${SET_VAR}=${NEW_VAL}" >> "${VAR_FILE}" || fatal "Failed to set ${C["Var"]}${SET_VAR}=${NEW_VAL}${NC}\nFailing command: ${C["FailingCommand"]} echo \"${SET_VAR}=${NEW_VAL}\" >> \"${VAR_FILE}\""
-    unset PROCESSED_APPVARS_CREATE_ALL
-    unset PROCESSED_ENV_UPDATE
-    unset PROCESSED_YML_MERGE
 }
 
 test_env_set_literal() {

--- a/.scripts/env_update.sh
+++ b/.scripts/env_update.sh
@@ -3,55 +3,68 @@ set -Eeuo pipefail
 IFS=$'\n\t'
 
 env_update() {
-    if [[ -n ${PROCESSED_ENV_UPDATE-} ]]; then
-        # Env files have already been updated, nothing to do
-        return
-    fi
-    local ENV_LINES_FILE
-    ENV_LINES_FILE=$(mktemp -t "${APPLICATION_NAME}.${FUNCNAME[0]}.ENV_LINES_FILE.XXXXXXXXXX")
-    run_script 'appvars_lines' "" > "${ENV_LINES_FILE}"
+    #if ! run_script 'needs_env_update'; then
+    #    # Env files have already been updated, nothing to do
+    #    notice "Environment variable files already updated."
+    #    return
+    #fi
+    notice "Updating environment variable files."
 
-    local -a UPDATED_ENV_LINES=()
-    readarray -t UPDATED_ENV_LINES < <(
-        run_script 'env_format_lines' "${ENV_LINES_FILE}" "${COMPOSE_ENV_DEFAULT_FILE}" ""
-    )
+    local -l applist
+    applist="$(run_script 'app_list_referenced')"
 
-    AppList="$(run_script 'app_list_referenced')"
     # Format the global .env file
-    for appname in ${AppList,,}; do
-        local APP_DEFAULT_GLOBAL_ENV_FILE=""
-        local -a UPDATED_APP_ENV_LINES=()
-        if ! run_script 'app_is_user_defined' "${appname}"; then
-            APP_DEFAULT_GLOBAL_ENV_FILE="$(run_script 'app_instance_file' "${appname}" ".env")"
-        fi
-        run_script 'appvars_lines' "${appname}" > "${ENV_LINES_FILE}"
-        readarray -t -O ${#UPDATED_ENV_LINES[@]} UPDATED_ENV_LINES < <(
-            run_script 'env_format_lines' "${ENV_LINES_FILE}" "${APP_DEFAULT_GLOBAL_ENV_FILE}" "${appname}"
+    if ! run_script 'needs_env_update' "${COMPOSE_ENV}"; then
+        info "'${C["File"]}${COMPOSE_ENV}'${NC} already updated."
+    else
+        notice "Updating '${C["File"]}${COMPOSE_ENV}${NC}'."
+        local ENV_LINES_FILE
+        ENV_LINES_FILE=$(mktemp -t "${APPLICATION_NAME}.${FUNCNAME[0]}.ENV_LINES_FILE.XXXXXXXXXX")
+        run_script 'appvars_lines' "" > "${ENV_LINES_FILE}"
+
+        local -a UPDATED_ENV_LINES=()
+        readarray -t UPDATED_ENV_LINES < <(
+            run_script 'env_format_lines' "${ENV_LINES_FILE}" "${COMPOSE_ENV_DEFAULT_FILE}" ""
         )
-    done
-    rm -f "${ENV_LINES_FILE}" ||
-        warn "Failed to remove temporary '${C["File"]}.env${NC}' update file.\nFailing command: ${C["FailingCommand"]}rm -f \"${ENV_LINES_FILE}\""
 
-    local MKTEMP_ENV_UPDATED
-    MKTEMP_ENV_UPDATED=$(mktemp -t "${APPLICATION_NAME}.${FUNCNAME[0]}.MKTEMP_ENV_UPDATED.XXXXXXXXXX") ||
-        fatal "Failed to create temporary update '${C["File"]}.env${NC}' file.\nFailing command: ${C["FailingCommand"]}mktemp -t \"${APPLICATION_NAME}.${FUNCNAME[0]}.MKTEMP_ENV_UPDATED.XXXXXXXXXX\""
-    printf '%s\n' "${UPDATED_ENV_LINES[@]}" > "${MKTEMP_ENV_UPDATED}" || fatal "Failed to write temporary '${C["File"]}.env${NC}' update file."
-    cp -f "${MKTEMP_ENV_UPDATED}" "${COMPOSE_ENV}" ||
-        fatal "Failed to copy file.\nFailing command: ${C["FailingCommand"]}cp -f \"${MKTEMP_ENV_UPDATED}\" \"${COMPOSE_ENV}\""
-    rm -f "${MKTEMP_ENV_UPDATED}" ||
-        warn "Failed to remove temporary ${C["File"]}.env${NC} update file.\nFailing command: ${C["FailingCommand"]}rm -f \"${MKTEMP_ENV_UPDATED}\""
-    run_script 'set_permissions' "${COMPOSE_ENV}"
+        for appname in ${applist}; do
+            local APP_DEFAULT_GLOBAL_ENV_FILE=""
+            local -a UPDATED_APP_ENV_LINES=()
+            if ! run_script 'app_is_user_defined' "${appname}"; then
+                APP_DEFAULT_GLOBAL_ENV_FILE="$(run_script 'app_instance_file' "${appname}" ".env")"
+            fi
+            run_script 'appvars_lines' "${appname}" > "${ENV_LINES_FILE}"
+            readarray -t -O ${#UPDATED_ENV_LINES[@]} UPDATED_ENV_LINES < <(
+                run_script 'env_format_lines' "${ENV_LINES_FILE}" "${APP_DEFAULT_GLOBAL_ENV_FILE}" "${appname}"
+            )
+        done
+        rm -f "${ENV_LINES_FILE}" ||
+            warn "Failed to remove temporary '${C["File"]}.env${NC}' update file.\nFailing command: ${C["FailingCommand"]}rm -f \"${ENV_LINES_FILE}\""
 
-    # Process all referenced appname.env files
-    for appname in ${AppList,,}; do
+        local MKTEMP_ENV_UPDATED
+        MKTEMP_ENV_UPDATED=$(mktemp -t "${APPLICATION_NAME}.${FUNCNAME[0]}.MKTEMP_ENV_UPDATED.XXXXXXXXXX") ||
+            fatal "Failed to create temporary update '${C["File"]}.env${NC}' file.\nFailing command: ${C["FailingCommand"]}mktemp -t \"${APPLICATION_NAME}.${FUNCNAME[0]}.MKTEMP_ENV_UPDATED.XXXXXXXXXX\""
+        printf '%s\n' "${UPDATED_ENV_LINES[@]}" > "${MKTEMP_ENV_UPDATED}" || fatal "Failed to write temporary '${C["File"]}.env${NC}' update file."
+        cp -f "${MKTEMP_ENV_UPDATED}" "${COMPOSE_ENV}" ||
+            fatal "Failed to copy file.\nFailing command: ${C["FailingCommand"]}cp -f \"${MKTEMP_ENV_UPDATED}\" \"${COMPOSE_ENV}\""
+        rm -f "${MKTEMP_ENV_UPDATED}" ||
+            warn "Failed to remove temporary ${C["File"]}.env${NC} update file.\nFailing command: ${C["FailingCommand"]}rm -f \"${MKTEMP_ENV_UPDATED}\""
+        run_script 'set_permissions' "${COMPOSE_ENV}"
+        #run_script 'unset_needs_env_update' "${COMPOSE_ENV}"
+    fi
+
+    # Process all referenced .env.app.appname files
+    for appname in ${applist}; do
         local APP_ENV_FILE
         APP_ENV_FILE="$(run_script 'app_env_file' "${appname}")"
-        local APP_DEFAULT_ENV_FILE=""
-        if ! run_script 'app_is_user_defined' "${appname}"; then
-            APP_DEFAULT_ENV_FILE="$(run_script 'app_instance_file' "${appname}" ".env.app.*")"
-        fi
-        if [[ -n ${APP_DEFAULT_ENV_FILE} || -f ${APP_ENV_FILE} ]]; then
-            # App is either added, or the user has an existing appname.env file
+        if ! run_script 'needs_env_update' "${APP_ENV_FILE}"; then
+            info "'${C["File"]}${APP_ENV_FILE}'${NC} already updated."
+        else
+            notice "Updating '${C["File"]}${APP_ENV_FILE}${NC}'."
+            local APP_DEFAULT_ENV_FILE=""
+            if ! run_script 'app_is_user_defined' "${appname}"; then
+                APP_DEFAULT_ENV_FILE="$(run_script 'app_instance_file' "${appname}" ".env.app.*")"
+            fi
             local -a UPDATED_APP_ENV_LINES=()
             readarray -t UPDATED_APP_ENV_LINES < <(
                 run_script 'env_format_lines' "${APP_ENV_FILE}" "${APP_DEFAULT_ENV_FILE}" "${appname}"
@@ -64,14 +77,15 @@ env_update() {
             cp -f "${MKTEMP_APP_ENV_UPDATED}" "${APP_ENV_FILE}" ||
                 fatal "Failed to copy file.\nFailing command: ${C["FailingCommand"]}cp -f \"${MKTEMP_APP_ENV_UPDATED}\" \"${APP_ENV_FILE}\""
             rm -f "${MKTEMP_APP_ENV_UPDATED}" ||
-                warn "Failed to remove temporary ${C["File"]}${appname}.env${NC} update file.\nFailing command: ${C["FailingCommand"]}rm -f \"${MKTEMP_APP_ENV_UPDATED}\""
+                warn "Failed to remove temporary '${C["File"]}.env.app.${appname}${NC}' update file.\nFailing command: ${C["FailingCommand"]}rm -f \"${MKTEMP_APP_ENV_UPDATED}\""
             run_script 'set_permissions' "${APP_ENV_FILE}"
+            #run_script 'unset_needs_env_update' "${APP_ENV_FILE}"
         fi
     done
 
     #run_script 'env_sanitize'
-    info "Environment file update complete."
-    declare -gx PROCESSED_ENV_UPDATE=1
+    run_script 'unset_needs_env_update'
+    info "Environment variable files update complete."
 }
 
 test_env_update() {

--- a/.scripts/menu_config.sh
+++ b/.scripts/menu_config.sh
@@ -9,7 +9,7 @@ menu_config() {
 
     local Title="Configuration Menu"
 
-    if [[ -z ${PROCESSED_APPVARS_CREATE_ALL-} ]]; then
+    if run_script 'needs_appvars_create'; then
         coproc {
             dialog_pipe "${DC[TitleSuccess]}Creating environment variables for added apps" "Please be patient, this can take a while.\n${DC[CommandLine]} ${APPLICATION_COMMAND} --env" "${DIALOGTIMEOUT}"
         }

--- a/.scripts/needs_appvars_create.sh
+++ b/.scripts/needs_appvars_create.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+declare Prefix="appvars_create_"
+
+# shellcheck disable=SC2317  # Don't warn about unreachable commands in this function
+needs_appvars_create() {
+    return 0
+
+    if [[ $# -eq 0 ]]; then
+        local -a AppList
+        readarray -t AppList < <(run_script 'app_list_added')
+        if [[ -z ${AppList[*]-} ]]; then
+            file_changed "${COMPOSE_ENV}"
+            return
+        fi
+        run_script 'needs_appvars_create' "${AppList[@]}"
+        return
+    fi
+
+    for AppName in "$@"; do
+        local -u APPNAME=${AppName^^}
+        if [[ -n ${APPNAME} ]]; then
+            if file_changed "$(run_script 'app_env_file' "${APPNAME}")"; then
+                # .env.app.env file has changed, return true
+                return 0
+            fi
+            if ! file_changed "${COMPOSE_ENV}"; then
+                # .env file has not changed, return false
+                continue
+            fi
+            if ! run_script 'env_var_exists' "${APPNAME^^}__ENABLED"; then
+                # No "enabled" variable for the app, return true
+                return 0
+            fi
+        fi
+    done
+    return 1
+}
+
+file_changed() {
+    local file=${1-}
+    local timestamp_file
+    timestamp_file="${TIMESTAMPS_FOLDER:?}/${Prefix}$(basename "${file}")"
+    if [[ ! -f ${file} || ! -f ${timestamp_file} ]]; then
+        return 0
+    fi
+    [[ $(stat -c %Y "${file}") != $(stat -c %Y "${timestamp_file}") ]]
+}
+
+test_needs_appvars_create() {
+    warn "CI does not test needs_appvars_create."
+}

--- a/.scripts/needs_env_update.sh
+++ b/.scripts/needs_env_update.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+declare Prefix="env_update_"
+
+needs_env_update() {
+    local VarFile=${1-}
+
+    # Checking if we need to update .env
+    if [[ ${VarFile} == "${COMPOSE_ENV}" ]]; then
+        local filename
+        filename="$(basename "${VarFile}")"
+        local ReferencedAppsFile
+        ReferencedAppsFile="$(timestamp_file "${filename}_ReferencedApps")"
+        if file_changed "${VarFile}"; then
+            return 0
+        fi
+        if [[ ! -f ${ReferencedAppsFile} ]] || ! cmp -s "${ReferencedAppsFile}" <(run_script 'app_list_referenced'); then
+            return 0
+        fi
+        return 1
+    fi
+
+    # Checking if we need to update .env.app.appname
+    if file_changed "${VarFile}"; then
+        return 0
+    fi
+    local filename
+    filename="$(basename "${VarFile}")"
+    if file_changed "${COMPOSE_ENV}" "${filename}_$(basename "${COMPOSE_ENV}")"; then
+        local -u APPNAME
+        APPNAME="$(run_script 'varfile_to_appname' "${VarFile}")"
+        local AppEnabledFile
+        AppEnabledFile="$(timestamp_file "${filename}_${APPNAME}__ENABLED")"
+        if ! cmp -s "${AppEnabledFile}" <(run_script 'env_get_line' "${APPNAME}__ENABLED"); then
+            return 0
+        fi
+    fi
+    return 1
+}
+
+timestamp_file() {
+    printf "${TIMESTAMPS_FOLDER:?}/${Prefix}%s\n" "$1"
+}
+
+file_changed() {
+    local file1=${1-}
+    local file2=${2-}
+    if [[ -z ${file2-} ]]; then
+        file2="$(basename "${file1}")"
+    fi
+    file2="$(timestamp_file "${file2}")"
+    if [[ ! -f ${file1} || ! -f ${file2} ]]; then
+        return 0
+    fi
+    [[ $(stat -c %Y "${file1}") != $(stat -c %Y "${file2}") ]]
+}
+
+test_needs_env_update() {
+    warn "CI does not test needs_env_update."
+}

--- a/.scripts/needs_yml_merge.sh
+++ b/.scripts/needs_yml_merge.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+declare Prefix="yml_merge_"
+
+needs_yml_merge() {
+    if [[ ! -f ${DOCKER_COMPOSE_FILE} ]]; then
+        # Compose file doesn't exists, return true
+        return 0
+    fi
+
+    if file_changed "${DOCKER_COMPOSE_FILE}"; then
+        # Compose file has changed, return true
+        return 0
+    fi
+    if file_changed "${COMPOSE_ENV}"; then
+        # .env has changed, return true
+        return 0
+    fi
+    for AppName in $(run_script 'app_list_enabled'); do
+        if file_changed "$(run_script 'app_env_file' "${AppName}")"; then
+            # .env.app.appname has changed, return true
+            return 0
+        fi
+    done
+
+    # No files have changed, return false
+    return 1
+}
+
+file_changed() {
+    local file=${1-}
+    local timestamp_file
+    timestamp_file="${TIMESTAMPS_FOLDER:?}/${Prefix}$(basename "${file}")"
+    if [[ ! -f ${file} && ! -f ${timestamp_file} ]]; then
+        return 1
+    elif [[ -f ${file} && ! -f ${timestamp_file} ]]; then
+        return 0
+    elif [[ ! -f ${file} && -f ${timestamp_file} ]]; then
+        return 0
+    fi
+    [[ $(stat -c %Y "${file}") != $(stat -c %Y "${timestamp_file}") ]]
+}
+
+test_needs_yml_merge() {
+    warn "CI does not test needs_yml_merge."
+}

--- a/.scripts/override_var_rename.sh
+++ b/.scripts/override_var_rename.sh
@@ -16,7 +16,6 @@ override_var_rename() {
         # Replace $FromVar or ${FromVar followed by a word break to $ToVar or ${ToVar
         sed -i -E "s/([$]\{?)${FromVar}\b/\1${ToVar}/g" "${COMPOSE_OVERRIDE}" ||
             fatal "Failed to rename variable in override file.\nFailing command: ${C["FailingCommand"]} sed -i -E \"s/([$]\\{?)${FromVar}\\\\b/\\\\1${ToVar}/g\" \"${COMPOSE_OVERRIDE}\""
-        unset PROCESSED_YML_MERGE
 
     fi
 }

--- a/.scripts/reset_needs.sh
+++ b/.scripts/reset_needs.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+reset_needs() {
+    if [[ -d ${TIMESTAMPS_FOLDER:?} ]]; then
+        run_script 'set_permissions' "${TIMESTAMPS_FOLDER:?}"
+        rm -rf "${TIMESTAMPS_FOLDER:?}/"* &> /dev/null || true
+    fi
+}
+
+test_reset_needs() {
+    # run_script 'env_delete'
+    warn "CI does not test reset_needs."
+}

--- a/.scripts/unset_needs_appvars_create.sh
+++ b/.scripts/unset_needs_appvars_create.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+declare Prefix="appvars_create_"
+
+# shellcheck disable=SC2317  # Don't warn about unreachable commands in this function
+unset_needs_appvars_create() {
+    return
+
+    if [[ -d ${TIMESTAMPS_FOLDER:?} ]]; then
+        rm -f "${TIMESTAMPS_FOLDER:?}/${Prefix}"* &> /dev/null || true
+    else
+        mkdir "${TIMESTAMPS_FOLDER:?}"
+        run_script 'set_permissions' "${TIMESTAMPS_FOLDER:?}"
+    fi
+
+    if [[ $# -gt 0 ]]; then
+        for AppName in "$@"; do
+            local VarFile
+            VarFile="$(run_script 'app_env_file' "${AppName}")"
+            if [[ -f ${VarFile} ]]; then
+                touch -r "${VarFile}" "${TIMESTAMPS_FOLDER:?}/${Prefix}$(basename "${VarFile}")"
+            fi
+        done
+        return
+    fi
+
+    for AppName in $(run_script 'app_list_added'); do
+        local VarFile
+        VarFile="$(run_script 'app_env_file' "${AppName}")"
+        if [[ -f ${VarFile} ]]; then
+            touch -r "${VarFile}" "${TIMESTAMPS_FOLDER:?}/${Prefix}$(basename "${VarFile}")"
+        fi
+    done
+}
+
+test_unset_needs_appvars_create() {
+    warn "CI does not test unset_needs_appvars_create."
+}

--- a/.scripts/unset_needs_env_update.sh
+++ b/.scripts/unset_needs_env_update.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+declare Prefix="env_update_"
+
+unset_needs_env_update() {
+    local VarFile=${1-}
+
+    if [[ -z ${VarFile} ]]; then
+        run_script 'unset_needs_env_update' "${COMPOSE_ENV}"
+        for AppName in $(run_script 'app_list_referenced'); do
+            run_script 'unset_needs_env_update' "$(run_script 'app_env_file' "${AppName}")"
+        done
+        return
+    fi
+
+    if [[ ! -d ${TIMESTAMPS_FOLDER:?} ]]; then
+        mkdir "${TIMESTAMPS_FOLDER:?}"
+        run_script 'set_permissions' "${TIMESTAMPS_FOLDER:?}"
+    fi
+
+    local filename
+    filename="$(basename "${VarFile}")"
+
+    rm -f "$(timestamp_file "${filename}")"* &> /dev/null || true
+
+    touch -r "${VarFile}" "$(timestamp_file "${filename}")"
+    if [[ ${VarFile} == "${COMPOSE_ENV}" ]]; then
+        local ReferencedAppsFile
+        ReferencedAppsFile="$(timestamp_file "${filename}_ReferencedApps")"
+        run_script 'app_list_referenced' > "${ReferencedAppsFile}"
+    else
+        local -u APPNAME
+        APPNAME="$(run_script 'varfile_to_appname' "${VarFile}")"
+        local AppEnabledFile
+        AppEnabledFile="$(timestamp_file "${filename}_${APPNAME}__ENABLED")"
+        run_script 'env_get_line' "${APPNAME}__ENABLED" > "${AppEnabledFile}"
+    fi
+}
+
+timestamp_file() {
+    printf "${TIMESTAMPS_FOLDER:?}/${Prefix}%s\n" "$1"
+}
+
+test_unset_needs_env_update() {
+    warn "CI does not test unset_needs_env_update."
+}

--- a/.scripts/unset_needs_yml_merge.sh
+++ b/.scripts/unset_needs_yml_merge.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+declare Prefix="yml_merge_"
+
+unset_needs_yml_merge() {
+    if [[ -d ${TIMESTAMPS_FOLDER:?} ]]; then
+        rm -f "${TIMESTAMPS_FOLDER:?}/${Prefix}"* &> /dev/null || true
+    else
+        mkdir "${TIMESTAMPS_FOLDER:?}"
+        run_script 'set_permissions' "${TIMESTAMPS_FOLDER:?}"
+    fi
+    make_timestamp_file "${DOCKER_COMPOSE_FILE}"
+    make_timestamp_file "${COMPOSE_ENV}"
+    for AppName in $(run_script 'app_list_enabled'); do
+        make_timestamp_file "$(run_script 'app_env_file' "${AppName}")"
+    done
+}
+
+make_timestamp_file() {
+    for file in "$@"; do
+        if [[ -f ${file} ]]; then
+            touch -r "${file}" "${TIMESTAMPS_FOLDER:?}/${Prefix}$(basename "${file}")"
+        fi
+    done
+}
+
+test_unset_needs_yml_merge() {
+    warn "CI does not test unset_needs_yml_merge."
+}

--- a/.scripts/update_self.sh
+++ b/.scripts/update_self.sh
@@ -78,10 +78,6 @@ update_self() {
         return 1
     fi
 
-    unset PROCESSED_APPVARS_CREATE_ALL
-    unset PROCESSED_ENV_UPDATE
-    unset PROCESSED_YML_MERGE
-
     if use_dialog_box; then
         commands_update_self "${BRANCH}" "${YesNotice}" "$@" |&
             dialog_pipe "${DC[TitleSuccess]}${Title}" "${YesNotice}\n${DC[CommandLine]} ${APPLICATION_COMMAND} --update $*"
@@ -123,6 +119,13 @@ commands_update_self() {
     sudo chown "${DETECTED_PUID}":"${DETECTED_PGID}" "${SCRIPTPATH}" > /dev/null 2>&1 || true
     notice "Updated ${APPLICATION_NAME} to '${C["Version"]}$(ds_version)${NC}'"
     popd &> /dev/null
+
+    # run_script 'reset_needs' # Add script lines in-line below
+    if [[ -d ${TIMESTAMPS_FOLDER:?} ]]; then
+        run_script 'set_permissions' "${TIMESTAMPS_FOLDER:?}"
+        rm -rf "${TIMESTAMPS_FOLDER:?}/"* &> /dev/null || true
+    fi
+
     if [[ -z $* ]]; then
         exec bash "${SCRIPTNAME}" -e
     else

--- a/.scripts/varfile_to_appname.sh
+++ b/.scripts/varfile_to_appname.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+varfile_to_appname() {
+    # Returns the DS application name based on the variable filename passed
+
+    local VarFile=${1-}
+    local FileName
+    FileName="$(basename "${VarFile}")"
+    local Prefix='.env.app.'
+    local AppName="${FileName#"${Prefix}"}"
+    if [[ ${AppName} != "${FileName}" && ${AppName} == "${AppName,,}" ]] && run_script 'appname_is_valid' "${AppName}"; then
+        echo "${AppName}"
+    fi
+}
+
+test_varfile_to_appname() {
+    local -a PathList=(
+        '/home/test/.docker/.env'
+        '/home/test/.docker/.env.app.radarr'
+        '/home/test/.docker/.env.app.Radarr'
+        '/home/test/.docker/.env.app.1radarr'
+        '/home/test/.docker/.env.app.radarr__4k'
+        '/home/test/.docker/.env.app.radarr___4k'
+    )
+    for filepath in "${PathList[@]}"; do
+        notice "[${filepath}] [$(run_script 'varfile_to_appname' "${filepath}")]"
+    done
+}

--- a/.scripts/yml_merge.sh
+++ b/.scripts/yml_merge.sh
@@ -7,8 +7,9 @@ yml_merge() {
 }
 
 commands_yml_merge() {
-    if [[ -n ${PROCESSED_YML_MERGE-} && -f ${COMPOSE_FOLDER}/docker-compose.yml ]]; then
+    if ! run_script 'needs_yml_merge'; then
         # Compose file has already been created, nothing to do
+        notice "Enabled app templates already merged to '${C["File"]}docker-compose.yml${NC}'."
         return 0
     fi
     run_script 'appvars_create_all'
@@ -124,7 +125,7 @@ commands_yml_merge() {
         return ${result}
     fi
     info "Merging '${C["File"]}docker-compose.yml${NC}' complete."
-    declare -gx PROCESSED_YML_MERGE=1
+    run_script 'unset_needs_yml_merge'
     return 0
 }
 test_yml_merge() {


### PR DESCRIPTION
Skip formatting of variable files if it is detected the files would not be changed.

Skip creating `docker-compose.yml` if it is detected the existing file would not be changed.

# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
Keep track of the timestamps of the user's files in a `.timestamps` folder.  Also keep track of the value of `APPNAME_ENABLED` variables after the variable files have been updated, and the list of referenced apps the last time that the global `.env` file was updated.  Use this information to determine if `env_update` needs to be run.  Similarly, check if `yml_merge` needs to be done.

Add a `ds --reset / ds -R` command to clear this folder, to force the next run to update all files.

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Use file timestamps to avoid redundant env_update, appvars_create, and yml_merge operations, add helper scripts to track and clear task‐state, and introduce a reset command to force reprocessing

New Features:
- Introduce timestamp-based checks in a dedicated .timestamps folder to determine if environment variables update, app variable creation, or Docker Compose merge actions are required
- Add ds --reset (alias -R) command to clear timestamp data and force all tasks to re-run

Enhancements:
- Skip variable file formatting and docker-compose.yml generation when files are unchanged
- Replace PROCESSED_* flags with needs_* and unset_needs_* helper scripts to manage task idempotency

Documentation:
- Update CLI help text to include the new --reset option

Tests:
- Stub CI tests for needs_* and unset_* helper scripts with warnings