### PR TITLE
Redirect output of `kill` and `rm` to /dev/null in `menu_app_select`

### DIFF
--- a/.scripts/menu_app_select.sh
+++ b/.scripts/menu_app_select.sh
@@ -313,13 +313,13 @@ show_gauge() {
 
 close_gauge() {
     # Signal the dialog gauge and progress windows to terminate
-    kill -SIGTERM "${Dialog_PID}"
+    kill -SIGTERM "${Dialog_PID}" &> /dev/null || true
     wait "${Dialog_PID}"
     # Remove the communication pipes to dialog
-    exec {GaugePipe_fd}>&-
-    rm "${GaugePipe}" || true
-    exec {ProgressLog_fd}>&-
-    rm "${ProgressLog}" || true
+    exec {GaugePipe_fd}>&- &> /dev/null || true
+    rm "${GaugePipe}" &> /dev/null || true
+    exec {ProgressLog_fd}>&- &> /dev/null || true
+    rm "${ProgressLog}" &> /dev/null || true
 }
 
 init_gauge_text() {


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Enhancements:
- Silence output of kill, exec, and rm commands in close_gauge by redirecting to /dev/null and using || true