### PR TITLE
Look in override file to check for referenced apps

### DIFF
--- a/.scripts/app_is_referenced.sh
+++ b/.scripts/app_is_referenced.sh
@@ -5,14 +5,28 @@ IFS=$'\n\t'
 app_is_referenced() {
     local APPNAME=${1:-}
 
-    if [[ -z "$(run_script 'appvars_list' "${APPNAME}")" ]]; then
-        if [[ -z "$(run_script 'appvars_list' "${APPNAME}:")" ]]; then
-            false
-            return
+    # Check for app variables in the global .env file
+    if [[ -n $(run_script 'appvars_list' "${APPNAME}") ]]; then
+        return 0
+    fi
+
+    # Check for app variables in the .env.app.appname file
+    if [[ -n $(run_script 'appvars_list' "${APPNAME}:") ]]; then
+        return 0
+    fi
+
+    # Check for an un-commented reference to .env.app.appname in the override file
+    if [[ -f ${COMPOSE_OVERRIDE} ]]; then
+        local AppEnvFile
+        AppEnvFile="$(basename "$(run_script 'app_env_file' "${APPNAME}")")"
+        local SearchString="${AppEnvFile//./[.]}"
+        if grep -q -P "^(?:[^#]*)(?:^|\s)(?<Q>['\"]?)${SearchString}(?=\k<Q>\s|$)" "${COMPOSE_OVERRIDE}" &> /dev/null; then
+
+            return 0
         fi
     fi
-    true
-    return
+
+    return 1
 }
 
 test_app_is_referenced() {

--- a/.scripts/app_list_hasvarfile.sh
+++ b/.scripts/app_list_hasvarfile.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+app_list_hasvarfile() {
+    find "${COMPOSE_FOLDER}" -maxdepth 1 -type f -name '.env.app.*' ! -name '.env.app.' 2> /dev/null | tr -s '\n' | run_script 'varfile_to_appname_pipe' | sort
+}
+
+test_app_list_hasvarfile() {
+    run_script 'app_list_hasvarfile'
+}

--- a/.scripts/app_list_referenced.sh
+++ b/.scripts/app_list_referenced.sh
@@ -4,28 +4,37 @@ IFS=$'\n\t'
 
 app_list_referenced() {
     local APPNAME_REGEX='^[A-Z][A-Z0-9]*(__[A-Z0-9]+)?'
-    local APPFILE_REGEX='^[a-z][a-z0-9]*(__[a-z0-9]+)?$'
+    #local APPFILE_REGEX='^[a-z][a-z0-9]*(__[a-z0-9]+)?$'
 
-    local -a ReferencedApps=()
+    local -al ReferencedApps=()
 
-    # Add the list of apps with appname.env an file with variables in it
-    local -a AppEnvFileList
-    readarray -t AppEnvFileList < <(find "${COMPOSE_FOLDER}"/.env.app.* 2> /dev/null || true)
-    for AppEnvFile in "${AppEnvFileList[@]}"; do
-        local AppName="${AppEnvFile##*.}"
-        if [[ ${AppName} =~ ${APPFILE_REGEX} && -n $(run_script 'appvars_list' "${AppName}:") ]]; then
-            ReferencedApps+=("${AppName^^}")
+    # Add the list of apps with .env.app.appname files with variables in them
+    local -au AppList
+    readarray -t AppList < <(
+        run_script 'app_list_hasvarfile'
+    )
+    for AppName in "${AppList[@]-}"; do
+        if [[ -n ${AppName} && -n $(run_script 'appvars_list' "${AppName}:") ]]; then
+            ReferencedApps+=("${AppName}")
         fi
     done
 
     # Add the list of referenced apps in the global .env file
     local REFERENCED_APPS_REGEX="^${APPNAME_REGEX}(?=__[A-Za-z0-9]\w*\s*=)"
-    readarray -O ${#ReferencedApps[@]} ReferencedApps <<< "$(
+    readarray -O ${#ReferencedApps[@]} ReferencedApps < <(
         grep --color=never -o -P "${REFERENCED_APPS_REGEX}" "${COMPOSE_ENV}" 2> /dev/null || true
-    )"
+    )
+
+    # Add the list of referenced apps in the override file
+    REFERENCED_APPS_REGEX="^(?:[^#]*)(?:^|\s)(?<Q>['\"]?)[.]env[.]app[.]\K([a-z][a-z0-9]*(?:__[a-z0-9]+)?)(?=\k<Q>\s|$)"
+    readarray -O ${#ReferencedApps[@]} ReferencedApps < <(
+        grep --color=never -o -P "${REFERENCED_APPS_REGEX}" "${COMPOSE_OVERRIDE}" 2> /dev/null || true
+    )
 
     # Output the sorted list, removing duplicates
-    sort -u <<< "$(printf '%s\n' "${ReferencedApps[@]}")"
+    if [[ -n ${ReferencedApps[*]-} ]]; then
+        sort -u < <(printf '%s\n' "${ReferencedApps[@]}" | tr -s '\n')
+    fi
 }
 
 test_app_list_referenced() {

--- a/.scripts/app_status.sh
+++ b/.scripts/app_status.sh
@@ -9,18 +9,20 @@ app_status() {
     for APPNAME in ${AppList}; do
         local AppName
         AppName="$(run_script 'app_nicename' "${APPNAME}")"
-        if ! run_script 'app_is_builtin' "${AppName}"; then
-            echo "${AppName} does not exist."
-            continue
-        fi
-        if ! run_script 'app_is_added' "${AppName}"; then
+        if run_script 'app_is_referenced' "${AppName}"; then
+            if run_script 'app_is_added' "${AppName}"; then
+                if run_script 'app_is_enabled' "${AppName}"; then
+                    echo "${AppName} is enabled."
+                else
+                    echo "${AppName} is disabled."
+                fi
+            else
+                echo "${AppName} is referenced."
+            fi
+        elif run_script 'app_is_builtin' "${AppName}"; then
             echo "${AppName} is not added."
-            continue
-        fi
-        if run_script 'app_is_enabled' "${AppName}"; then
-            echo "${AppName} is enabled."
         else
-            echo "${AppName} is disabled."
+            echo "${AppName} does not exist."
         fi
     done
 }

--- a/.scripts/appvars_purge.sh
+++ b/.scripts/appvars_purge.sh
@@ -108,5 +108,9 @@ test_appvars_purge() {
     local EnvFile
     EnvFile="$(run_script 'app_env_file' "watchtower")"
     echo "${EnvFile}:"
-    cat "${EnvFile}"
+    if [[ -f ${EnvFile} ]]; then
+        cat "${EnvFile}"
+    else
+        echo "*File Not Found*"
+    fi
 }

--- a/.scripts/env_update.sh
+++ b/.scripts/env_update.sh
@@ -10,9 +10,24 @@ env_update() {
     #fi
     notice "Updating environment variable files."
 
-    local -l applist
-    applist="$(run_script 'app_list_referenced')"
+    local -al applist
+    readarray -t applist < <(
+        run_script 'app_list_hasvarfile'
+    )
+    for appname in "${applist[@]}"; do
+        if ! run_script 'app_is_referenced' "${appname}"; then
+            local AppEnvFile
+            AppEnvFile="$(run_script 'app_env_file' "${appname}")"
+            run_script 'set_permissions' "${AppEnvFile}"
+            notice "Deleting '${C["File"]}${AppEnvFile}${NC}'."
+            rm -f "${AppEnvFile}" ||
+                warn "Failed to remove '${C["File"]}${AppEnvFile}${NC}'.\nFailing command: ${C["FailingCommand"]}rm -f \"${AppEnvFile}\""
+        fi
+    done
 
+    readarray -t applist < <(
+        run_script 'app_list_referenced'
+    )
     # Format the global .env file
     if ! run_script 'needs_env_update' "${COMPOSE_ENV}"; then
         info "'${C["File"]}${COMPOSE_ENV}'${NC} already updated."
@@ -27,17 +42,19 @@ env_update() {
             run_script 'env_format_lines' "${ENV_LINES_FILE}" "${COMPOSE_ENV_DEFAULT_FILE}" ""
         )
 
-        for appname in ${applist}; do
-            local APP_DEFAULT_GLOBAL_ENV_FILE=""
-            local -a UPDATED_APP_ENV_LINES=()
-            if ! run_script 'app_is_user_defined' "${appname}"; then
-                APP_DEFAULT_GLOBAL_ENV_FILE="$(run_script 'app_instance_file' "${appname}" ".env")"
-            fi
-            run_script 'appvars_lines' "${appname}" > "${ENV_LINES_FILE}"
-            readarray -t -O ${#UPDATED_ENV_LINES[@]} UPDATED_ENV_LINES < <(
-                run_script 'env_format_lines' "${ENV_LINES_FILE}" "${APP_DEFAULT_GLOBAL_ENV_FILE}" "${appname}"
-            )
-        done
+        if [[ -n ${applist[*]-} ]]; then
+            for appname in "${applist[@]}"; do
+                local APP_DEFAULT_GLOBAL_ENV_FILE=""
+                local -a UPDATED_APP_ENV_LINES=()
+                if ! run_script 'app_is_user_defined' "${appname}"; then
+                    APP_DEFAULT_GLOBAL_ENV_FILE="$(run_script 'app_instance_file' "${appname}" ".env")"
+                fi
+                run_script 'appvars_lines' "${appname}" > "${ENV_LINES_FILE}"
+                readarray -t -O ${#UPDATED_ENV_LINES[@]} UPDATED_ENV_LINES < <(
+                    run_script 'env_format_lines' "${ENV_LINES_FILE}" "${APP_DEFAULT_GLOBAL_ENV_FILE}" "${appname}"
+                )
+            done
+        fi
         rm -f "${ENV_LINES_FILE}" ||
             warn "Failed to remove temporary '${C["File"]}.env${NC}' update file.\nFailing command: ${C["FailingCommand"]}rm -f \"${ENV_LINES_FILE}\""
 
@@ -54,34 +71,40 @@ env_update() {
     fi
 
     # Process all referenced .env.app.appname files
-    for appname in ${applist}; do
-        local APP_ENV_FILE
-        APP_ENV_FILE="$(run_script 'app_env_file' "${appname}")"
-        if ! run_script 'needs_env_update' "${APP_ENV_FILE}"; then
-            info "'${C["File"]}${APP_ENV_FILE}'${NC} already updated."
-        else
-            notice "Updating '${C["File"]}${APP_ENV_FILE}${NC}'."
-            local APP_DEFAULT_ENV_FILE=""
-            if ! run_script 'app_is_user_defined' "${appname}"; then
-                APP_DEFAULT_ENV_FILE="$(run_script 'app_instance_file' "${appname}" ".env.app.*")"
+    if [[ -n ${applist[*]-} ]]; then
+        for appname in "${applist[@]-}"; do
+            local APP_ENV_FILE
+            APP_ENV_FILE="$(run_script 'app_env_file' "${appname}")"
+            if ! run_script 'needs_env_update' "${APP_ENV_FILE}"; then
+                info "'${C["File"]}${APP_ENV_FILE}'${NC} already updated."
+            else
+                if [[ ! -f ${APP_ENV_FILE} ]]; then
+                    notice "Creating '${C["File"]}${APP_ENV_FILE}${NC}'."
+                else
+                    notice "Updating '${C["File"]}${APP_ENV_FILE}${NC}'."
+                fi
+                local APP_DEFAULT_ENV_FILE=""
+                if ! run_script 'app_is_user_defined' "${appname}"; then
+                    APP_DEFAULT_ENV_FILE="$(run_script 'app_instance_file' "${appname}" ".env.app.*")"
+                fi
+                local -a UPDATED_APP_ENV_LINES=()
+                readarray -t UPDATED_APP_ENV_LINES < <(
+                    run_script 'env_format_lines' "${APP_ENV_FILE}" "${APP_DEFAULT_ENV_FILE}" "${appname}"
+                )
+                local MKTEMP_APP_ENV_UPDATED
+                MKTEMP_APP_ENV_UPDATED=$(mktemp -t "${APPLICATION_NAME}.${FUNCNAME[0]}.MKTEMP_APP_ENV_UPDATED.XXXXXXXXXX") ||
+                    fatal "Failed to create temporary update '${C["File"]}.env.app.${appname}${NC}' file.\nFailing command: ${C["FailingCommand"]}mktemp -t \"${APPLICATION_NAME}.${FUNCNAME[0]}.MKTEMP_APP_ENV_UPDATED.XXXXXXXXXX\"${NC}"
+                printf '%s\n' "${UPDATED_APP_ENV_LINES[@]}" > "${MKTEMP_APP_ENV_UPDATED}" ||
+                    fatal "Failed to write temporary '${C["File"]}.env.app.${appname}${NC}' update file."
+                cp -f "${MKTEMP_APP_ENV_UPDATED}" "${APP_ENV_FILE}" ||
+                    fatal "Failed to copy file.\nFailing command: ${C["FailingCommand"]}cp -f \"${MKTEMP_APP_ENV_UPDATED}\" \"${APP_ENV_FILE}\""
+                rm -f "${MKTEMP_APP_ENV_UPDATED}" ||
+                    warn "Failed to remove temporary '${C["File"]}.env.app.${appname}${NC}' update file.\nFailing command: ${C["FailingCommand"]}rm -f \"${MKTEMP_APP_ENV_UPDATED}\""
+                run_script 'set_permissions' "${APP_ENV_FILE}"
+                #run_script 'unset_needs_env_update' "${APP_ENV_FILE}"
             fi
-            local -a UPDATED_APP_ENV_LINES=()
-            readarray -t UPDATED_APP_ENV_LINES < <(
-                run_script 'env_format_lines' "${APP_ENV_FILE}" "${APP_DEFAULT_ENV_FILE}" "${appname}"
-            )
-            local MKTEMP_APP_ENV_UPDATED
-            MKTEMP_APP_ENV_UPDATED=$(mktemp -t "${APPLICATION_NAME}.${FUNCNAME[0]}.MKTEMP_APP_ENV_UPDATED.XXXXXXXXXX") ||
-                fatal "Failed to create temporary update '${C["File"]}.env.app.${appname}${NC}' file.\nFailing command: ${C["FailingCommand"]}mktemp -t \"${APPLICATION_NAME}.${FUNCNAME[0]}.MKTEMP_APP_ENV_UPDATED.XXXXXXXXXX\"${NC}"
-            printf '%s\n' "${UPDATED_APP_ENV_LINES[@]}" > "${MKTEMP_APP_ENV_UPDATED}" ||
-                fatal "Failed to write temporary '${C["File"]}.env.app.${appname}${NC}' update file."
-            cp -f "${MKTEMP_APP_ENV_UPDATED}" "${APP_ENV_FILE}" ||
-                fatal "Failed to copy file.\nFailing command: ${C["FailingCommand"]}cp -f \"${MKTEMP_APP_ENV_UPDATED}\" \"${APP_ENV_FILE}\""
-            rm -f "${MKTEMP_APP_ENV_UPDATED}" ||
-                warn "Failed to remove temporary '${C["File"]}.env.app.${appname}${NC}' update file.\nFailing command: ${C["FailingCommand"]}rm -f \"${MKTEMP_APP_ENV_UPDATED}\""
-            run_script 'set_permissions' "${APP_ENV_FILE}"
-            #run_script 'unset_needs_env_update' "${APP_ENV_FILE}"
-        fi
-    done
+        done
+    fi
 
     #run_script 'env_sanitize'
     run_script 'unset_needs_env_update'

--- a/.scripts/varfile_to_appname.sh
+++ b/.scripts/varfile_to_appname.sh
@@ -6,13 +6,15 @@ varfile_to_appname() {
     # Returns the DS application name based on the variable filename passed
 
     local VarFile=${1-}
-    local FileName
-    FileName="$(basename "${VarFile}")"
-    local Prefix='.env.app.'
-    local AppName="${FileName#"${Prefix}"}"
-    if [[ ${AppName} != "${FileName}" && ${AppName} == "${AppName,,}" ]] && run_script 'appname_is_valid' "${AppName}"; then
-        echo "${AppName}"
-    fi
+    for VarFile in "$@"; do
+        local FileName
+        FileName="$(basename "${VarFile}")"
+        local Prefix='.env.app.'
+        local AppName="${FileName#"${Prefix}"}"
+        if [[ -n ${AppName} && ${AppName} != "${FileName}" && ${AppName} == "${AppName,,}" ]] && run_script 'appname_is_valid' "${AppName}"; then
+            echo "${AppName}"
+        fi
+    done
 }
 
 test_varfile_to_appname() {
@@ -27,4 +29,5 @@ test_varfile_to_appname() {
     for filepath in "${PathList[@]}"; do
         notice "[${filepath}] [$(run_script 'varfile_to_appname' "${filepath}")]"
     done
+    notice "$(run_script 'varfile_to_appname' "${PathList[@]}")"
 }

--- a/.scripts/varfile_to_appname_pipe.sh
+++ b/.scripts/varfile_to_appname_pipe.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+varfile_to_appname_pipe() {
+    # Returns the DS application name based on the variable filename passed to stdin
+    local -a Args
+    readarray -t Args < /dev/stdin
+    if [[ -n ${Args[*]-} ]]; then
+        run_script 'varfile_to_appname' "${Args[@]}"
+    fi
+}
+
+test_varfile_to_appname_pipe() {
+    local -a PathList=(
+        '/home/test/.docker/.env'
+        '/home/test/.docker/.env.app.radarr'
+        '/home/test/.docker/.env.app.Radarr'
+        '/home/test/.docker/.env.app.1radarr'
+        '/home/test/.docker/.env.app.radarr__4k'
+        '/home/test/.docker/.env.app.radarr___4k'
+    )
+    notice "$(run_script 'varfile_to_appname_pipe' < <(printf '%s\n' "${PathList[@]}"))"
+}


### PR DESCRIPTION
Search the override for for `.env.app.appname` strings, and if found, consider `appname` to be referenced.

Delete any `.env.app.appname` files for apps that are no longer referenced, i.e., do not have any `APPNAME__*` variables in the global `.env` file, do not have any variables in the `.env.app.appname` file, and do not have `.env.app.appname` in the override file.

# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).
