### PR TITLE
Allow `./` before `.env.app.appname` when searching the compose file

### DIFF
--- a/.scripts/app_is_referenced.sh
+++ b/.scripts/app_is_referenced.sh
@@ -20,7 +20,7 @@ app_is_referenced() {
         local AppEnvFile
         AppEnvFile="$(basename "$(run_script 'app_env_file' "${APPNAME}")")"
         local SearchString="${AppEnvFile//./[.]}"
-        if grep -q -P "^(?:[^#]*)(?:\s|^)(?<Q>['\"]?)${SearchString}(?=\k<Q>(?:\s|$))" "${COMPOSE_OVERRIDE}" &> /dev/null; then
+        if grep -q -P "^(?:[^#]*)(?:\s|^)(?<Q>['\"]?)(?:[.]\/)?${SearchString}(?=\k<Q>(?:\s|$))" "${COMPOSE_OVERRIDE}" &> /dev/null; then
 
             return 0
         fi

--- a/.scripts/app_list_referenced.sh
+++ b/.scripts/app_list_referenced.sh
@@ -26,7 +26,7 @@ app_list_referenced() {
     )
 
     # Add the list of referenced apps in the override file
-    REFERENCED_APPS_REGEX="^(?:[^#]*)(?:\s|^)(?<Q>['\"]?)[.]env[.]app[.]\K([a-z][a-z0-9]*(?:__[a-z0-9]+)?)(?=\k<Q>(?:\s|$))"
+    REFERENCED_APPS_REGEX="^(?:[^#]*)(?:\s|^)(?<Q>['\"]?)(?:[.]\/)?[.]env[.]app[.]\K([a-z][a-z0-9]*(?:__[a-z0-9]+)?)(?=\k<Q>(?:\s|$))"
     readarray -O ${#ReferencedApps[@]} ReferencedApps < <(
         grep --color=never -o -P "${REFERENCED_APPS_REGEX}" "${COMPOSE_OVERRIDE}" 2> /dev/null || true
     )


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Enhancements:
- Support optional "./" prefix when matching .env.app references in compose override scripts