### PR TITLE
Change all dialog color references to `${DC["ColorName"]-}`, adding q…

### DIFF
--- a/.scripts/appvars_purge.sh
+++ b/.scripts/appvars_purge.sh
@@ -48,7 +48,7 @@ appvars_purge() {
         fi
 
         if [[ -z ${GlobalVarsToRemove[*]-} && -z ${AppEnvVarsToRemove[*]-} ]]; then
-            local WarningText="'${DC["Highlight"]}${C["App"]}${AppName}${NC}${DC[NC]}' has no variables to remove."
+            local WarningText="'${DC["Highlight"]-}${C["App"]}${AppName}${NC}${DC["NC"]-}' has no variables to remove."
             local WarningTextNotice
             WarningTextNotice="$(strip_dialog_colors "${WarningText}")"
             if use_dialog_box; then
@@ -62,15 +62,15 @@ appvars_purge() {
 
         local Indent='   '
         local Question
-        Question="Would you like to purge these settings for '${DC["Highlight"]}${C["App"]}${AppName}${NC}${DC[NC]}'?\n"
+        Question="Would you like to purge these settings for '${DC["Highlight"]-}${C["App"]}${AppName}${NC}${DC["NC"]-}'?\n"
         if [[ -n ${GlobalLinesToRemove[*]-} ]]; then
-            Question+="${Indent}${DC["Highlight"]}${C["Folder"]}${COMPOSE_ENV}${NC}${DC[NC]}:\n"
+            Question+="${Indent}${DC["Highlight"]-}${C["Folder"]}${COMPOSE_ENV}${NC}${DC["NC"]-}:\n"
             for line in "${GlobalLinesToRemove[@]}"; do
                 Question+="${Indent}${Indent}${C["Var"]}${line}${NC}\n"
             done
         fi
         if [[ -n ${AppEnvLinesToRemove[*]-} ]]; then
-            Question+="${Indent}${DC["Highlight"]}${C["Folder"]}${AppEnvFile}${NC}${DC[NC]}:\n"
+            Question+="${Indent}${DC["Highlight"]-}${C["Folder"]}${AppEnvFile}${NC}${DC["NC"]-}:\n"
             for line in "${AppEnvLinesToRemove[@]}"; do
                 Question+="${Indent}${Indent}${C["Var"]}${line}${NC}\n"
             done

--- a/.scripts/docker_compose.sh
+++ b/.scripts/docker_compose.sh
@@ -108,7 +108,7 @@ docker_compose() {
     if run_script 'question_prompt' Y "${Question}" "${Title}" "${FORCE:+Y}"; then
         if use_dialog_box; then
             coproc {
-                dialog_pipe "${DC[TitleSuccess]}${Title}" "${YesNotice}${DC[NC]}\n${DC[CommandLine]} ${APPLICATION_COMMAND} --compose ${ComposeInput}"
+                dialog_pipe "${DC["TitleSuccess"]-}${Title}" "${YesNotice}${DC["NC"]-}\n${DC["CommandLine"]-} ${APPLICATION_COMMAND} --compose ${ComposeInput}"
             }
             local -i DialogBox_PID=${COPROC_PID}
             local -i DialogBox_FD="${COPROC[1]}"
@@ -150,7 +150,7 @@ docker_compose() {
         fi
     else
         if use_dialog_box; then
-            [[ -n ${NoNotice-} ]] && notice "${NoNotice}" |& dialog_pipe "${DC[TitleError]}${Title}" "${NoNotice}"
+            [[ -n ${NoNotice-} ]] && notice "${NoNotice}" |& dialog_pipe "${DC["TitleError"]-}${Title}" "${NoNotice}"
         else
             [[ -n ${NoNotice-} ]] && notice "${NoNotice}"
         fi

--- a/.scripts/docker_prune.sh
+++ b/.scripts/docker_prune.sh
@@ -15,7 +15,7 @@ docker_prune() {
                 notice "${YesNotice}"
                 notice "Running: ${C["RunningCommand"]}${Command}${NC}"
                 eval "${Command}" || error "Failed to remove unused docker resources.\nFailing command: ${C["FailingCommand"]}${Command}"
-            } |& dialog_pipe "${DC[TitleSuccess]}${Title}" "${YesNotice}${DC[NC]}\n${DC[CommandLine]} ${Command}"
+            } |& dialog_pipe "${DC["TitleSuccess"]-}${Title}" "${YesNotice}${DC["NC"]-}\n${DC["CommandLine"]-} ${Command}"
         else
             notice "${YesNotice}"
             notice "Running: ${C["RunningCommand"]}${Command}${NC}"

--- a/.scripts/menu_add_app.sh
+++ b/.scripts/menu_add_app.sh
@@ -6,7 +6,7 @@ menu_add_app() {
     local Title="Add Application"
 
     local AppNameMaxLength=256
-    local AppNameNone="${DC[Highlight]}[*NONE*]"
+    local AppNameNone="${DC["Highlight"]-}[*NONE*]"
 
     local AppName=""
     #local BaseAppName InstanceName
@@ -26,7 +26,7 @@ menu_add_app() {
         )
         local -a InputValueDialog=(
             --stdout
-            --title "${DC["Title"]}${Title}"
+            --title "${DC["Title"]-}${Title}"
             --max-input 256
             --form "${InputValueText}"
             "$((LINES - DC["WindowRowsAdjust"]))" "$((COLUMNS - DC["WindowColsAdjust"]))" 0
@@ -58,7 +58,7 @@ menu_add_app() {
                     AppNameHeading="${AppName}"
                 else
                     AppNameHeading="${AppNameNone}"
-                    ErrorMessage="The application name ${DC[Highlight]}${AppName}${DC[NC]} is not a valid name.\n\n Please input another application name."
+                    ErrorMessage="The application name ${DC["Highlight"]-}${AppName}${DC["NC"]-} is not a valid name.\n\n Please input another application name."
                 fi
                 if [[ -n ${ErrorMessage} ]]; then
                     Heading="$(run_script 'menu_heading' "${AppNameHeading}")"
@@ -68,7 +68,7 @@ menu_add_app() {
                 Heading="$(run_script 'menu_heading' "${AppNameHeading}")"
                 if ! run_script 'app_is_builtin' "${AppName}"; then
                     local Question
-                    Question="Create user defined application ${DC[Highlight]}${AppName}${DC[NC]}?\n"
+                    Question="Create user defined application ${DC["Highlight"]-}${AppName}${DC["NC"]-}?\n"
                     Heading="$(run_script 'menu_heading' "${AppNameHeading}")"
                     if run_script 'question_prompt' N "${Heading}\n\n${Question}" "Create Application" "" "User Defined" "Back"; then
                         Heading="$(run_script 'menu_heading' "${AppNameHeading}")"
@@ -78,7 +78,7 @@ menu_add_app() {
                     fi
                 else
                     local Question
-                    Question="Application ${DC[Highlight]}${AppName}${DC[NC]} can be added as a built-in application.\n\nCreate ${DC[Highlight]}${AppName}${DC[NC]} as a ${DC[Highlight]}Built In${DC[NC]} or a ${DC[Highlight]}User Defined${DC[NC]} application?\n"
+                    Question="Application ${DC["Highlight"]-}${AppName}${DC["NC"]-} can be added as a built-in application.\n\nCreate ${DC["Highlight"]-}${AppName}${DC["NC"]-} as a ${DC["Highlight"]-}Built In${DC["NC"]-} or a ${DC["Highlight"]-}User Defined${DC["NC"]-} application?\n"
                     Heading="$(run_script 'menu_heading' "${AppNameHeading}")"
                     local -a YesNoDialog=(
                         --title "${Title}"
@@ -96,7 +96,7 @@ menu_add_app() {
                         OK) # Built In
                             Heading="$(run_script 'menu_heading' "${AppNameHeading}")"
                             coproc {
-                                dialog_pipe "${DC[TitleSuccess]}Adding Built In Application" "${Heading}\n\n${DC[Subtitle]}Adding application:\n${DC[CommandLine]} ${APPLICATION_COMMAND} --add ${AppName}" "${DIALOGTIMEOUT}"
+                                dialog_pipe "${DC["TitleSuccess"]-}Adding Built In Application" "${Heading}\n\n${DC["Subtitle"]-}Adding application:\n${DC["CommandLine"]-} ${APPLICATION_COMMAND} --add ${AppName}" "${DIALOGTIMEOUT}"
                             }
                             local -i DialogBox_PID=${COPROC_PID}
                             local -i DialogBox_FD="${COPROC[1]}"
@@ -111,7 +111,7 @@ menu_add_app() {
                             ;;
                         EXTRA) # User Defined
                             Heading="$(run_script 'menu_heading' "${AppNameHeading}")"
-                            dialog_success "${DC[TitleSuccess]}Adding User Defined Application" "${Heading}" "${DIALOGTIMEOUT}"
+                            dialog_success "${DC["TitleSuccess"]-}Adding User Defined Application" "${Heading}" "${DIALOGTIMEOUT}"
                             run_script 'menu_add_var' "${AppName}"
                             return
                             ;;

--- a/.scripts/menu_add_var.sh
+++ b/.scripts/menu_add_var.sh
@@ -12,7 +12,7 @@ menu_add_var() {
     local Heading
     local VarNameMaxLength=256
     local VarNameHeading
-    local VarNameNone="${DC[Highlight]}[*NONE*]"
+    local VarNameNone="${DC["Highlight"]-}[*NONE*]"
     Heading=""
     if [[ -z ${APPNAME-} ]]; then
         # No appname specified, creating a global variable in .env
@@ -74,15 +74,15 @@ menu_add_var() {
             }
             local -A OptionHelpLine=(
                 ["${APPNAME__}"]="Complete this with any variable you want."
-                ["${APPNAME__ENVIRONMENT_}"]="Complete this with a var to use in the ${DC["Highlight"]}environment:${DC[NC]} section of your override. Suggest adding to ${DC["Highlight"]}${DC["Highlight"]}env_files/${APPNAME,,}.env${DC[NC]} instead."
-                ["${APPNAME__PORT_}"]="Complete this with a var to use in the ${DC["Highlight"]}ports:${DC[NC]} section of your override."
-                ["${APPNAME__VOLUME_}"]="Complete this with a var to use in the ${DC["Highlight"]}volumes:${DC[NC]} section of your override."
-                ["${APPNAME__CONTAINER_NAME}"]="This can be used in the ${DC["Highlight"]}container_name:${DC[NC]} section in your override."
+                ["${APPNAME__ENVIRONMENT_}"]="Complete this with a var to use in the ${DC["Highlight"]-}environment:${DC["NC"]-} section of your override. Suggest adding to ${DC["Highlight"]-}${DC["Highlight"]-}env_files/${APPNAME,,}.env${DC["NC"]-} instead."
+                ["${APPNAME__PORT_}"]="Complete this with a var to use in the ${DC["Highlight"]-}ports:${DC["NC"]-} section of your override."
+                ["${APPNAME__VOLUME_}"]="Complete this with a var to use in the ${DC["Highlight"]-}volumes:${DC["NC"]-} section of your override."
+                ["${APPNAME__CONTAINER_NAME}"]="This can be used in the ${DC["Highlight"]-}container_name:${DC["NC"]-} section in your override."
                 ["${APPNAME__ENABLED}"]="Creating this variable will cause the app to be controlled by ${APPLICATION_NAME} with no override needed."
-                ["${APPNAME__HOSTNAME}"]="This can be used in the ${DC["Highlight"]}hostname:${DC[NC]} section of your override."
-                ["${APPNAME__NETWORK_MODE}"]="This can be used in the ${DC["Highlight"]}network_mode:${DC[NC]} section of your override."
-                ["${APPNAME__RESTART}"]="This can be used in the ${DC["Highlight"]}restart:${DC[NC]} section of your override."
-                ["${APPNAME__TAG}"]="This can be used in the ${DC["Highlight"]}image:${DC[NC]} section of your override. Add it at the end as ${DC["Highlight"]}:\${${APPNAME__TAG// /}}${DC[NC]}."
+                ["${APPNAME__HOSTNAME}"]="This can be used in the ${DC["Highlight"]-}hostname:${DC["NC"]-} section of your override."
+                ["${APPNAME__NETWORK_MODE}"]="This can be used in the ${DC["Highlight"]-}network_mode:${DC["NC"]-} section of your override."
+                ["${APPNAME__RESTART}"]="This can be used in the ${DC["Highlight"]-}restart:${DC["NC"]-} section of your override."
+                ["${APPNAME__TAG}"]="This can be used in the ${DC["Highlight"]-}image:${DC["NC"]-} section of your override. Add it at the end as ${DC["Highlight"]-}:\${${APPNAME__TAG// /}}${DC["NC"]-}."
             )
             ClearHelpLine="This will clear any variable name already entered."
             AddAllHelpLine="This will add all stock variables listed below."
@@ -169,12 +169,12 @@ menu_add_var() {
                     )
                 fi
                 Heading="$(run_script 'menu_heading' ":${AppName}" "${VarNameHeading}")"
-                local SelectValueMenuText="${Heading}\n\nWhat variable would you like create for application ${DC[Highlight]}${AppName}${DC[NC]}?"
+                local SelectValueMenuText="${Heading}\n\nWhat variable would you like create for application ${DC["Highlight"]-}${AppName}${DC["NC"]-}?"
                 local SelectValueDialogParams=(
                     --stdout
                     --item-help
                     --no-hot-list
-                    --title "${DC["Title"]}${Title}"
+                    --title "${DC["Title"]-}${Title}"
                 )
                 local -i MenuTextLines
                 MenuTextLines="$(_dialog_ "${SelectValueDialogParams[@]}" --print-text-size "${SelectValueMenuText}" "$((LINES - DC["WindowRowsAdjust"]))" "$((COLUMNS - DC["WindowColsAdjust"]))" | cut -d ' ' -f 1)"
@@ -196,15 +196,15 @@ menu_add_var() {
                         if [[ ${SelectedOption} == "${OptionClear}" ]]; then
                             VarName=""
                         elif [[ ${SelectedOption} == "${OptionAddAll}" ]]; then
-                            local Question="${DC[NC]}Would you like to create the following stock variables to use in your override file?\n"
+                            local Question="${DC["NC"]-}Would you like to create the following stock variables to use in your override file?\n"
                             for Option in "${ValidStockOptions[@]}"; do
-                                Question+="\n   ${DC["Highlight"]}${Option// /}${DC[NC]}"
+                                Question+="\n   ${DC["Highlight"]-}${Option// /}${DC["NC"]-}"
                             done
                             Heading="$(run_script 'menu_heading' ":${AppName}")"
                             if run_script 'question_prompt' N "${Heading}\n\n${Question}" "Create Stock Variables" "" "Create" "Back"; then
                                 Heading="$(run_script 'menu_heading' ":${AppName}" "${VarNameHeading}")"
                                 coproc {
-                                    dialog_pipe "${DC["TitleSuccess"]}Creating Stock Variables" "${Heading}"
+                                    dialog_pipe "${DC["TitleSuccess"]-}Creating Stock Variables" "${Heading}"
                                 }
                                 local -i DialogBox_PID=${COPROC_PID}
                                 local -i DialogBox_FD="${COPROC[1]}"
@@ -248,15 +248,15 @@ menu_add_var() {
                             fi
                             continue
                         elif ! run_script 'varname_is_valid' "${VarName}" "_BARE_"; then
-                            ErrorMessage="The variable name ${DC[Highlight]}${VarName}${DC[NC]} is not a valid name.\n\n Please input another variable name."
+                            ErrorMessage="The variable name ${DC["Highlight"]-}${VarName}${DC["NC"]-} is not a valid name.\n\n Please input another variable name."
                         elif run_script 'env_var_exists' "${VarName}"; then
-                            ErrorMessage="The variable ${DC[Highlight]}${VarName}${DC[NC]} already exists.\n\n Please input another variable name."
+                            ErrorMessage="The variable ${DC["Highlight"]-}${VarName}${DC["NC"]-} already exists.\n\n Please input another variable name."
                         else
                             DetectedAppName="$(run_script 'app_nicename' "$(run_script 'varname_to_appname' "${VarName}")")"
                             if [[ ${DetectedAppName^^} == "" ]]; then
-                                ErrorMessage="The variable name ${DC[Highlight]}${VarName}${DC[NC]} is not a valid name for app ${DC[Highlight]}${AppName}${DC[NC]}. It would be a global variable.\n\n Please input another variable name."
+                                ErrorMessage="The variable name ${DC["Highlight"]-}${VarName}${DC["NC"]-} is not a valid name for app ${DC["Highlight"]-}${AppName}${DC["NC"]-}. It would be a global variable.\n\n Please input another variable name."
                             elif [[ ${DetectedAppName^^} != "${APPNAME}" ]]; then
-                                ErrorMessage="The variable name ${DC[Highlight]}${VarName}${DC[NC]} is not a valid name for app ${DC[Highlight]}${AppName}${DC[NC]}. It would be a variable for an app named ${DC[Highlight]}${DetectedAppName}${DC[NC]}.\n\n Please input another variable name."
+                                ErrorMessage="The variable name ${DC["Highlight"]-}${VarName}${DC["NC"]-} is not a valid name for app ${DC["Highlight"]-}${AppName}${DC["NC"]-}. It would be a variable for an app named ${DC["Highlight"]-}${DetectedAppName}${DC["NC"]-}.\n\n Please input another variable name."
                             fi
                         fi
                         if [[ -n ${ErrorMessage-} ]]; then
@@ -264,12 +264,12 @@ menu_add_var() {
                             dialog_error "${Title}" "${Heading}\n\n${ErrorMessage}"
                             continue
                         fi
-                        Question="Create variable ${DC[Highlight]}${VarName}${DC[NC]} for application ${DC[Highlight]}${AppName}${DC[NC]}?\n"
+                        Question="Create variable ${DC["Highlight"]-}${VarName}${DC["NC"]-} for application ${DC["Highlight"]-}${AppName}${DC["NC"]-}?\n"
                         Heading="$(run_script 'menu_heading' "$:{AppName}" "${VarNameHeading}")"
                         if run_script 'question_prompt' N "${Heading}\n\n${Question}" "Create Variable" "" "Create" "Back"; then
                             Default="$(run_script 'var_default_value' "${VarName}")"
                             Heading="$(run_script 'menu_heading' ":${AppName}" "${VarNameHeading}")"
-                            run_script_dialog "${DC["TitleSuccess"]}Creating Variable" "${Heading}\n\n" "${DIALOGTIMEOUT}" \
+                            run_script_dialog "${DC["TitleSuccess"]-}Creating Variable" "${Heading}\n\n" "${DIALOGTIMEOUT}" \
                                 'env_set_literal' "${VarName}" "${Default}"
                             run_script 'menu_value_prompt' "${VarName}"
                             return
@@ -289,7 +289,7 @@ menu_add_var() {
                 local InputValueText
                 Heading="$(run_script 'menu_heading' "${AppNameHeading}" "")"
                 if [[ ${VarType} == APPENV ]]; then
-                    InputValueText="${Heading}\n\nWhat variable would you like create for application ${DC[Highlight]}${AppName}${DC[NC]}?\n"
+                    InputValueText="${Heading}\n\nWhat variable would you like create for application ${DC["Highlight"]-}${AppName}${DC["NC"]-}?\n"
                 else # GLOBAL
                     InputValueText="${Heading}\n\nWhat global variable would you like create?\n"
                 fi
@@ -303,7 +303,7 @@ menu_add_var() {
                 )
                 local -a InputValueDialog=(
                     --stdout
-                    --title "${DC["Title"]}${Title}"
+                    --title "${DC["Title"]-}${Title}"
                     --max-input 256
                     --form "${InputValueText}"
                     "$((LINES - DC["WindowRowsAdjust"]))" "$((COLUMNS - DC["WindowColsAdjust"]))" 0
@@ -320,13 +320,13 @@ menu_add_var() {
                         fi
                         VarNameHeading="${VarName:-${VarNameNone}}"
                         if ! run_script 'varname_is_valid' "${VarName}" "_BARE_"; then
-                            ErrorMessage="The variable name ${DC[Highlight]}${VarName}${DC[NC]} is not a valid name.\n\n Please input another variable name."
+                            ErrorMessage="The variable name ${DC["Highlight"]-}${VarName}${DC["NC"]-} is not a valid name.\n\n Please input another variable name."
                         elif run_script 'env_var_exists' "${VarName}" "${VarFile}"; then
-                            ErrorMessage="The variable ${DC[Highlight]}${VarName}${DC[NC]} already exists.\n\n Please input another variable name."
+                            ErrorMessage="The variable ${DC["Highlight"]-}${VarName}${DC["NC"]-} already exists.\n\n Please input another variable name."
                         elif [[ ${VarType} == GLOBAL ]]; then
                             DetectedAppName="$(run_script 'app_nicename' "$(run_script 'varname_to_appname' "${VarName}")")"
                             if [[ ${DetectedAppName} != "" ]]; then
-                                ErrorMessage="The variable name ${DC[Highlight]}${VarName}${DC[NC]} is not a valid global variable name. It would be a variable for an app named ${DC[Highlight]}${DetectedAppName}${DC[NC]}\n\n Please input another variable name."
+                                ErrorMessage="The variable name ${DC["Highlight"]-}${VarName}${DC["NC"]-} is not a valid global variable name. It would be a variable for an app named ${DC["Highlight"]-}${DetectedAppName}${DC["NC"]-}\n\n Please input another variable name."
                             fi
                         fi
                         if [[ -n ${ErrorMessage} ]]; then
@@ -336,24 +336,24 @@ menu_add_var() {
                         fi
                         Heading="$(run_script 'menu_heading' "${AppNameHeading}" "${VarNameHeading}")"
                         local Question
-                        Question="Create variable ${DC[Highlight]}${VarName}${DC[NC]}?\n"
+                        Question="Create variable ${DC["Highlight"]-}${VarName}${DC["NC"]-}?\n"
                         if [[ ${VarType} == "APPENV" ]]; then
-                            Question="Create variable ${DC[Highlight]}${VarName}${DC[NC]} for application ${DC[Highlight]}${AppName}${DC[NC]}?\n"
+                            Question="Create variable ${DC["Highlight"]-}${VarName}${DC["NC"]-} for application ${DC["Highlight"]-}${AppName}${DC["NC"]-}?\n"
                             if run_script 'question_prompt' N "${Heading}\n\n${Question}" "Create Variable" "" "Create" "Back"; then
                                 Default="$(run_script 'var_default_value' "${AppName}:${VarName}")"
                                 Heading="$(run_script 'menu_heading' "${AppNameHeading}" "${VarNameHeading}")"
-                                run_script_dialog "${DC["TitleSuccess"]}Creating Variable" "${Heading}\n\n" "${DIALOGTIMEOUT}" \
+                                run_script_dialog "${DC["TitleSuccess"]-}Creating Variable" "${Heading}\n\n" "${DIALOGTIMEOUT}" \
                                     'env_set_literal' "${appname}:${VarName}" "${Default}"
                                 run_script 'menu_value_prompt' "${appname}:${VarName}"
                                 return
                             fi
                         else # GLOBAL
                             Heading="$(run_script 'menu_heading' "${AppNameHeading}" "${VarNameHeading}")"
-                            Question="Create global variable ${DC[Highlight]}${VarName}${DC[NC]}?\n"
+                            Question="Create global variable ${DC["Highlight"]-}${VarName}${DC["NC"]-}?\n"
                             if run_script 'question_prompt' N "${Heading}\n\n${Question}" "Create Variable" "" "Create" "Back"; then
                                 Default="$(run_script 'var_default_value' "${VarName}")"
                                 Heading="$(run_script 'menu_heading' "${AppNameHeading}" "${VarNameHeading}")"
-                                run_script_dialog "${DC["TitleSuccess"]}Creating Variable" "${Heading}\n\n" "${DIALOGTIMEOUT}" \
+                                run_script_dialog "${DC["TitleSuccess"]-}Creating Variable" "${Heading}\n\n" "${DIALOGTIMEOUT}" \
                                     'env_set_literal' "${VarName}" "${Default}"
                                 run_script 'menu_value_prompt' "${VarName}"
                                 return

--- a/.scripts/menu_app_select.sh
+++ b/.scripts/menu_app_select.sh
@@ -9,9 +9,9 @@ declare -A StatusText=(
 )
 
 declare -A StatusHighlight=(
-    ["_Waiting_"]="${DC["ProgressWaiting"]}"
-    ["_InProgress_"]="${DC["ProgressInProgress"]}"
-    ["_Completed_"]="${DC["ProgressCompleted"]}"
+    ["_Waiting_"]="${DC["ProgressWaiting"]-}"
+    ["_InProgress_"]="${DC["ProgressInProgress"]-}"
+    ["_Completed_"]="${DC["ProgressCompleted"]-}"
 )
 
 declare Title="Select Applications"
@@ -133,9 +133,9 @@ menu_app_select() {
     if [[ ${CI-} == true ]]; then
         SelectedAppsDialogButtonPressed=${DIALOG_CANCEL}
     else
-        local SelectAppsDialogText="Choose which apps you would like to install:\n Use ${DC["KeyCap"]}[up]${DC["NC"]}, ${DC["KeyCap"]}[down]${DC["NC"]}, and ${DC["KeyCap"]}[space]${DC["NC"]} to select apps, and ${DC["KeyCap"]}[tab]${DC["NC"]} to switch to the buttons at the bottom."
+        local SelectAppsDialogText="Choose which apps you would like to install:\n Use ${DC["KeyCap"]-}[up]${DC["NC"]-}, ${DC["KeyCap"]-}[down]${DC["NC"]-}, and ${DC["KeyCap"]-}[space]${DC["NC"]-} to select apps, and ${DC["KeyCap"]-}[tab]${DC["NC"]-} to switch to the buttons at the bottom."
         local SelectedAppsDialogParams=(
-            --title "${DC["Title"]}${Title}"
+            --title "${DC["Title"]-}${Title}"
             --output-fd 1
         )
         local -i MenuTextLines
@@ -286,7 +286,7 @@ show_gauge() {
 
     local -a GaugeDialog=(
         "${GlobalDialogOptions[@]}"
-        --title "${DC["TitleSuccess"]}${GaugeTitle}"
+        --title "${DC["TitleSuccess"]-}${GaugeTitle}"
         --begin "${GaugeDialogStartRow}" "${DialogStartCol}"
         --gauge "${DialogGaugeText}"
         "${GaugeDialogRows}" "${DialogCols}"
@@ -294,7 +294,7 @@ show_gauge() {
     )
     local -a LogDialog=(
         "${GlobalDialogOptions[@]}"
-        --title "${DC["Title"]}Log Output"
+        --title "${DC["Title"]-}Log Output"
         --begin "${LogDialogStartRow}" "${DialogStartCol}"
         --keep-window
         --tailboxbg "${ProgressLog}"
@@ -352,7 +352,7 @@ init_gauge_text() {
             HeadingPadCols=$((HeadingCols - ${#HeadingText[index]}))
             local HeadingPad
             HeadingPad="$(printf "%${HeadingPadCols}s" '')"
-            DialogGaugeText+="${WaitingHighlight}${HeadingText[index]}${DC["NC"]}${HeadingPad} ${WaitingHighlight}[${WaitingText}]${DC["NC"]}\n"
+            DialogGaugeText+="${WaitingHighlight}${HeadingText[index]}${DC["NC"]-}${HeadingPad} ${WaitingHighlight}[${WaitingText}]${DC["NC"]-}\n"
         fi
         if [[ -n ${Command[index]} ]]; then
             local -i CommandCols=${#Command[index]}
@@ -371,7 +371,7 @@ init_gauge_text() {
 
             # Get the color codes to add to the app names
             local BeginHighlight="${WaitingHighlight}"
-            local EndHighlight="${DC["NC"]}"
+            local EndHighlight="${DC["NC"]-}"
             # Escape the backslahes to be used in sed
             BeginHighlight="${BeginHighlight//\\/\\\\}"
             EndHighlight="${EndHighlight//\\/\\\\}"
@@ -380,7 +380,7 @@ init_gauge_text() {
             FormattedAppNames="$(sed -E "s/\<([A-Za-z0-9_]+)\>/${BeginHighlight}\1${EndHighlight}/g" <<< "${FormattedAppNames}")"
 
             # Add the command name to the first line
-            DialogGaugeText+="${Indent}${WaitingHighlight}${Command[index]}${DC["NC"]}${Space}${FormattedAppNames:AppsColumnStart}\n"
+            DialogGaugeText+="${Indent}${WaitingHighlight}${Command[index]}${DC["NC"]-}${Space}${FormattedAppNames:AppsColumnStart}\n"
         fi
         #DialogGaugeText+="\n"
     done

--- a/.scripts/menu_config.sh
+++ b/.scripts/menu_config.sh
@@ -11,7 +11,7 @@ menu_config() {
 
     if run_script 'needs_appvars_create'; then
         coproc {
-            dialog_pipe "${DC[TitleSuccess]}Creating environment variables for added apps" "Please be patient, this can take a while.\n${DC[CommandLine]} ${APPLICATION_COMMAND} --env" "${DIALOGTIMEOUT}"
+            dialog_pipe "${DC["TitleSuccess"]-}Creating environment variables for added apps" "Please be patient, this can take a while.\n${DC["CommandLine"]-} ${APPLICATION_COMMAND} --env" "${DIALOGTIMEOUT}"
         }
         local -i DialogBox_PID=${COPROC_PID}
         local -i DialogBox_FD="${COPROC[1]}"
@@ -44,7 +44,7 @@ menu_config() {
     while true; do
         local -a ConfigChoiceDialog=(
             --output-fd 1
-            --title "${DC["Title"]}${Title}"
+            --title "${DC["Title"]-}${Title}"
             --ok-label "Select"
             --cancel-label "Back"
             --menu "What would you like to do?" 0 0 0
@@ -76,26 +76,26 @@ menu_config() {
                         ;;
                     "${OptionComposeDown}")
                         local Question
-                        Question="Would you like to ${DC["Highlight"]}Stop${DC[NC]} all containers, or bring all containers ${DC["Highlight"]}Down${DC[NC]}?\n\n${DC["Highlight"]}Stop${DC[NC]} will stop them, ${DC["Highlight"]}Down${DC[NC]} will stop and remove them."
+                        Question="Would you like to ${DC["Highlight"]-}Stop${DC["NC"]-} all containers, or bring all containers ${DC["Highlight"]-}Down${DC["NC"]-}?\n\n${DC["Highlight"]-}Stop${DC["NC"]-} will stop them, ${DC["Highlight"]-}Down${DC["NC"]-} will stop and remove them."
                         local -a YesNoDialog=(
-                            --title "${DC["TitleQuestion"]}Docker Compose"
+                            --title "${DC["TitleQuestion"]-}Docker Compose"
                             --no-collapse
                             --extra-button
                             --yes-label "Stop"
                             --extra-label "Down"
                             --no-label "Cancel"
-                            --yesno "${Question}${DC[NC]}"
+                            --yesno "${Question}${DC["NC"]-}"
                             "$((LINES - DC["WindowRowsAdjust"]))" "$((COLUMNS - DC["WindowColsAdjust"]))"
                         )
                         local -i YesNoDialogButtonPressed=0
                         _dialog_ "${YesNoDialog[@]}" || YesNoDialogButtonPressed=$?
                         case ${DIALOG_BUTTONS[YesNoDialogButtonPressed]-} in
                             OK) # Stop
-                                run_script_dialog "${DC["TitleSuccess"]}Docker Compose" "Stopping all running services.\n${DC["CommandLine"]} ${APPLICATION_COMMAND} --compose stop" "" \
+                                run_script_dialog "${DC["TitleSuccess"]-}Docker Compose" "Stopping all running services.\n${DC["CommandLine"]-} ${APPLICATION_COMMAND} --compose stop" "" \
                                     'docker_compose' "stop"
                                 ;;
                             EXTRA) # Down
-                                run_script_dialog "${DC["TitleSuccess"]}Docker Compose" "Stopping and removing all containers, networks, volumes, and images.\n${DC["CommandLine"]} ${APPLICATION_COMMAND} --compose down" "" \
+                                run_script_dialog "${DC["TitleSuccess"]-}Docker Compose" "Stopping and removing all containers, networks, volumes, and images.\n${DC["CommandLine"]-} ${APPLICATION_COMMAND} --compose down" "" \
                                     'docker_compose' "down"
                                 ;;
                             CANCEL | ESC) ;; # Cancel

--- a/.scripts/menu_config_apps.sh
+++ b/.scripts/menu_config_apps.sh
@@ -40,7 +40,7 @@ menu_config_apps() {
             local AppDescription
             AppDescription=$(run_script 'app_description' "${AppName}")
             if run_script 'app_is_user_defined' "${AppName}"; then
-                AppOptions+=("${AppName}" "${DC["ListAppUserDefined"]}${AppDescription}")
+                AppOptions+=("${AppName}" "${DC["ListAppUserDefined"]-}${AppDescription}")
             else
                 AppOptions+=("${AppName}" "${AppDescription}")
             fi
@@ -66,7 +66,7 @@ menu_config_apps() {
         WindowCols=$((WindowCols < WindowColsMax ? WindowCols : WindowColsMax))
         local -a AppChoiceDialog=(
             "${AppChoiceParams[@]}"
-            --title "${DC["Title"]}${Title}"
+            --title "${DC["Title"]-}${Title}"
             --ok-label "Select"
             --cancel-label "Done"
             --menu "${MenuText}"

--- a/.scripts/menu_config_vars.sh
+++ b/.scripts/menu_config_vars.sh
@@ -47,7 +47,7 @@ menu_config_vars() {
         # Add lines from global .env file to the dialog
         if [[ -n ${APPNAME-} ]]; then
             ((++LineNumber))
-            LineColor[LineNumber]="${DC[LineHeading]}"
+            LineColor[LineNumber]="${DC["LineHeading"]-}"
             CurrentValueOnLine[LineNumber]="*** ${COMPOSE_ENV} ***"
         fi
         run_script 'appvars_lines' "${APPNAME}" > "${CurrentGlobalEnvFile}"
@@ -65,9 +65,9 @@ menu_config_vars() {
                 local DefaultLine
                 DefaultLine="${VarName}=$(run_script 'var_default_value' "${VarName}")"
                 if [[ ${line} == "${DefaultLine}" ]]; then
-                    LineColor[LineNumber]="${DC[LineVar]}"
+                    LineColor[LineNumber]="${DC["LineVar"]-}"
                 else
-                    LineColor[LineNumber]="${DC[LineModifiedVar]}"
+                    LineColor[LineNumber]="${DC["LineModifiedVar"]-}"
                 fi
                 VarNameOnLine[LineNumber]="${VarName}"
                 if [[ -z ${FirstVarLine-} ]]; then
@@ -75,25 +75,25 @@ menu_config_vars() {
                 fi
             elif (grep -q -P '^\s*#' <<< "${line}"); then
                 # Line is a comment
-                LineColor[LineNumber]="${DC[LineComment]}"
+                LineColor[LineNumber]="${DC["LineComment"]-}"
             else
                 # Line is an unknowwn line
-                LineColor[LineNumber]="${DC[LineAddVariable]}"
+                LineColor[LineNumber]="${DC["LineAddVariable"]-}"
             fi
         done
         ((LineNumber++))
         local AddGlobalVariableLineNumber=${LineNumber}
         CurrentValueOnLine[LineNumber]="${AddVariableText}"
-        LineColor[LineNumber]="${DC[LineAddVariable]}"
+        LineColor[LineNumber]="${DC["LineAddVariable"]-}"
 
         if [[ -n ${APPNAME-} ]]; then
             # Add lines from appvar.env file to the dialog
             ((++LineNumber))
             CurrentValueOnLine[LineNumber]=""
-            LineColor[LineNumber]="${DC[LineOther]}"
+            LineColor[LineNumber]="${DC["LineOther"]-}"
             ((++LineNumber))
             CurrentValueOnLine[LineNumber]="*** $(run_script 'app_env_file' "${APPNAME}") ***"
-            LineColor[LineNumber]="${DC[LineHeading]}"
+            LineColor[LineNumber]="${DC["LineHeading"]-}"
             run_script 'appvars_lines' "${APPNAME}:" > "${CurrentAppEnvFile}"
             local -a CurrentAppEnvLines
             readarray -t CurrentAppEnvLines < <(
@@ -109,9 +109,9 @@ menu_config_vars() {
                     local DefaultLine
                     DefaultLine="${VarName}=$(run_script 'var_default_value' "${APPNAME}:${VarName}")"
                     if [[ ${line} == "${DefaultLine}" ]]; then
-                        LineColor[LineNumber]="${DC[LineVar]}"
+                        LineColor[LineNumber]="${DC["LineVar"]-}"
                     else
-                        LineColor[LineNumber]="${DC[LineModifiedVar]}"
+                        LineColor[LineNumber]="${DC["LineModifiedVar"]-}"
                     fi
                     VarNameOnLine[LineNumber]="${APPNAME}:${VarName}"
                     if [[ -z ${FirstVarLine-} ]]; then
@@ -119,16 +119,16 @@ menu_config_vars() {
                     fi
                 elif (grep -q -P '^\s*#' <<< "${line}"); then
                     # Line is a comment
-                    LineColor[LineNumber]="${DC[LineComment]}"
+                    LineColor[LineNumber]="${DC["LineComment"]-}"
                 else
                     # Line is an unknowwn line
-                    LineColor[LineNumber]="${DC[LineOther]}"
+                    LineColor[LineNumber]="${DC["LineOther"]-}"
                 fi
             done
             ((LineNumber++))
             local AddAppEnvVariableLineNumber=${LineNumber}
             CurrentValueOnLine[LineNumber]="${AddVariableText}"
-            LineColor[LineNumber]="${DC[LineAddVariable]}"
+            LineColor[LineNumber]="${DC["LineAddVariable"]-}"
         fi
 
         local TotalLines=$((10#${LineNumber}))
@@ -153,7 +153,7 @@ menu_config_vars() {
                 --ok-label "Select"
                 --extra-label "Remove"
                 --cancel-label "Done"
-                --title "${DC["Title"]}${Title}"
+                --title "${DC["Title"]-}${Title}"
                 --default-item "${LastLineChoice}"
                 --menu "${DialogHeading}" "$((LINES - DC["WindowRowsAdjust"]))" "$((COLUMNS - DC["WindowColsAdjust"]))" -1
                 "${LineOptions[@]}"
@@ -188,11 +188,11 @@ menu_config_vars() {
                         if [[ ${CleanVarName} == *":"* ]]; then
                             CleanVarName="${CleanVarName#*:}"
                         fi
-                        local Question="Do you really want to delete ${DC[Highlight]}${CleanVarName}${DC[NC]}?"
+                        local Question="Do you really want to delete ${DC["Highlight"]-}${CleanVarName}${DC["NC"]-}?"
                         if run_script 'question_prompt' N "${DialogHeading}\n\n${Question}\n" "Delete Variable" "" "Delete" "Back"; then
                             DialogHeading="$(run_script 'menu_heading' "${APPNAME-}" "${VarName}")"
                             coproc {
-                                dialog_pipe "${DC["TitleSuccess"]}Deleting Variable" "${DialogHeading}" "${DIALOGTIMEOUT}"
+                                dialog_pipe "${DC["TitleSuccess"]-}Deleting Variable" "${DialogHeading}" "${DIALOGTIMEOUT}"
                             }
                             local -i DialogBox_PID=${COPROC_PID}
                             local -i DialogBox_FD="${COPROC[1]}"

--- a/.scripts/menu_dialog_example.sh
+++ b/.scripts/menu_dialog_example.sh
@@ -23,27 +23,27 @@ menu_dialog_example() {
         if [[ -n ${Title-} ]]; then
             Title+=' '
         fi
-        Title+="${DC["${TitleStyle}"]}${TitleStyle}${DC[NC]}"
+        Title+="${DC["${TitleStyle}"]-}${TitleStyle}${DC["NC"]-}"
     done
 
     DialogText=''
-    DialogText+="${DC["Subtitle"]}${Message} and displaying sample${DC[NC]}\n"
-    DialogText+="  ${DC["CommandLine"]}${CommandLine}${DC[NC]}\n"
+    DialogText+="${DC["Subtitle"]-}${Message} and displaying sample${DC["NC"]-}\n"
+    DialogText+="  ${DC["CommandLine"]-}${CommandLine}${DC["NC"]-}\n"
     DialogText+="\n"
-    DialogText+="        Theme: ${DC[Heading]}${ThemeName}${DC[NC]}\n"
-    DialogText+="               ${DC["HeadingAppDescription"]}${ThemeDescription}${DC[NC]}\n"
+    DialogText+="        Theme: ${DC["Heading"]-}${ThemeName}${DC["NC"]-}\n"
+    DialogText+="               ${DC["HeadingAppDescription"]-}${ThemeDescription}${DC["NC"]-}\n"
     DialogText+="\n"
-    DialogText+=" Theme Author: ${DC[Heading]}${ThemeAuthor}${DC[NC]}\n"
+    DialogText+=" Theme Author: ${DC["Heading"]-}${ThemeAuthor}${DC["NC"]-}\n"
     DialogText+="\n"
-    DialogText+="Final Heading: ${DC["HeadingValue"]}AppName${DC[NC]}"
-    DialogText+=" ${DC["HeadingTag"]}[*HeadingTag*]${DC[NC]} ${DC["HeadingTag"]}(HeadingTag)${DC[NC]}\n"
+    DialogText+="Final Heading: ${DC["HeadingValue"]-}AppName${DC["NC"]-}"
+    DialogText+=" ${DC["HeadingTag"]-}[*HeadingTag*]${DC["NC"]-} ${DC["HeadingTag"]-}(HeadingTag)${DC["NC"]-}\n"
     DialogText+="\n"
-    DialogText+="     Key Caps: ${DC["KeyCap"]}[up]${DC[NC]} ${DC["KeyCap"]}[down]${DC[NC]} ${DC["KeyCap"]}[left]${DC[NC]} ${DC["KeyCap"]}[right]${DC[NC]}\n"
+    DialogText+="     Key Caps: ${DC["KeyCap"]-}[up]${DC["NC"]-} ${DC["KeyCap"]-}[down]${DC["NC"]-} ${DC["KeyCap"]-}[left]${DC["NC"]-} ${DC["KeyCap"]-}[right]${DC["NC"]-}\n"
     DialogText+="\n"
     DialogText+="Normal text\n"
-    DialogText+="${DC["Highlight"]}Highlighted text${DC[NC]}\n"
+    DialogText+="${DC["Highlight"]-}Highlighted text${DC["NC"]-}\n"
 
-    local Helpline="This is a sample help line with ${DC["Highlight"]}highlighted${DC[NC]} text."
+    local Helpline="This is a sample help line with ${DC["Highlight"]-}highlighted${DC["NC"]-} text."
 
     local -i MenuTextLines
     MenuTextLines="$(
@@ -57,14 +57,14 @@ menu_dialog_example() {
     local -a DialogOptions=(
         "" "" "${Helpline}"
         "BuiltInApp" "Built In App Description" "${Helpline}"
-        "UserDefinedApp" "${DC["ListAppUserDefined"]}User Defined App Description" "${Helpline}"
+        "UserDefinedApp" "${DC["ListAppUserDefined"]-}User Defined App Description" "${Helpline}"
         "" "" "${Helpline}"
-        "Variable File Heading" "${DC["LineHeading"]}*** ${COMPOSE_ENV} ***" "${Helpline}"
-        "Variable File Comment" "${DC["LineComment"]}### A comment in the variable file" "${Helpline}"
-        "Variable File Other" "${DC["LineOther"]}Any other line in the file" "${Helpline}"
-        "Variable File Variable" "${DC["LineVar"]}VarName='Default Value'" "${Helpline}"
-        "Variable File Mofified" "${DC["LineModifiedVar"]}VarName='Modified Value'" "${Helpline}"
-        "Variable File Add" "${DC["LineAddVariable"]}<ADD VARIABLE>" "${Helpline}"
+        "Variable File Heading" "${DC["LineHeading"]-}*** ${COMPOSE_ENV} ***" "${Helpline}"
+        "Variable File Comment" "${DC["LineComment"]-}### A comment in the variable file" "${Helpline}"
+        "Variable File Other" "${DC["LineOther"]-}Any other line in the file" "${Helpline}"
+        "Variable File Variable" "${DC["LineVar"]-}VarName='Default Value'" "${Helpline}"
+        "Variable File Mofified" "${DC["LineModifiedVar"]-}VarName='Modified Value'" "${Helpline}"
+        "Variable File Add" "${DC["LineAddVariable"]-}<ADD VARIABLE>" "${Helpline}"
         "" "" "${Helpline}"
         "" "" "${Helpline}"
         "" "" "${Helpline}"

--- a/.scripts/menu_display_options.sh
+++ b/.scripts/menu_display_options.sh
@@ -19,7 +19,7 @@ menu_display_options() {
     while true; do
         local -a ChoiceDialog=(
             --output-fd 1
-            --title "${DC["Title"]}${Title}"
+            --title "${DC["Title"]-}${Title}"
             --ok-label "Select"
             --cancel-label "Back"
             --menu "What would you like to do?" 0 0 0

--- a/.scripts/menu_display_options_general.sh
+++ b/.scripts/menu_display_options_general.sh
@@ -43,7 +43,7 @@ menu_display_options_general() {
         done
         local -a ChoiceDialog=(
             --output-fd 1
-            --title "${DC["Title"]}${Title}"
+            --title "${DC["Title"]-}${Title}"
             --ok-label "Select"
             --cancel-label "Back"
             --separate-output

--- a/.scripts/menu_display_options_theme.sh
+++ b/.scripts/menu_display_options_theme.sh
@@ -38,7 +38,7 @@ menu_display_options_theme() {
         done
         local -a ChoiceDialog=(
             --output-fd 1
-            --title "${DC["Title"]}${Title}"
+            --title "${DC["Title"]-}${Title}"
             --ok-label "Select"
             --cancel-label "Back"
             --radiolist "Select the theme to apply." 0 0 0

--- a/.scripts/menu_heading.sh
+++ b/.scripts/menu_heading.sh
@@ -16,10 +16,10 @@ menu_heading() {
         [CurrentValue]="Current Value: "
     )
     local -A Tag=(
-        [AppDeprecated]="${DC[HeadingTag]}[*DEPRECATED*]${DC[NC]}"
-        [AppDisabled]="${DC[HeadingTag]}(Disabled)${DC[NC]}"
-        [AppUserDefined]="${DC[HeadingTag]}(User Defined)${DC[NC]}"
-        [VarUserDefined]="${DC[HeadingTag]}(User Defined)${DC[NC]}"
+        [AppDeprecated]="${DC["HeadingTag"]-}[*DEPRECATED*]${DC["NC"]-}"
+        [AppDisabled]="${DC["HeadingTag"]-}(Disabled)${DC["NC"]-}"
+        [AppUserDefined]="${DC["HeadingTag"]-}(User Defined)${DC["NC"]-}"
+        [VarUserDefined]="${DC["HeadingTag"]-}(User Defined)${DC["NC"]-}"
     )
     local -i LabelWidth=0
     for LabelText in "${Label[@]}"; do
@@ -92,21 +92,21 @@ menu_heading() {
         fi
     fi
 
-    local Highlight="${DC[HeadingValue]}"
+    local Highlight="${DC["HeadingValue"]-}"
     for LabelName in CurrentValue OriginalValue Variable Filename Application; do
         case "${LabelName}" in
             Application)
                 if [[ -n ${AppName-} ]]; then
-                    Heading[Application]="${DC[NC]}${Label[Application]}${Highlight}${AppName}${DC[NC]}"
+                    Heading[Application]="${DC["NC"]-}${Label[Application]}${Highlight}${AppName}${DC["NC"]-}"
                     if [[ ${AppIsValid-} == "Y" ]]; then
                         if [[ ${AppIsDeprecated-} == "Y" ]]; then
-                            Heading[Application]+=" ${DC[HeadingTag]}${Tag[AppDeprecated]}${DC[NC]}"
+                            Heading[Application]+=" ${DC["HeadingTag"]-}${Tag[AppDeprecated]}${DC["NC"]-}"
                         fi
                         if [[ ${AppIsDisabled-} == "Y" ]]; then
-                            Heading[Application]+=" ${DC[HeadingTag]}${Tag[AppDisabled]}${DC[NC]}"
+                            Heading[Application]+=" ${DC["HeadingTag"]-}${Tag[AppDisabled]}${DC["NC"]-}"
                         fi
                         if [[ ${AppIsUserDefined-} == "Y" ]]; then
-                            Heading[Application]+=" ${DC[HeadingTag]}${Tag[AppUserDefined]}${DC[NC]}"
+                            Heading[Application]+=" ${DC["HeadingTag"]-}${Tag[AppUserDefined]}${DC["NC"]-}"
                         fi
                         Heading[Application]+="\n"
 
@@ -117,39 +117,39 @@ menu_heading() {
                         local -i TextWidth=$((ScreenCols - DC["WindowColsAdjust"] - DC["TextColsAdjust"] - LabelWidth))
                         local -a AppDesciptionArray
                         readarray -t AppDesciptionArray < <(fmt -w ${TextWidth} <<< "${AppDescription}")
-                        Heading[Application]+="$(printf "${Indent}${DC[HeadingAppDescription]}%s${DC[NC]}\n" "${AppDesciptionArray[@]-}")"
+                        Heading[Application]+="$(printf "${Indent}${DC[HeadingAppDescription]}%s${DC["NC"]-}\n" "${AppDesciptionArray[@]-}")"
                         Heading[Application]+="\n"
                     fi
                     Heading[Application]+="\n"
-                    Highlight="${DC[Heading]}"
+                    Highlight="${DC["Heading"]-}"
                 fi
                 ;;
             Filename)
                 if [[ -n ${VarFile-} ]]; then
-                    Heading[Filename]="${DC[NC]}${Label[Filename]}${Highlight}${VarFile}${DC[NC]}\n"
-                    Highlight="${DC[Heading]}"
+                    Heading[Filename]="${DC["NC"]-}${Label[Filename]}${Highlight}${VarFile}${DC["NC"]-}\n"
+                    Highlight="${DC["Heading"]-}"
                 fi
                 ;;
             Variable)
                 if [[ -n ${VarName-} ]]; then
-                    Heading[Variable]="${DC[NC]}${Label[Variable]}${Highlight}${VarName}${DC[NC]}"
+                    Heading[Variable]="${DC["NC"]-}${Label[Variable]}${Highlight}${VarName}${DC["NC"]-}"
                     if [[ ${VarIsUserDefined-} == "Y" ]]; then
-                        Heading[Variable]+=" ${DC[HeadingTag]}${Tag[VarUserDefined]}${DC[NC]}"
+                        Heading[Variable]+=" ${DC["HeadingTag"]-}${Tag[VarUserDefined]}${DC["NC"]-}"
                     fi
                     Heading[Variable]+="\n"
-                    Highlight="${DC[Heading]}"
+                    Highlight="${DC["Heading"]-}"
                 fi
                 ;;
             OriginalValue)
                 if [[ -n ${OriginalValue-} ]]; then
-                    Heading[OriginalValue]="\n${Label[OriginalValue]}${Highlight}${OriginalValue}${DC[NC]}\n"
-                    Highlight="${DC[Heading]}"
+                    Heading[OriginalValue]="\n${Label[OriginalValue]}${Highlight}${OriginalValue}${DC["NC"]-}\n"
+                    Highlight="${DC["Heading"]-}"
                 fi
                 ;;
             CurrentValue)
                 if [[ -n ${CurrentValue-} ]]; then
-                    Heading[CurrentValue]="${Label[CurrentValue]}${Highlight}${CurrentValue}${DC[NC]}\n"
-                    Highlight="${DC[Heading]}"
+                    Heading[CurrentValue]="${Label[CurrentValue]}${Highlight}${CurrentValue}${DC["NC"]-}\n"
+                    Highlight="${DC["Heading"]-}"
                 fi
                 ;;
         esac

--- a/.scripts/menu_main.sh
+++ b/.scripts/menu_main.sh
@@ -23,7 +23,7 @@ menu_main() {
     while true; do
         local -a MainChoiceDialog=(
             --output-fd 1
-            --title "${DC["Title"]}${Title}"
+            --title "${DC["Title"]-}${Title}"
             --ok-label "Select"
             --cancel-label "Exit"
             --menu "What would you like to do?" 0 0 0

--- a/.scripts/menu_value_prompt.sh
+++ b/.scripts/menu_value_prompt.sh
@@ -12,7 +12,7 @@ menu_value_prompt() {
 
     local APPNAME AppName
 
-    local VarDeletedTag="${DC[Highlight]}[*DELETED*]"
+    local VarDeletedTag="${DC["Highlight"]-}[*DELETED*]"
 
     local Title
     local CleanVarName="${VarName}"
@@ -58,7 +58,7 @@ menu_value_prompt() {
         GLOBAL)
             case "${VarName}" in
                 DOCKER_GID)
-                    ValueDescription="\n\n This should be the Docker group ID. If you are unsure, select ${DC[Highlight]}${SystemValueOption}${DC[NC]}."
+                    ValueDescription="\n\n This should be the Docker group ID. If you are unsure, select ${DC["Highlight"]-}${SystemValueOption}${DC["NC"]-}."
                     PossibleOptions+=(
                         "${SystemValueOption}"
                     )
@@ -67,7 +67,7 @@ menu_value_prompt() {
                     )
                     ;;
                 DOCKER_HOSTNAME)
-                    ValueDescription="\n\n This should be your system hostname. If you are unsure, select ${DC[Highlight]}${SystemValueOption}${DC[NC]}."
+                    ValueDescription="\n\n This should be your system hostname. If you are unsure, select ${DC["Highlight"]-}${SystemValueOption}${DC["NC"]-}."
                     PossibleOptions+=(
                         "${SystemValueOption}"
                     )
@@ -103,7 +103,7 @@ menu_value_prompt() {
                     )
                     ;;
                 PGID)
-                    ValueDescription="\n\n This should be your user group ID. If you are unsure, select ${DC[Highlight]}${SystemValueOption}${DC[NC]}."
+                    ValueDescription="\n\n This should be your user group ID. If you are unsure, select ${DC["Highlight"]-}${SystemValueOption}${DC["NC"]-}."
                     PossibleOptions+=(
                         "${SystemValueOption}"
                     )
@@ -112,7 +112,7 @@ menu_value_prompt() {
                     )
                     ;;
                 PUID)
-                    ValueDescription="\n\n This should be your user account ID. If you are unsure, select ${DC[Highlight]}${SystemValueOption}${DC[NC]}."
+                    ValueDescription="\n\n This should be your user account ID. If you are unsure, select ${DC["Highlight"]-}${SystemValueOption}${DC["NC"]-}."
                     PossibleOptions+=(
                         "${SystemValueOption}"
                     )
@@ -143,7 +143,7 @@ menu_value_prompt() {
         APP)
             case "${VarName}" in
                 "${APPNAME}__ENABLED")
-                    ValueDescription="\n\n This is used to set the application as enabled or disabled. If this variable is removed, the application will not be controlled by ${APPLICATION_NAME}. Must be ${DC[Highlight]}true${DC[NC]} or ${DC[Highlight]}false${DC[NC]}."
+                    ValueDescription="\n\n This is used to set the application as enabled or disabled. If this variable is removed, the application will not be controlled by ${APPLICATION_NAME}. Must be ${DC["Highlight"]-}true${DC["NC"]-} or ${DC["Highlight"]-}false${DC["NC"]-}."
                     PossibleOptions+=(
                         "Enabled"
                         "Disabled"
@@ -156,7 +156,7 @@ menu_value_prompt() {
                     )
                     ;;
                 "${APPNAME}__NETWORK_MODE")
-                    ValueDescription="\n\n Network Mode is usually left blank but can also be ${DC[Highlight]}bridge${DC[NC]}, ${DC[Highlight]}host${DC[NC]}, ${DC[Highlight]}none${DC[NC]}, ${DC[Highlight]}service:<appname>${DC[NC]}, or ${DC[Highlight]}container:<appname>${DC[NC]}."
+                    ValueDescription="\n\n Network Mode is usually left blank but can also be ${DC["Highlight"]-}bridge${DC["NC"]-}, ${DC["Highlight"]-}host${DC["NC"]-}, ${DC["Highlight"]-}none${DC["NC"]-}, ${DC["Highlight"]-}service:<appname>${DC["NC"]-}, or ${DC["Highlight"]-}container:<appname>${DC["NC"]-}."
                     PossibleOptions+=(
                         "${DefaultValueOption}"
                         "Bridge Network"
@@ -166,11 +166,11 @@ menu_value_prompt() {
                         "Use PrivoxyVPN"
                     )
                     OptionHelpLine+=(
-                        ["Bridge Network"]="Connects ${DC[Highlight]}${AppName}${DC[NC]} to the internal Docker bridge network. Same as leaving the value empty."
-                        ["Host Network"]="Connects ${DC[Highlight]}${AppName}${DC[NC]} to the host OS's network."
-                        ["No Network"]="Leaves ${DC[Highlight]}${AppName}${DC[NC]} without a network connection."
-                        ["Use Gluetun"]="Connects ${DC[Highlight]}${AppName}${DC[NC]} to the VPN running in the ${DC[Highlight]}Gluetun${DC[NC]} container if running."
-                        ["Use PrivoxyVPN"]="Connects ${DC[Highlight]}${AppName}${DC[NC]} to the VPN running in the ${DC[Highlight]}PrivoxyVPN${DC[NC]} container if running."
+                        ["Bridge Network"]="Connects ${DC["Highlight"]-}${AppName}${DC["NC"]-} to the internal Docker bridge network. Same as leaving the value empty."
+                        ["Host Network"]="Connects ${DC["Highlight"]-}${AppName}${DC["NC"]-} to the host OS's network."
+                        ["No Network"]="Leaves ${DC["Highlight"]-}${AppName}${DC["NC"]-} without a network connection."
+                        ["Use Gluetun"]="Connects ${DC["Highlight"]-}${AppName}${DC["NC"]-} to the VPN running in the ${DC["Highlight"]-}Gluetun${DC["NC"]-} container if running."
+                        ["Use PrivoxyVPN"]="Connects ${DC["Highlight"]-}${AppName}${DC["NC"]-} to the VPN running in the ${DC["Highlight"]-}PrivoxyVPN${DC["NC"]-} container if running."
                     )
                     OptionValue+=(
                         ["${DefaultValueOption}"]="$(run_script 'var_default_value' "${VarName}")"
@@ -182,7 +182,7 @@ menu_value_prompt() {
                     )
                     ;;
                 "${APPNAME}__RESTART")
-                    ValueDescription="\n\n Restart is usually ${DC[Highlight]}unless-stopped${DC[NC]} but can also be ${DC[Highlight]}no${DC[NC]}, ${DC[Highlight]}always${DC[NC]}, or ${DC[Highlight]}on-failure${DC[NC]}."
+                    ValueDescription="\n\n Restart is usually ${DC["Highlight"]-}unless-stopped${DC["NC"]-} but can also be ${DC["Highlight"]-}no${DC["NC"]-}, ${DC["Highlight"]-}always${DC["NC"]-}, or ${DC["Highlight"]-}on-failure${DC["NC"]-}."
                     PossibleOptions+=(
                         "${DefaultValueOption}"
                         "Restart Unless Stopped"
@@ -224,7 +224,7 @@ menu_value_prompt() {
                     ;;
                 *)
                     if [[ ${VarName} =~ ^${APPNAME}__PORT_[0-9]+$ ]]; then
-                        ValueDescription="\n\n Must be an unused port between ${DC[Highlight]}0${DC[NC]} and ${DC[Highlight]}65535${DC[NC]}."
+                        ValueDescription="\n\n Must be an unused port between ${DC["Highlight"]-}0${DC["NC"]-} and ${DC["Highlight"]-}65535${DC["NC"]-}."
                         PossibleOptions+=(
                             "${DefaultValueOption}"
                         )
@@ -291,10 +291,10 @@ menu_value_prompt() {
         local DialogHeading
         local CurrentValueHeading="${OptionValue["${CurrentValueOption}"]:-${VarDeletedTag}}"
         DialogHeading="$(run_script 'menu_heading' "${APPNAME}" "${VarName}" "${OptionValue["${OriginalValueOption}"]-}" "${CurrentValueHeading}")"
-        local SelectValueMenuText="${DialogHeading}\n\nWhat would you like set for ${DC[Highlight]}${CleanVarName}${DC[NC]}?${ValueDescription}"
+        local SelectValueMenuText="${DialogHeading}\n\nWhat would you like set for ${DC["Highlight"]-}${CleanVarName}${DC["NC"]-}?${ValueDescription}"
         local SelectValueDialogParams=(
             --output-fd 1
-            --title "${DC["Title"]}${Title}"
+            --title "${DC["Title"]-}${Title}"
             --item-help
         )
         local -i MenuTextLines
@@ -352,7 +352,7 @@ menu_value_prompt() {
                                     ;;
                                 *)
                                     ValueValid="false"
-                                    dialog_error "${Title}" "${DialogHeading}\n${DC[Highlight]}${OptionValue["${CurrentValueOption}"]}${DC[NC]} is not ${DC[Highlight]}true${DC[NC]}/${DC[Highlight]}on${DC[NC]}/${DC[Highlight]}yes${DC[NC]} or ${DC[Highlight]}false${DC[NC]}/${DC[Highlight]}off${DC[NC]}/${DC[Highlight]}no${DC[NC]}. Please try setting ${DC[Highlight]}${CleanVarName}${DC[NC]} again."
+                                    dialog_error "${Title}" "${DialogHeading}\n${DC["Highlight"]-}${OptionValue["${CurrentValueOption}"]}${DC["NC"]-} is not ${DC["Highlight"]-}true${DC["NC"]-}/${DC["Highlight"]-}on${DC["NC"]-}/${DC["Highlight"]-}yes${DC["NC"]-} or ${DC["Highlight"]-}false${DC["NC"]-}/${DC["Highlight"]-}off${DC["NC"]-}/${DC["Highlight"]-}no${DC["NC"]-}. Please try setting ${DC["Highlight"]-}${CleanVarName}${DC["NC"]-} again."
                                     ;;
                             esac
                             ;;
@@ -363,7 +363,7 @@ menu_value_prompt() {
                                     ;;
                                 *)
                                     ValueValid="false"
-                                    dialog_error "${Title}" "${DialogHeading}\n\n${DC[Highlight]}${OptionValue["${CurrentValueOption}"]}${DC[NC]} is not a valid network mode. Please try setting ${DC[Highlight]}${CleanVarName}${DC[NC]} again."
+                                    dialog_error "${Title}" "${DialogHeading}\n\n${DC["Highlight"]-}${OptionValue["${CurrentValueOption}"]}${DC["NC"]-} is not a valid network mode. Please try setting ${DC["Highlight"]-}${CleanVarName}${DC["NC"]-} again."
                                     ;;
                             esac
                             ;;
@@ -374,40 +374,40 @@ menu_value_prompt() {
                                     ;;
                                 *)
                                     ValueValid="false"
-                                    dialog_error "${Title}" "${DialogHeading}\n\n${DC[Highlight]}${OptionValue["${CurrentValueOption}"]}${DC[NC]} is not a valid restart value. Please try setting ${DC[Highlight]}${CleanVarName}${DC[NC]} again."
+                                    dialog_error "${Title}" "${DialogHeading}\n\n${DC["Highlight"]-}${OptionValue["${CurrentValueOption}"]}${DC["NC"]-} is not a valid restart value. Please try setting ${DC["Highlight"]-}${CleanVarName}${DC["NC"]-} again."
                                     ;;
                             esac
                             ;;
                         "${APPNAME}__VOLUME_"*)
                             if [[ ${StrippedValue} == "/" ]]; then
-                                dialog_error "${Title}" "${DialogHeading}\n\nCannot use ${DC[Highlight]}/${DC[NC]} for ${DC[Highlight]}${CleanVarName}${DC[NC]}. Please select another folder."
+                                dialog_error "${Title}" "${DialogHeading}\n\nCannot use ${DC["Highlight"]-}/${DC["NC"]-} for ${DC["Highlight"]-}${CleanVarName}${DC["NC"]-}. Please select another folder."
                                 ValueValid="false"
                             elif [[ ${StrippedValue} == *~* ]]; then
                                 local CORRECTED_DIR="${OptionValue["${CurrentValueOption}"]//\~/"${DETECTED_HOMEDIR}"}"
-                                if run_script 'question_prompt' Y "${DialogHeading}\n\nCannot use the ${DC[Highlight]}~${DC[NC]} shortcut in ${DC[Highlight]}${CleanVarName}${DC[NC]}. Would you like to use ${DC[Highlight]}${CORRECTED_DIR}${DC[NC]} instead?" "${Title}"; then
+                                if run_script 'question_prompt' Y "${DialogHeading}\n\nCannot use the ${DC["Highlight"]-}~${DC["NC"]-} shortcut in ${DC["Highlight"]-}${CleanVarName}${DC["NC"]-}. Would you like to use ${DC["Highlight"]-}${CORRECTED_DIR}${DC["NC"]-} instead?" "${Title}"; then
                                     OptionValue["${CurrentValueOption}"]="${CORRECTED_DIR}"
                                     ValueValid="false"
                                     dialog_success "${Title}" "Returning to the previous menu to confirm selection."
                                 else
                                     ValueValid="false"
-                                    dialog_error "${Title}" "${DialogHeading}\n\nCannot use the ${DC[Highlight]}~${DC[NC]} shortcut in ${DC[Highlight]}${CleanVarName}${DC[DC]}. Please select another folder."
+                                    dialog_error "${Title}" "${DialogHeading}\n\nCannot use the ${DC["Highlight"]-}~${DC["NC"]-} shortcut in ${DC["Highlight"]-}${CleanVarName}${DC[DC]}. Please select another folder."
                                 fi
                             elif [[ -d ${StrippedValue} ]]; then
                                 if run_script 'question_prompt' Y "${DialogHeading}\n\nWould you like to set permissions on ${OptionValue["${CurrentValueOption}"]} ?" "${Title}"; then
-                                    run_script_dialog "Setting Permissions" "${DC[Heading]}${StrippedValue}${DC[NC]}" "${DIALOGTIMEOUT}" \
+                                    run_script_dialog "Setting Permissions" "${DC["Heading"]-}${StrippedValue}${DC["NC"]-}" "${DIALOGTIMEOUT}" \
                                         'set_permissions' "${StrippedValue}"
                                 fi
                                 ValueValid="true"
                             else
-                                if run_script 'question_prompt' Y "${DialogHeading}\n\n${DC[Highlight]}${OptionValue["${CurrentValueOption}"]}${DC[NC]} is not a valid path. Would you like to attempt to create it?" "${Title}"; then
+                                if run_script 'question_prompt' Y "${DialogHeading}\n\n${DC["Highlight"]-}${OptionValue["${CurrentValueOption}"]}${DC["NC"]-} is not a valid path. Would you like to attempt to create it?" "${Title}"; then
                                     {
                                         mkdir -p "${StrippedValue}" || fatal "Failed to make directory.\nFailing command: ${C["FailingCommand"]}mkdir -p \"${StrippedValue}\""
                                         run_script 'set_permissions' "${StrippedValue}"
                                     } |& dialog_pipe "Creating folder and settings permissions" "${OptionValue["${CurrentValueOption}"]}" "${DIALOGTIMEOUT}"
-                                    dialog_error "${DC["TitleSuccess"]}${Title}" --msgbox "${DC[Highlight]}${OptionValue["${CurrentValueOption}"]}${DC[NC]} folder was created successfully." "$((LINES - DC["WindowRowsAdjust"]))" "$((COLUMNS - DC["WindowColsAdjust"]))"
+                                    dialog_error "${DC["TitleSuccess"]-}${Title}" --msgbox "${DC["Highlight"]-}${OptionValue["${CurrentValueOption}"]}${DC["NC"]-} folder was created successfully." "$((LINES - DC["WindowRowsAdjust"]))" "$((COLUMNS - DC["WindowColsAdjust"]))"
                                     ValueValid="true"
                                 else
-                                    dialog_error "${Title}" "${DialogHeading}\n\n${DC[Highlight]}${OptionValue["${CurrentValueOption}"]}${DC[NC]} is not a valid path. Please try setting ${DC[Highlight]}${CleanVarName}${DC[NC]} again."
+                                    dialog_error "${Title}" "${DialogHeading}\n\n${DC["Highlight"]-}${OptionValue["${CurrentValueOption}"]}${DC["NC"]-} is not a valid path. Please try setting ${DC["Highlight"]-}${CleanVarName}${DC["NC"]-} again."
                                     ValueValid="false"
                                 fi
                             fi
@@ -415,7 +415,7 @@ menu_value_prompt() {
                         P[GU]ID)
                             if [[ ${StrippedValue} =~ ^[0-9]+$ ]]; then
                                 if [[ ${StrippedValue} -eq 0 ]]; then
-                                    if run_script 'question_prompt' Y "${DialogHeading}\n\nRunning as ${DC[Highlight]}root${DC[NC]} is not recommended. Would you like to select a different ID?" "${Title}" ""; then
+                                    if run_script 'question_prompt' Y "${DialogHeading}\n\nRunning as ${DC["Highlight"]-}root${DC["NC"]-} is not recommended. Would you like to select a different ID?" "${Title}" ""; then
                                         ValueValid="false"
                                     else
                                         ValueValid="true"
@@ -424,7 +424,7 @@ menu_value_prompt() {
                                     ValueValid="true"
                                 fi
                             else
-                                dialog_error "${Title}" "${DialogHeading}\n\n${DC[Highlight]}${OptionValue["${CurrentValueOption}"]}${DC[NC]} is not a valid ${CleanVarName}. Please try setting ${DC[Highlight]}${CleanVarName}${DC[NC]} again."
+                                dialog_error "${Title}" "${DialogHeading}\n\n${DC["Highlight"]-}${OptionValue["${CurrentValueOption}"]}${DC["NC"]-} is not a valid ${CleanVarName}. Please try setting ${DC["Highlight"]-}${CleanVarName}${DC["NC"]-} again."
                                 ValueValid="false"
                             fi
                             ;;
@@ -434,7 +434,7 @@ menu_value_prompt() {
                                     ValueValid="true"
                                 else
                                     ValueValid="false"
-                                    dialog_error "${Title}" "${DialogHeading}\n\n${DC[Highlight]}${OptionValue["${CurrentValueOption}"]}${DC[NC]} is not a valid port. Please try setting ${DC[Highlight]}${CleanVarName}${DC[NC]} again."
+                                    dialog_error "${Title}" "${DialogHeading}\n\n${DC["Highlight"]-}${OptionValue["${CurrentValueOption}"]}${DC["NC"]-} is not a valid port. Please try setting ${DC["Highlight"]-}${CleanVarName}${DC["NC"]-} again."
                                 fi
                             else
                                 ValueValid="true"
@@ -444,10 +444,10 @@ menu_value_prompt() {
                 fi
                 if ${ValueValid}; then
                     if [[ -z ${OptionValue["${CurrentValueOption}"]-} ]]; then
-                        if run_script 'question_prompt' N "${DialogHeading}\n\nDo you really want to delete ${DC[Highlight]}${CleanVarName}${DC[NC]}?\n" "Delete Variable" "" "Delete" "Back"; then
+                        if run_script 'question_prompt' N "${DialogHeading}\n\nDo you really want to delete ${DC["Highlight"]-}${CleanVarName}${DC["NC"]-}?\n" "Delete Variable" "" "Delete" "Back"; then
                             # Value is empty, delete the variable
                             coproc {
-                                dialog_pipe "${DC["TitleSuccess"]}Deleting Variable" "${DialogHeading}" "${DIALOGTIMEOUT}"
+                                dialog_pipe "${DC["TitleSuccess"]-}Deleting Variable" "${DialogHeading}" "${DIALOGTIMEOUT}"
                             }
                             local -i DialogBox_PID=${COPROC_PID}
                             local -i DialogBox_FD="${COPROC[1]}"
@@ -472,10 +472,10 @@ menu_value_prompt() {
                             return 0
                         fi
                     elif [[ ${OptionValue["${CurrentValueOption}"]-} == "${OptionValue["${OriginalValueOption}"]-}" ]]; then
-                        if run_script 'question_prompt' N "${DialogHeading}\n\nThe value of ${DC[Highlight]}${CleanVarName}${DC[NC]} has not been changed, exit anyways?\n" "Save Variable" "" "Done" "Back"; then
+                        if run_script 'question_prompt' N "${DialogHeading}\n\nThe value of ${DC["Highlight"]-}${CleanVarName}${DC["NC"]-} has not been changed, exit anyways?\n" "Save Variable" "" "Done" "Back"; then
                             # Value has not changed, confirm exiting
                             coproc {
-                                dialog_pipe "${DC["TitleSuccess"]}Canceling Variable Edit" "${DialogHeading}" "${DIALOGTIMEOUT}"
+                                dialog_pipe "${DC["TitleSuccess"]-}Canceling Variable Edit" "${DialogHeading}" "${DIALOGTIMEOUT}"
                             }
                             local -i DialogBox_PID=${COPROC_PID}
                             local -i DialogBox_FD="${COPROC[1]}"
@@ -499,10 +499,10 @@ menu_value_prompt() {
                             return 0
                         fi
                     else
-                        if run_script 'question_prompt' N "${DialogHeading}\n\nWould you like to save ${DC[Highlight]}${CleanVarName}${DC[NC]}?\n" "Save Variable" "" "Save" "Back"; then
+                        if run_script 'question_prompt' N "${DialogHeading}\n\nWould you like to save ${DC["Highlight"]-}${CleanVarName}${DC["NC"]-}?\n" "Save Variable" "" "Save" "Back"; then
                             # Value is valid, save it and exit
                             coproc {
-                                dialog_pipe "${DC["TitleSuccess"]}Saving Variable" "${DialogHeading}" "${DIALOGTIMEOUT}"
+                                dialog_pipe "${DC["TitleSuccess"]-}Saving Variable" "${DialogHeading}" "${DIALOGTIMEOUT}"
                             }
                             local -i DialogBox_PID=${COPROC_PID}
                             local -i DialogBox_FD="${COPROC[1]}"

--- a/.scripts/menu_value_prompt.sh
+++ b/.scripts/menu_value_prompt.sh
@@ -390,7 +390,7 @@ menu_value_prompt() {
                                     dialog_success "${Title}" "Returning to the previous menu to confirm selection."
                                 else
                                     ValueValid="false"
-                                    dialog_error "${Title}" "${DialogHeading}\n\nCannot use the ${DC["Highlight"]-}~${DC["NC"]-} shortcut in ${DC["Highlight"]-}${CleanVarName}${DC[DC]}. Please select another folder."
+                                    dialog_error "${Title}" "${DialogHeading}\n\nCannot use the ${DC["Highlight"]-}~${DC["NC"]-} shortcut in ${DC["Highlight"]-}${CleanVarName}${DC["NC"]-}. Please select another folder."
                                 fi
                             elif [[ -d ${StrippedValue} ]]; then
                                 if run_script 'question_prompt' Y "${DialogHeading}\n\nWould you like to set permissions on ${OptionValue["${CurrentValueOption}"]} ?" "${Title}"; then

--- a/.scripts/question_prompt.sh
+++ b/.scripts/question_prompt.sh
@@ -50,9 +50,9 @@ question_prompt() {
                 --no-collapse
                 --yes-label "${YesButton}"
                 --no-label "${NoButton}"
-                --title "${DC[TitleQuestion]}${Title}${DC[NC]}"
+                --title "${DC["TitleQuestion"]-}${Title}${DC["NC"]-}"
                 ${DIALOG_DEFAULT-}
-                --yesno "${DC[NC]}${DialogQuestion}${DC[NC]}"
+                --yesno "${DC["NC"]-}${DialogQuestion}${DC["NC"]-}"
                 "$((LINES - DC["WindowRowsAdjust"]))" "$((COLUMNS - DC["WindowColsAdjust"]))"
             )
             local -i YesNoDialogButtonPressed=0

--- a/.scripts/run_install.sh
+++ b/.scripts/run_install.sh
@@ -12,14 +12,14 @@ run_install() {
             {
                 notice "${YesNotice}"
                 run_install_commands
-            } |& dialog_pipe "${DC[TitleSuccess]}${Title}" "${YesNotice}\n${DC[CommandLine]} ${APPLICATION_COMMAND} --install"
+            } |& dialog_pipe "${DC["TitleSuccess"]-}${Title}" "${YesNotice}\n${DC["CommandLine"]-} ${APPLICATION_COMMAND} --install"
         else
             notice "${YesNotice}"
             run_install_commands
         fi
     else
         if use_dialog_box; then
-            notice "${NoNotice}" |& dialog_pipe "${DC[TitleError]}${Title}" "${NoNotice}"
+            notice "${NoNotice}" |& dialog_pipe "${DC["TitleError"]-}${Title}" "${NoNotice}"
         else
             notice "${NoNotice}"
         fi

--- a/.scripts/update_self.sh
+++ b/.scripts/update_self.sh
@@ -49,7 +49,7 @@ update_self() {
         local ErrorMessage="${APPLICATION_NAME} branch '${C["Branch"]}${BRANCH}${NC}' does not exists."
         if use_dialog_box; then
             error "${ErrorMessage}" |&
-                dialog_pipe "${DC[TitleError]}${Title}" "${DC[CommandLine]} ${APPLICATION_COMMAND} --update $*"
+                dialog_pipe "${DC["TitleError"]-}${Title}" "${DC["CommandLine"]-} ${APPLICATION_COMMAND} --update $*"
         else
             error "${ErrorMessage}"
         fi
@@ -60,7 +60,7 @@ update_self() {
             {
                 notice "${APPLICATION_NAME} is already up to date on branch '${C["Branch"]}${CurrentBranch}${NC}'."
                 notice "Current version is '${C["Version"]}${CurrentVersion}${NC}'"
-            } |& dialog_pipe "${DC[TitleWarning]}${Title}" "${DC[CommandLine]} ${APPLICATION_COMMAND} --update $*"
+            } |& dialog_pipe "${DC["TitleWarning"]-}${Title}" "${DC[CommandLine]-} ${APPLICATION_COMMAND} --update $*"
         else
             notice "${APPLICATION_NAME} is already up to date on branch '${C["Branch"]}${CurrentBranch}${NC}'."
             notice "Current version is '${C["Version"]}${CurrentVersion}${NC}'"
@@ -71,7 +71,7 @@ update_self() {
     BRANCH="${BRANCH:-"${CurrentBranch}"}"
     if ! run_script 'question_prompt' Y "${Question}" "${Title}" "${FORCE:+Y}"; then
         if use_dialog_box; then
-            notice "${NoNotice}" |& dialog_pipe "${DC[TitleError]}${Title}" "${NoNotice}"
+            notice "${NoNotice}" |& dialog_pipe "${DC["TitleError"]-}${Title}" "${NoNotice}"
         else
             notice "${NoNotice}"
         fi
@@ -80,7 +80,7 @@ update_self() {
 
     if use_dialog_box; then
         commands_update_self "${BRANCH}" "${YesNotice}" "$@" |&
-            dialog_pipe "${DC[TitleSuccess]}${Title}" "${YesNotice}\n${DC[CommandLine]} ${APPLICATION_COMMAND} --update $*"
+            dialog_pipe "${DC["TitleSuccess"]-}${Title}" "${YesNotice}\n${DC["CommandLine"]-} ${APPLICATION_COMMAND} --update $*"
     else
         commands_update_self "${BRANCH}" "${YesNotice}" "$@"
     fi


### PR DESCRIPTION
…uotes and the `-`

# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Enhancements:
- Standardize dialog color references to use quoted DC array keys with default parameter expansion syntax `${DC["Key"]-}` across all scripts