### PR TITLE
Apply theme at start of testing `menu_heading`

### DIFF
--- a/.scripts/menu_heading.sh
+++ b/.scripts/menu_heading.sh
@@ -159,6 +159,7 @@ menu_heading() {
 }
 
 test_menu_heading() {
+    run_script 'apply_theme'
     notice WATCHTOWER:
     run_script 'menu_heading' WATCHTOWER
     notice "WATCHTOWER WATCHTOWER__ENABLED:"


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Tests:
- Add a run_script call to apply_theme in test_menu_heading to apply the theme prior to heading tests