### PR TITLE
Rewrite `env_merge_newonly` using the `comm` command

### DIFF
--- a/.scripts/env_get_line_regex.sh
+++ b/.scripts/env_get_line_regex.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+env_get_line_regex() {
+    # env_get_line GET_VAR [VAR_FILE]
+    # env_get_line APPNAME:GET_VAR
+    #
+    # Returns the variable "GET_VAR"  If no "VAR_FILE" is given, uses the global .env file
+    # If "APPNAME:" is provided, gets variable from ".env.app.appname"
+    local GET_VAR=${1-}
+    local VAR_FILE=${2:-$COMPOSE_ENV}
+
+    if [[ ${GET_VAR} == *:* ]]; then
+        # GET_VAR is in the form of "APPNAME:VARIABLE", set new file to use
+        local APPNAME=${GET_VAR%%:*}
+        VAR_FILE="$(run_script 'app_env_file' "${APPNAME}")"
+        GET_VAR=${GET_VAR#"${APPNAME}:"}
+    fi
+    if [[ -f ${VAR_FILE} ]]; then
+        grep --color=never -Po "^\s*${GET_VAR}\s*=.*" "${VAR_FILE}" || true
+    else
+        # VAR_FILE does not exist, give a warning
+        warn "${F[C]}${VAR_FILE}${NC} does not exist."
+    fi
+
+}
+
+test_env_get_line_regex() {
+    run_script 'appvars_create' WATCHTOWER
+    run_script 'env_get_line_regex' WATCHTOWER__ENABLED
+    run_script 'env_get_line_regex' WATCHTOWER:WATCHTOWER_NOTIFICATIONS
+    run_script 'env_get_line_regex' 'WATCHTOWER__ENABLED|WATCHTOWER_HOSTNAME'
+    run_script 'appvars_purge' WATCHTOWER
+}


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Use comm and new helper functions to simplify and optimize the env_merge_newonly logic and add a dedicated script for regex-based environment variable extraction.

New Features:
- Introduce env_get_line_regex helper script for extracting environment variable lines via regex from .env files

Enhancements:
- Refactor env_merge_newonly to use comm on sorted variable lists and helper scripts instead of manual parsing and grep loops

Tests:
- Add test_env_get_line_regex function to validate the new env_get_line_regex script