### PR TITLE
Only apply the theme if using the GUI

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -137,6 +137,8 @@ declare -Agr C=( # Pre-defined colors
     ["No"]="${F[R]}"
 )
 
+declare -Ax DC
+
 DIALOG=$(command -v dialog) || true
 export DIALOG
 
@@ -1040,7 +1042,9 @@ main() {
         fi
     fi
     # Apply the GUI theme
-    run_script 'apply_theme'
+    if [[ ${PROMPT:-CLI} == "GUI" ]]; then
+        run_script 'apply_theme'
+    fi
     # Check if we're running a test
     if [[ -n ${TEST-} ]]; then
         run_test "${TEST}"
@@ -1105,55 +1109,63 @@ main() {
                 ;;
             theme-shadow)
                 notice "Turning on GUI shadows."
+                run_script 'apply_theme'
                 run_script 'config_set' Shadow yes "${MENU_INI_FILE}"
                 if use_dialog_box; then
                     run_script 'menu_dialog_example' "Turned on shadows" "${APPLICATION_COMMAND} --theme-shadow"
                 fi
                 ;;
             theme-no-shadow)
-                run_script 'config_set' Shadow no "${MENU_INI_FILE}"
                 notice "Turning off GUI shadows."
+                run_script 'apply_theme'
+                run_script 'config_set' Shadow no "${MENU_INI_FILE}"
                 if use_dialog_box; then
                     run_script 'menu_dialog_example' "Turned off shadows" "${APPLICATION_COMMAND} --theme-no-shadow"
                 fi
                 ;;
             theme-scrollbar)
-                run_script 'config_set' Scrollbar yes "${MENU_INI_FILE}"
                 notice "Turning on GUI scrollbars."
+                run_script 'apply_theme'
+                run_script 'config_set' Scrollbar yes "${MENU_INI_FILE}"
                 if use_dialog_box; then
                     run_script 'menu_dialog_example' "Turned on scrollbars" "${APPLICATION_COMMAND} --theme-scrollbar"
                 fi
                 ;;
             theme-no-scrollbar)
-                run_script 'config_set' Scrollbar no "${MENU_INI_FILE}"
                 notice "Turning off GUI scrollbars."
+                run_script 'apply_theme'
+                run_script 'config_set' Scrollbar no "${MENU_INI_FILE}"
                 if use_dialog_box; then
                     run_script 'menu_dialog_example' "Turned off scrollbars" "${APPLICATION_COMMAND} --theme-no-scrollbar"
                 fi
                 ;;
             theme-lines)
-                run_script 'config_set' LineCharacters yes "${MENU_INI_FILE}"
                 notice "Turning on GUI line drawing characters."
+                run_script 'apply_theme'
+                run_script 'config_set' LineCharacters yes "${MENU_INI_FILE}"
                 if use_dialog_box; then
                     run_script 'menu_dialog_example' "Turned on line drawing" "${APPLICATION_COMMAND} --theme-lines"
                 fi
                 ;;
             theme-no-lines)
                 notice "Turning off GUI line drawing characters."
+                run_script 'apply_theme'
                 run_script 'config_set' LineCharacters no "${MENU_INI_FILE}"
                 if use_dialog_box; then
                     run_script 'menu_dialog_example' "Turned off line drawing" "${APPLICATION_COMMAND} --theme-no-lines"
                 fi
                 ;;
             theme-borders)
-                run_script 'config_set' Borders yes "${MENU_INI_FILE}"
                 notice "Turning on GUI borders."
+                run_script 'apply_theme'
+                run_script 'config_set' Borders yes "${MENU_INI_FILE}"
                 if use_dialog_box; then
                     run_script 'menu_dialog_example' "Turned on borders" "${APPLICATION_COMMAND} --theme-borders"
                 fi
                 ;;
             theme-no-borders)
                 notice "Turning off GUI borders."
+                run_script 'apply_theme'
                 run_script 'config_set' Borders no "${MENU_INI_FILE}"
                 if use_dialog_box; then
                     run_script 'menu_dialog_example' "Turned off borders" "${APPLICATION_COMMAND} --theme-no-borders"
@@ -1434,6 +1446,7 @@ main() {
     fi
     if [[ -n ${SELECT-} ]]; then
         PROMPT='GUI'
+        run_script 'apply_theme'
         run_script 'menu_app_select' || true
         exit
     fi
@@ -1463,6 +1476,7 @@ main() {
     if [[ -n ${DIALOG-} ]]; then
         MENU=true
         PROMPT="GUI"
+        run_script 'apply_theme'
         run_script 'menu_main'
     else
         error "The GUI requires the '${C["Program"]}dialog${NC}' command to be installed."


### PR DESCRIPTION
Only apply the theme if we are using the GUI, or setting a GUI option.

This avoids calling `apply_theme`, where the `envsubst` command is used, before the command is installed in `update_system` with the `-i` command-line option (which is done on fresh install).

# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Only apply the GUI theme when running in GUI mode or altering GUI options to avoid premature envsubst calls before installation

Enhancements:
- Wrap the initial apply_theme call to run only when PROMPT is set to GUI
- Add apply_theme invocations before config changes in all GUI theme toggles
- Invoke apply_theme when entering GUI modes via select or dialog options

Chores:
- Introduce a new associative array DC