### PR TITLE
Determine the packages to install for dependencies using `apt-file`

### DIFF
--- a/.scripts/package_manager_run.sh
+++ b/.scripts/package_manager_run.sh
@@ -16,10 +16,9 @@ package_manager_run() {
         run_script "pm_yum_${ACTION}"
     else
         if [[ ${ACTION} == "install" ]]; then
-            local COMMAND_DEPS=("column" "curl" "dialog" "envsubst" "git" "grep" "sed")
-            for COMMAND_DEP in "${COMMAND_DEPS[@]}"; do
-                if [[ -z "$(command -v "${COMMAND_DEP}")" ]]; then
-                    fatal "'${C["Program"]}${COMMAND_DEP}${NC}' is not available. Please install '${C["Program"]}${COMMAND_DEP}${NC}' and try again."
+            for CommandDep in "${COMMAND_DEPS[@]}"; do
+                if [[ -z "$(command -v "${CommandDep}")" ]]; then
+                    fatal "'${C["Program"]}${CommandDep}${NC}' is not available. Please install '${C["Program"]}${CommandDep}${NC}' and try again."
                 fi
             done
         elif [[ ${ACTION} == "install_docker" ]]; then

--- a/.scripts/pm_apt_install.sh
+++ b/.scripts/pm_apt_install.sh
@@ -2,19 +2,64 @@
 set -Eeuo pipefail
 IFS=$'\n\t'
 
+declare Title="Install Dependencies"
+
 pm_apt_install() {
-    local Title="Install Dependencies"
-    notice "Installing dependencies. Please be patient, this can take a while."
-    local COMMAND=""
-    local REDIRECT="> /dev/null 2>&1"
-    if run_script 'question_prompt' Y "Would you like to display the command output?" "${Title}" "${VERBOSE:+Y}"; then
-        #shellcheck disable=SC2016 # (info): Expressions don't expand in single quotes, use double quotes for that.
-        REDIRECT='run_command_dialog "${Title}" "${COMMAND}" "" '
+    if use_dialog_box; then
+        coproc {
+            dialog_pipe "${DC["TitleSuccess"]-}Install Dependencies" "Please be patient, this can take a while.\n${DC["CommandLine"]-} ${APPLICATION_COMMAND} --install" ""
+        }
+        local -i DialogBox_PID=${COPROC_PID}
+        local -i DialogBox_FD="${COPROC[1]}"
+        pm_apt_install_commands >&${DialogBox_FD} 2>&1
+        exec {DialogBox_FD}<&-
+        wait ${DialogBox_PID}
+    else
+        pm_apt_install_commands
     fi
-    COMMAND='sudo apt-get -y install bsdmainutils curl dialog gettext-base git grep sed util-linux'
-    eval "${REDIRECT}${COMMAND}" || fatal "Failed to install dependencies from apt.\nFailing command: ${C["FailingCommand"]}${COMMAND}"
 }
 
+pm_apt_install_commands() {
+    local IgnorePackages='9base'
+    local Command=""
+
+    local REDIRECT='> /dev/null 2>&1 '
+    if run_script 'question_prompt' Y "Would you like to display the command output?" "${Title}" "${VERBOSE:+Y}"; then
+        REDIRECT='2>&1 '
+    fi
+
+    notice "Installing dependencies. Please be patient, this can take a while."
+
+    if [[ -z "$(command -v apt-file)" ]]; then
+        info "Installing '${C["Program"]}apt-file${NC}'."
+        Command="sudo apt-get -y install apt-file"
+        info "Running: ${C["RunningCommand"]}${Command}${NC}"
+        eval "${REDIRECT}${Command}" ||
+            fatal "Failed to install '${C["Program"]}apt-file${NC}' from apt.\nFailing command: ${C["FailingCommand"]}${Command}"
+        notice "Updating repositories."
+        Command='sudo apt-get -y update'
+        info "Running: ${C["RunningCommand"]}${Command}${NC}"
+        eval "${REDIRECT}${Command}" ||
+            fatal "Failed to get updates from apt.\nFailing command: ${C["FailingCommand"]}${Command}"
+    fi
+
+    notice "Determining packages to install."
+    local old_IFS="${IFS}"
+    IFS='|'
+    local DepsRegex="${COMMAND_DEPS[*]}"
+    IFS="${old_IFS}"
+    Command="apt-file search --regexp '/bin/(.*/)?(${DepsRegex})$'"
+    info "Running: ${C["RunningCommand"]}${Command}${NC}"
+    Packages="$(eval "2> /dev/null ${Command}")" ||
+        fatal "Failed to find packages to install.\nFailing command: ${C["FailingCommand"]}${Command}"
+    Packages="$(grep -E -v "\b(${IgnorePackages})\b" <<< "${Packages}" | cut -d : -f 1 | sort -u | xargs)"
+
+    notice "Installing packages."
+    Command="sudo apt-get -y install ${Packages}"
+    info "Running: ${C["RunningCommand"]}${Command}${NC}"
+    eval "${REDIRECT}${Command}" ||
+        fatal "Failed to install dependencies from apt.\nFailing command: ${C["FailingCommand"]}${Command}"
+}
 test_pm_apt_install() {
     run_script 'pm_apt_repos'
     run_script 'pm_apt_install'

--- a/main.sh
+++ b/main.sh
@@ -33,6 +33,15 @@ SCRIPTPATH=$(cd -P "$(dirname "$(get_scriptname)")" > /dev/null 2>&1 && pwd)
 readonly SCRIPTPATH
 SCRIPTNAME="${SCRIPTPATH}/$(basename "$(get_scriptname)")"
 readonly SCRIPTNAME
+declare -rx COMMAND_DEPS=(
+    "column"
+    "curl"
+    "dialog"
+    "envsubst"
+    "git"
+    "grep"
+    "sed"
+)
 
 # System Information
 ARCH=$(uname -m)


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Implement dynamic apt dependency resolution using apt-file and improve user feedback by adding optional dialog-based progress display

New Features:
- Determine apt packages to install by searching for required binaries with apt-file
- Show installation progress in a dialog coprocess with fallback to standard output

Enhancements:
- Extract COMMAND_DEPS into a global array for reuse in dependency checks
- Refactor pm_apt_install to delegate command logic to a dedicated pm_apt_install_commands function