### PR TITLE
Add `envsubst` and `column` as dependencies

### DIFF
--- a/.scripts/package_manager_run.sh
+++ b/.scripts/package_manager_run.sh
@@ -16,7 +16,7 @@ package_manager_run() {
         run_script "pm_yum_${ACTION}"
     else
         if [[ ${ACTION} == "install" ]]; then
-            local COMMAND_DEPS=("curl" "dialog" "envsubst" "git" "grep" "sed")
+            local COMMAND_DEPS=("column" "curl" "dialog" "envsubst" "git" "grep" "sed")
             for COMMAND_DEP in "${COMMAND_DEPS[@]}"; do
                 if [[ -z "$(command -v "${COMMAND_DEP}")" ]]; then
                     fatal "'${C["Program"]}${COMMAND_DEP}${NC}' is not available. Please install '${C["Program"]}${COMMAND_DEP}${NC}' and try again."

--- a/.scripts/pm_apk_install.sh
+++ b/.scripts/pm_apk_install.sh
@@ -11,7 +11,7 @@ pm_apk_install() {
         #shellcheck disable=SC2016 # (info): Expressions don't expand in single quotes, use double quotes for that.
         REDIRECT='run_command_dialog "${Title}" "${COMMAND}" "" '
     fi
-    COMMAND='sudo apk add coreutils curl dialog gettext git grep openrc sed'
+    COMMAND='sudo apk add coreutils bsdmainutils curl dialog gettext git grep openrc sed util-linux'
     eval "${REDIRECT}${COMMAND}" || fatal "Failed to install dependencies from apk.\nFailing command: ${C["FailingCommand"]}${COMMAND}"
 }
 

--- a/.scripts/pm_apt_install.sh
+++ b/.scripts/pm_apt_install.sh
@@ -11,7 +11,7 @@ pm_apt_install() {
         #shellcheck disable=SC2016 # (info): Expressions don't expand in single quotes, use double quotes for that.
         REDIRECT='run_command_dialog "${Title}" "${COMMAND}" "" '
     fi
-    COMMAND='sudo apt-get -y install curl dialog gettext git grep sed'
+    COMMAND='sudo apt-get -y install bsdmainutils curl dialog gettext git grep sed util-linux'
     eval "${REDIRECT}${COMMAND}" || fatal "Failed to install dependencies from apt.\nFailing command: ${C["FailingCommand"]}${COMMAND}"
 }
 

--- a/.scripts/pm_dnf_install.sh
+++ b/.scripts/pm_dnf_install.sh
@@ -11,7 +11,7 @@ pm_dnf_install() {
         #shellcheck disable=SC2016 # (info): Expressions don't expand in single quotes, use double quotes for that.
         REDIRECT='run_command_dialog "${Title}" "${COMMAND}" "" '
     fi
-    COMMAND='sudo dnf -y install curl dialog gettext git grep sed'
+    COMMAND='sudo dnf -y install bsdmainutils curl dialog gettext git grep sed util-linux'
     eval "${REDIRECT}${COMMAND}" || fatal "Failed to install dependencies from dnf.\nFailing command: ${C["FailingCommand"]}${COMMAND}"
 }
 

--- a/.scripts/pm_pacman_install.sh
+++ b/.scripts/pm_pacman_install.sh
@@ -11,7 +11,7 @@ pm_pacman_install() {
         #shellcheck disable=SC2016 # (info): Expressions don't expand in single quotes, use double quotes for that.
         REDIRECT='run_command_dialog "${Title}" "${COMMAND}" "" '
     fi
-    COMMAND='sudo pacman -Sy --noconfirm curl dialog gettext git grep sed'
+    COMMAND='sudo pacman -Sy --noconfirm bsdmainutils curl dialog gettext git grep sed util-linux'
     eval "${REDIRECT}${COMMAND}" || fatal "Failed to install dependencies from pacman.\nFailing command: ${C["FailingCommand"]}${COMMAND}"
 }
 

--- a/.scripts/pm_yum_install.sh
+++ b/.scripts/pm_yum_install.sh
@@ -11,7 +11,7 @@ pm_yum_install() {
         #shellcheck disable=SC2016 # (info): Expressions don't expand in single quotes, use double quotes for that.
         REDIRECT='run_command_dialog "${Title}" "${COMMAND}" "" '
     fi
-    COMMAND='sudo yum -y install curl dialog gettext git grep sed'
+    COMMAND='sudo yum -y install bsdmainutils curl dialog gettext git grep sed util-linux'
     eval "${REDIRECT}${COMMAND}" || fatal "Failed to install dependencies from yum.\nFailing command: ${C["FailingCommand"]}${COMMAND}"
 }
 


### PR DESCRIPTION
# Pull request

**Purpose**
Fixes #2169
Fixes #2166

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Add envsubst and column as required dependencies by introducing gettext and bsdmainutils packages in installation scripts and checking for their availability in the runtime environment.

Enhancements:
- Include envsubst and column in the command dependency checks
- Install gettext (for envsubst) and bsdmainutils (for column) in all supported package manager scripts