### PR TITLE
Fix incorrect `apt-get update` call to `apt-file update`, and always …

### DIFF
--- a/.scripts/pm_apt_install.sh
+++ b/.scripts/pm_apt_install.sh
@@ -36,12 +36,12 @@ pm_apt_install_commands() {
         info "Running: ${C["RunningCommand"]}${Command}${NC}"
         eval "${REDIRECT}${Command}" ||
             fatal "Failed to install '${C["Program"]}apt-file${NC}' from apt.\nFailing command: ${C["FailingCommand"]}${Command}"
-        notice "Updating repositories."
-        Command='sudo apt-get -y update'
-        info "Running: ${C["RunningCommand"]}${Command}${NC}"
-        eval "${REDIRECT}${Command}" ||
-            fatal "Failed to get updates from apt.\nFailing command: ${C["FailingCommand"]}${Command}"
     fi
+    notice "Updating package information."
+    Command='sudo apt-file update'
+    info "Running: ${C["RunningCommand"]}${Command}${NC}"
+    eval "${REDIRECT}${Command}" ||
+        fatal "Failed to get updates from apt.\nFailing command: ${C["FailingCommand"]}${Command}"
 
     notice "Determining packages to install."
     local old_IFS="${IFS}"


### PR DESCRIPTION
…run it

# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Fix the package update step for apt-file in the installation script by replacing the incorrect apt-get update invocation with apt-file update and ensuring it always runs

Bug Fixes:
- Use apt-file update instead of apt-get update when refreshing package information
- Always execute the apt-file update step regardless of prior conditions