### PR TITLE
Remove `bsdmainutils` from `dnf` installs.  `column` is in `util-linu…

### DIFF
--- a/.scripts/pm_dnf_install.sh
+++ b/.scripts/pm_dnf_install.sh
@@ -11,7 +11,7 @@ pm_dnf_install() {
         #shellcheck disable=SC2016 # (info): Expressions don't expand in single quotes, use double quotes for that.
         REDIRECT='run_command_dialog "${Title}" "${COMMAND}" "" '
     fi
-    COMMAND='sudo dnf -y install bsdmainutils curl dialog gettext git grep sed util-linux'
+    COMMAND='sudo dnf -y install curl dialog gettext git grep sed util-linux'
     eval "${REDIRECT}${COMMAND}" || fatal "Failed to install dependencies from dnf.\nFailing command: ${C["FailingCommand"]}${COMMAND}"
 }
 


### PR DESCRIPTION
…x`, not `bsdmainutils`

# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).
