### PR TITLE
Check for existing dependencies before trying to install them in pacman

### DIFF
--- a/.scripts/pm_pacman_install.sh
+++ b/.scripts/pm_pacman_install.sh
@@ -2,17 +2,84 @@
 set -Eeuo pipefail
 IFS=$'\n\t'
 
+declare Title="Install Dependencies"
+
 pm_pacman_install() {
-    local Title="Install Dependencies"
-    notice "Installing dependencies. Please be patient, this can take a while."
-    local COMMAND=""
-    local REDIRECT="> /dev/null 2>&1"
-    if run_script 'question_prompt' Y "Would you like to display the command output?" "${Title}" "${VERBOSE:+Y}"; then
-        #shellcheck disable=SC2016 # (info): Expressions don't expand in single quotes, use double quotes for that.
-        REDIRECT='run_command_dialog "${Title}" "${COMMAND}" "" '
+    if use_dialog_box; then
+        coproc {
+            dialog_pipe "${DC["TitleSuccess"]-}Install Dependencies" "Please be patient, this can take a while.\n${DC["CommandLine"]-} ${APPLICATION_COMMAND} --install" ""
+        }
+        local -i DialogBox_PID=${COPROC_PID}
+        local -i DialogBox_FD="${COPROC[1]}"
+        pm_pacman_install_commands >&${DialogBox_FD} 2>&1
+        exec {DialogBox_FD}<&-
+        wait ${DialogBox_PID}
+    else
+        pm_pacman_install_commands
     fi
-    COMMAND='sudo pacman -Sy --noconfirm curl dialog gettext git grep sed util-linux'
-    eval "${REDIRECT}${COMMAND}" || fatal "Failed to install dependencies from pacman.\nFailing command: ${C["FailingCommand"]}${COMMAND}"
+}
+
+pm_pacman_install_commands() {
+    local IgnorePackages=''
+    local Command=""
+
+    local REDIRECT='> /dev/null 2>&1 '
+    if run_script 'question_prompt' Y "Would you like to display the command output?" "${Title}" "${VERBOSE:+Y}"; then
+        REDIRECT='2>&1 '
+    fi
+
+    local -a Dependencies=("${COMMAND_DEPS[@]}")
+    if [[ ${FORCE-} != true ]]; then
+        for index in "${!Dependencies[@]}"; do
+            if [[ -n $(command -v "${Dependencies[index]}") ]]; then
+                unset 'Dependencies[index]'
+            fi
+        done
+        Dependencies=("${Dependencies[@]}")
+    fi
+    if [[ ${#Dependencies[@]} -eq 0 ]]; then
+        notice "All dependencies have already been installed."
+    else
+        notice "Installing dependencies. Please be patient, this can take a while."
+
+        if [[ -z "$(command -v pkgfile)" ]]; then
+            info "Installing '${C["Program"]}pkgfile${NC}'."
+            Command="sudo pacman -Sy --noconfirm pkgfile"
+            info "Running: ${C["RunningCommand"]}${Command}${NC}"
+            eval "${REDIRECT}${Command}" ||
+                fatal "Failed to install '${C["Program"]}pkgfile${NC}' from pacman.\nFailing command: ${C["FailingCommand"]}${Command}"
+        fi
+        notice "Updating package information."
+        Command='sudo pkgfile -u'
+        info "Running: ${C["RunningCommand"]}${Command}${NC}"
+        eval "${REDIRECT}${Command}" ||
+            fatal "Failed to get updates from pkgfile.\nFailing command: ${C["FailingCommand"]}${Command}"
+
+        notice "Determining packages to install."
+        local -a Packages
+        for Dep in "${Dependencies[@]}"; do
+            Command="pkgfile -b ${Dep}"
+            info "Running: ${C["RunningCommand"]}${Command}${NC}"
+            Package="$(eval "${Command}" 2> /dev/null)" ||
+                fatal "Failed to find packages to install.\nFailing command: ${C["FailingCommand"]}${Command}"
+            Package="${Package##*/}"
+            if [[ -n ${Package} && (-z ${IgnorePackages} || ! ${Package} =~ ${IgnorePackages}) ]]; then
+                Packages+=("${Package}")
+            fi
+        done
+        if [[ ${#Packages[@]} -eq 0 ]]; then
+            notice "No packages found to install."
+        else
+            notice "Installing packages."
+            readarray -t Packages < <(sort -u <<< "$(printf '%s\n' "${Packages[@]}")")
+            #shellcheck disable=SC2124 # Assigning an array to a string! Assign as array, or use * instead of @ to concatenate.
+            local PackagesString="${Packages[@]}"
+            Command="sudo pacman -Sy --noconfirm ${PackagesString}"
+            info "Running: ${C["RunningCommand"]}${Command}${NC}"
+            eval "${REDIRECT}${Command}" ||
+                fatal "Failed to install dependencies from pacman.\nFailing command: ${C["FailingCommand"]}${Command}"
+        fi
+    fi
 }
 
 test_pm_pacman_install() {


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Refactor the pacman installer script to dynamically resolve and install only missing dependencies, support optional verbose output, and provide a dialog-based progress interface.

Enhancements:
- Factor pacman installation logic into a new pm_pacman_install_commands function with optional dialog UI.
- Skip already available commands when FORCE is not set to prevent redundant installations.
- Automatically install and update pkgfile to resolve missing commands to package names.
- Dynamically collect, dedupe, and install only the required packages via pacman using pkgfile mappings.
- Add a prompt to let users choose whether to display full command output or run silently.