### PR TITLE
Fix incorrect "AppList" dialog color to "ListApp"

### DIFF
--- a/.scripts/menu_display_options_theme.sh
+++ b/.scripts/menu_display_options_theme.sh
@@ -31,9 +31,9 @@ menu_display_options_theme() {
                 ItemText+=" [by ${ThemeAuthor["${ThemeName}"]}]"
             fi
             if [[ ${ThemeName} == "${CurrentTheme}" ]]; then
-                Opts+=("${ThemeName}" "${DC["AppList"]-}${ItemText}" ON)
+                Opts+=("${ThemeName}" "${DC["ListApp"]-}${ItemText}" ON)
             else
-                Opts+=("${ThemeName}" "${DC["AppList"]-}${ItemText}" OFF)
+                Opts+=("${ThemeName}" "${DC["ListApp"]-}${ItemText}" OFF)
             fi
         done
         local -a ChoiceDialog=(


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Bug Fixes:
- Use the correct "ListApp" color key instead of "AppList" for menu items in menu_display_options_theme.sh