### PR TITLE
Use the "AppList" colors for the descriptions of apps in the app sele…

### DIFF
--- a/.scripts/menu_app_select.sh
+++ b/.scripts/menu_app_select.sh
@@ -117,10 +117,14 @@ menu_app_select() {
             update_gauge 1 "${ProcessAppList}" "_InProgress_" "_InProgress_" "${AppName}"
             local AppDescription
             AppDescription=$(run_script 'app_description_from_template' "${AppName}")
+            local AppColor="${DC["ListApp"]-}"
+            if [[ -n $(run_script 'appname_to_instancename' "${AppName}") ]]; then
+                AppColor="${DC["ListAppUserDefined"]-}"
+            fi
             if [[ ${AppName} =~ ^(${AddedAppsRegex})$ ]]; then
-                AppList+=("${AppName}" "${AppDescription}" "on")
+                AppList+=("${AppName}" "${AppColor}${AppDescription}" "on")
             else
-                AppList+=("${AppName}" "${AppDescription}" "off")
+                AppList+=("${AppName}" "${AppColor}${AppDescription}" "off")
             fi
         done
         update_gauge 0 "${ProcessAppList}" "_InProgress_" "_Completed_"


### PR DESCRIPTION
…ct menu

# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Apply configured AppList colors to app descriptions in the application selection menu, using a distinct color for user-defined instances.

Enhancements:
- Prefix app descriptions with the ListApp color code
- Switch to ListAppUserDefined color for descriptions of user-defined app instances