### PR TITLE
Add the `nala` package manager, an alternate to `apt` for Debian base…

### DIFF
--- a/.scripts/package_manager_run.sh
+++ b/.scripts/package_manager_run.sh
@@ -7,6 +7,7 @@ package_manager_run() {
 
     local -a PackageManagers=(
         apk
+        nala
         apt
         dnf
         pacman
@@ -14,6 +15,7 @@ package_manager_run() {
     )
     local -A PackageManagerCmd=(
         ["apk"]="apk"
+        ["nala"]="nala"
         ["apt"]="apt-get"
         ["dnf"]="dnf"
         ["pacman"]="pacman"

--- a/.scripts/pm_nala_clean.sh
+++ b/.scripts/pm_nala_clean.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+pm_nala_clean() {
+    info "Removing unused packages."
+    info "Running: ${C["RunningCommand"]}sudo nala autoremove -y ${NC}"
+    sudo nala autoremove -y > /dev/null 2>&1 || fatal "Failed to remove unused packages from apt.\nFailing command: ${C["FailingCommand"]}sudo nala autoremove -y "
+
+    info "Cleaning up package cache."
+    info "Running: ${C["RunningCommand"]}sudo nala clean${NC}"
+    sudo sudo nala clean > /dev/null 2>&1 || fatal "Failed to cleanup cache from nala.\nFailing command: ${C["FailingCommand"]}sudo nala clean"
+}
+
+test_pm_nala_clean() {
+    #run_script 'pm_nala_clean'
+    warn "CI does not test pm_nala_clean."
+}

--- a/.scripts/pm_nala_clean.sh
+++ b/.scripts/pm_nala_clean.sh
@@ -9,7 +9,7 @@ pm_nala_clean() {
 
     info "Cleaning up package cache."
     info "Running: ${C["RunningCommand"]}sudo nala clean${NC}"
-    sudo sudo nala clean > /dev/null 2>&1 || fatal "Failed to cleanup cache from nala.\nFailing command: ${C["FailingCommand"]}sudo nala clean"
+    sudo nala clean > /dev/null 2>&1 || fatal "Failed to cleanup cache from nala.\nFailing command: ${C["FailingCommand"]}sudo nala clean"
 }
 
 test_pm_nala_clean() {

--- a/.scripts/pm_nala_install.sh
+++ b/.scripts/pm_nala_install.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+declare Title="Install Dependencies"
+
+pm_nala_install() {
+    if use_dialog_box; then
+        coproc {
+            dialog_pipe "${DC["TitleSuccess"]-}Install Dependencies" "Please be patient, this can take a while.\n${DC["CommandLine"]-} ${APPLICATION_COMMAND} --install" ""
+        }
+        local -i DialogBox_PID=${COPROC_PID}
+        local -i DialogBox_FD="${COPROC[1]}"
+        pm_nala_install_commands >&${DialogBox_FD} 2>&1
+        exec {DialogBox_FD}<&-
+        wait ${DialogBox_PID}
+    else
+        pm_nala_install_commands
+    fi
+}
+
+pm_nala_install_commands() {
+    local IgnorePackages='9base'
+    local Command=""
+
+    local REDIRECT='> /dev/null 2>&1 '
+    if run_script 'question_prompt' Y "Would you like to display the command output?" "${Title}" "${VERBOSE:+Y}"; then
+        REDIRECT='2>&1 '
+    fi
+
+    local -a Dependencies=("${COMMAND_DEPS[@]}")
+    if [[ ${FORCE-} != true ]]; then
+        for index in "${!Dependencies[@]}"; do
+            if [[ -n $(command -v "${Dependencies[index]}") ]]; then
+                unset 'Dependencies[index]'
+            fi
+        done
+        Dependencies=("${Dependencies[@]}")
+    fi
+    if [[ ${#Dependencies[@]} -eq 0 ]]; then
+        notice "All dependencies have already been installed."
+    else
+        notice "Installing dependencies. Please be patient, this can take a while."
+
+        if [[ -z "$(command -v apt-file)" ]]; then
+            info "Installing '${C["Program"]}apt-file${NC}'."
+            Command="sudo nala install -y apt-file"
+            info "Running: ${C["RunningCommand"]}${Command}${NC}"
+            eval "${REDIRECT}${Command}" ||
+                fatal "Failed to install '${C["Program"]}apt-file${NC}' from apt.\nFailing command: ${C["FailingCommand"]}${Command}"
+        fi
+        notice "Updating package information."
+        Command='sudo apt-file update'
+        info "Running: ${C["RunningCommand"]}${Command}${NC}"
+        eval "${REDIRECT}${Command}" ||
+            fatal "Failed to get updates from apt.\nFailing command: ${C["FailingCommand"]}${Command}"
+
+        notice "Determining packages to install."
+        local old_IFS="${IFS}"
+        IFS='|'
+        local DepsRegex="${Dependencies[*]}"
+        IFS="${old_IFS}"
+        Command="apt-file search --regexp '/bin/(.*/)?(${DepsRegex})$'"
+        info "Running: ${C["RunningCommand"]}${Command}${NC}"
+        Packages="$(eval "2> /dev/null ${Command}")" ||
+            fatal "Failed to find packages to install.\nFailing command: ${C["FailingCommand"]}${Command}"
+        Packages="$(cut -d : -f 1 <<< "${Packages}")"
+        if [[ -n ${IgnorePackages} ]]; then
+            Packages="$(grep -E -v "\b(${IgnorePackages})\b" <<< "${Packages}")"
+        fi
+        Packages="$(sort -u <<< "${Packages}" | xargs)"
+        if [[ -z ${Packages} ]]; then
+            notice "No packages found to install."
+        else
+            notice "Installing packages."
+            Command="sudo nala install -y ${Packages}"
+            info "Running: ${C["RunningCommand"]}${Command}${NC}"
+            eval "${REDIRECT}${Command}" ||
+                fatal "Failed to install dependencies from nala.\nFailing command: ${C["FailingCommand"]}${Command}"
+        fi
+    fi
+}
+test_pm_nala_install() {
+    #run_script 'pm_nala_repos'
+    #run_script 'pm_nala_install'
+    warn "CI does not test pm_nala_install."
+}

--- a/.scripts/pm_nala_install_docker.sh
+++ b/.scripts/pm_nala_install_docker.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+pm_nala_install_docker() {
+    # https://docs.docker.com/install/linux/docker-ce/debian/
+    # https://docs.docker.com/install/linux/docker-ce/ubuntu/
+    local RemovePackages="containerd docker docker-compose docker-engine docker.io runc"
+    info "Removing conflicting Docker packages."
+    local Command="sudo nala remove -y ${RemovePackages}"
+    info "Running: ${C["RunningCommand"]}${Command}${NC}"
+    eval "${Command}" > /dev/null 2>&1 || true
+    run_script 'remove_snap_docker'
+    run_script 'get_docker'
+}
+
+test_pm_nala_install_docker() {
+    #run_script 'pm_nala_repos'
+    #run_script 'pm_nala_install_docker'
+    warn "CI does not test pm_nala_install_docker."
+}

--- a/.scripts/pm_nala_repos.sh
+++ b/.scripts/pm_nala_repos.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+pm_nala_repos() {
+    local Title="Update Repositories"
+    notice "Updating repositories. Please be patient, this can take a while."
+    local COMMAND=""
+    local REDIRECT='> /dev/null 2>&1 '
+    if run_script 'question_prompt' Y "Would you like to display the command output?" "${Title}" "${VERBOSE:+Y}"; then
+        #shellcheck disable=SC2016 # (info): Expressions don't expand in single quotes, use double quotes for that.
+        REDIRECT='run_command_dialog "${Title}" "${COMMAND}" "" '
+    fi
+    local MINIMUM_APT_TRANSPORT_HTTPS="1"
+    local INSTALLED_APT_TRANSPORT_HTTPS
+    INSTALLED_APT_TRANSPORT_HTTPS=$( (sudo apt-cache policy apt-transport-https | grep --color=never -Po 'Installed: \K.*') || echo "0")
+    if vergt "${MINIMUM_APT_TRANSPORT_HTTPS}" "${INSTALLED_APT_TRANSPORT_HTTPS:-0}"; then
+        info "Updating repositories (before installing apt-transport-https)."
+        COMMAND="sudo nala update"
+        info "Running: ${C["RunningCommand"]}${COMMAND}${NC}"
+        eval "${REDIRECT}${COMMAND}" ||
+            fatal "Failed to get updates from nala.\nFailing command: ${C["FailingCommand"]}${COMMAND}"
+        info "Installing APT transport for downloading via the HTTP Secure protocol (HTTPS)."
+        COMMAND="sudo nala install -y apt-transport-https"
+        info "Running: ${C["RunningCommand"]}${COMMAND}${NC}"
+        eval "${REDIRECT}${COMMAND}" ||
+            fatal "Failed to install apt-transport-https from nala.\nFailing command: ${C["FailingCommand"]}${COMMAND}"
+    fi
+    local MINIMUM_LIBSECCOMP2="2.4.4"
+    # Note compatibility from https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.14.0
+    local INSTALLED_LIBSECCOMP2
+    INSTALLED_LIBSECCOMP2=$( (apt-cache policy libseccomp2 | grep --color=never -Po 'Installed: \K.*') || echo "0")
+    if vergt "${MINIMUM_LIBSECCOMP2}" "${INSTALLED_LIBSECCOMP2:-0}"; then
+        info "Installing buster-backports repo for libseccomp2."
+        sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 04EE7237B7D453EC 648ACFD622F3D138 ||
+            error "Failed to get apt key for buster-backports repo.\nFailing command: ${C["FailingCommand"]}sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 04EE7237B7D453EC 648ACFD622F3D138"
+        echo "deb http://deb.debian.org/debian buster-backports main" | sudo tee -a /etc/apt/sources.list.d/buster-backports.list ||
+            error "Failed to add buster-backports repo to sources.\nFailing command: ${C["FailingCommand"]}echo \"deb http://deb.debian.org/debian buster-backports main\" | sudo tee -a /etc/apt/sources.list.d/buster-backports.list"
+    fi
+    info "Updating repositories."
+    COMMAND="sudo nala update"
+    info "Running: ${C["RunningCommand"]}${COMMAND}${NC}"
+    eval "${REDIRECT}${COMMAND}" ||
+        fatal "Failed to get updates from nala.\nFailing command: ${C["FailingCommand"]}${COMMAND}"
+    if vergt "${MINIMUM_LIBSECCOMP2}" "${INSTALLED_LIBSECCOMP2:-0}"; then
+        info "Installing libseccomp2 from buster-backports repo."
+        COMMAND="sudo nala install -y -t buster-backports libseccomp2"
+        info "Running: ${C["RunningCommand"]}${COMMAND}${NC}"
+        eval "${REDIRECT}${COMMAND}" ||
+            fatal "Failed to install libseccomp2 from buster-backports repo.\nFailing command: ${C["FailingCommand"]}${COMMAND}"
+    fi
+}
+
+test_pm_nala_repos() {
+    #run_script 'pm_nala_repos'
+    warn "CI does not test pm_nala_repos."
+}

--- a/.scripts/pm_nala_upgrade.sh
+++ b/.scripts/pm_nala_upgrade.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+pm_nala_upgrade() {
+    local Title="Upgrade Packages"
+    if [[ ${CI-} != true ]]; then
+        notice "Upgrading packages. Please be patient, this can take a while."
+        local COMMAND='sudo nala full-upgrade -y'
+        local REDIRECT='> /dev/null 2>&1 '
+        if run_script 'question_prompt' Y "Would you like to display the command output?" "${Title}" "${VERBOSE:+Y}"; then
+            #shellcheck disable=SC2016 # (info): Expressions don't expand in single quotes, use double quotes for that.
+            REDIRECT='run_command_dialog "${Title}" "${COMMAND}" "" '
+        fi
+        info "Running: ${C["RunningCommand"]}${COMMAND}${NC}"
+        eval "${REDIRECT}${COMMAND}" ||
+            fatal "Failed to upgrade packages from nala.\nFailing command: ${C["FailingCommand"]}${COMMAND}"
+    fi
+}
+
+test_pm_nala_upgrade() {
+    #run_script 'pm_nala_upgrade'
+    warn "CI does not test pm_nala_upgrade."
+}


### PR DESCRIPTION
…d distros

# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Add comprehensive support for the 'nala' package manager by integrating it into the package_manager_run wrapper and introducing dedicated pm_nala_* scripts to manage repositories, install dependencies, perform upgrades, install Docker, and clean up on Debian-based systems.

New Features:
- Support the 'nala' package manager as an alternative to apt on Debian-based distributions by adding it to package_manager_run and mapping it to the 'nala' command
- Introduce pm_nala_repos to configure repositories, install apt-transport-https, and enable buster-backports for libseccomp2
- Add pm_nala_install to resolve and install missing dependencies via nala with optional verbose output
- Add pm_nala_upgrade to perform full system upgrades using nala
- Add pm_nala_install_docker to remove conflicting Docker packages and install Docker via nala
- Add pm_nala_clean to autoremove unused packages and clean the nala cache

Tests:
- Add CI test stubs for all pm_nala_* scripts with warnings indicating they are not executed in CI