### PR TITLE
Change to using `git checkout` instead of `git switch` for compatibil…

### DIFF
--- a/.scripts/update_self.sh
+++ b/.scripts/update_self.sh
@@ -106,7 +106,7 @@ commands_update_self() {
     info "Fetching recent changes from git."
     eval git fetch ${QUIET-} --all --prune || fatal "Failed to fetch recent changes from git.\nFailing command: ${C["FailingCommand"]}git fetch ${QUIET-} --all --prune"
     if [[ ${CI-} != true ]]; then
-        eval git switch ${QUIET-} --force "${BRANCH}" || fatal "Failed to switch to github branch '${C["Branch"]}${BRANCH}${NC}'.\nFailing command: ${C["FailingCommand"]}git switch ${QUIET-} --force \"${BRANCH}\""
+        eval git checkout ${QUIET-} --force "${BRANCH}" || fatal "Failed to switch to github branch '${C["Branch"]}${BRANCH}${NC}'.\nFailing command: ${C["FailingCommand"]}git checkout ${QUIET-} --force \"${BRANCH}\""
         eval git reset ${QUIET-} --hard origin/"${BRANCH}" || fatal "Failed to reset to branch '${C["Branch"]}origin/${BRANCH}${NC}'.\nFailing command: ${C["FailingCommand"]}git reset ${QUIET-} --hard origin/\"${BRANCH}\""
         info "Pulling recent changes from git."
         eval git pull ${QUIET-} || fatal "Failed to pull recent changes from git.\nFailing command: ${C["FailingCommand"]}git pull ${QUIET-}"


### PR DESCRIPTION
…ity with older systems

# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Bug Fixes:
- Use git checkout instead of git switch when force-switching branches in update_self.sh for compatibility with older Git versions