### PR TITLE
Use a global variable for the packages to blacklist from being installed

### DIFF
--- a/.scripts/pm_apk_install.sh
+++ b/.scripts/pm_apk_install.sh
@@ -20,7 +20,6 @@ pm_apk_install() {
 }
 
 pm_apk_install_commands() {
-    local IgnorePackages=''
     local Command=""
 
     local REDIRECT='> /dev/null 2>&1 '
@@ -43,11 +42,18 @@ pm_apk_install_commands() {
         notice "Installing dependencies. Please be patient, this can take a while."
 
         notice "Determining packages to install."
+
+        local IgnorePackages
+        local old_IFS="${IFS}"
+        IFS='|'
+        IgnorePackages="${PM_PACKAGE_BLACKLIST[*]}"
+        IFS="${old_IFS}"
+
         local -a Packages
         local DepsSearch
         DepsSearch="$(printf 'cmd:%s ' "${Dependencies[@]}" | xargs)"
         Command="apk search -xqa ${DepsSearch}"
-        info "Running: ${C["RunningCommand"]}${Command}${NC}"
+        notice "Running: ${C["RunningCommand"]}${Command}${NC}"
         local Packages
         Packages="$(eval "${Command}" 2> /dev/null)" ||
             fatal "Failed to find packages to install.\nFailing command: ${C["FailingCommand"]}${Command}"
@@ -61,7 +67,7 @@ pm_apk_install_commands() {
         else
             notice "Installing packages."
             Command="sudo apk add ${Packages}"
-            info "Running: ${C["RunningCommand"]}${Command}${NC}"
+            notice "Running: ${C["RunningCommand"]}${Command}${NC}"
             eval "${REDIRECT}${Command}" ||
                 fatal "Failed to install dependencies from apk.\nFailing command: ${C["FailingCommand"]}${Command}"
         fi

--- a/.scripts/pm_apt_clean.sh
+++ b/.scripts/pm_apt_clean.sh
@@ -4,10 +4,10 @@ IFS=$'\n\t'
 
 pm_apt_clean() {
     info "Removing unused packages."
-    info "Running: ${C["RunningCommand"]}sudo apt-get -y autoremove${NC}"
+    notice "Running: ${C["RunningCommand"]}sudo apt-get -y autoremove${NC}"
     sudo apt-get -y autoremove > /dev/null 2>&1 || fatal "Failed to remove unused packages from apt.\nFailing command: ${C["FailingCommand"]}sudo apt-get -y autoremove"
     info "Cleaning up package cache."
-    info "Running: ${C["RunningCommand"]}sudo apt-get -y autoclean${NC}"
+    notice "Running: ${C["RunningCommand"]}sudo apt-get -y autoclean${NC}"
     sudo apt-get -y autoclean > /dev/null 2>&1 || fatal "Failed to cleanup cache from apt.\nFailing command: ${C["FailingCommand"]}sudo apt-get -y autoclean"
 }
 

--- a/.scripts/pm_apt_install.sh
+++ b/.scripts/pm_apt_install.sh
@@ -20,7 +20,6 @@ pm_apt_install() {
 }
 
 pm_apt_install_commands() {
-    local IgnorePackages='9base'
     local Command=""
 
     local REDIRECT='> /dev/null 2>&1 '
@@ -45,23 +44,31 @@ pm_apt_install_commands() {
         if [[ -z "$(command -v apt-file)" ]]; then
             info "Installing '${C["Program"]}apt-file${NC}'."
             Command="sudo apt-get -y install apt-file"
-            info "Running: ${C["RunningCommand"]}${Command}${NC}"
+            notice "Running: ${C["RunningCommand"]}${Command}${NC}"
             eval "${REDIRECT}${Command}" ||
                 fatal "Failed to install '${C["Program"]}apt-file${NC}' from apt.\nFailing command: ${C["FailingCommand"]}${Command}"
         fi
         notice "Updating package information."
         Command='sudo apt-file update'
-        info "Running: ${C["RunningCommand"]}${Command}${NC}"
+        notice "Running: ${C["RunningCommand"]}${Command}${NC}"
         eval "${REDIRECT}${Command}" ||
             fatal "Failed to get updates from apt.\nFailing command: ${C["FailingCommand"]}${Command}"
 
         notice "Determining packages to install."
+
+        local IgnorePackages
+        local old_IFS="${IFS}"
+        IFS='|'
+        IgnorePackages="${PM_PACKAGE_BLACKLIST[*]}"
+        IFS="${old_IFS}"
+
         local old_IFS="${IFS}"
         IFS='|'
         local DepsRegex="${Dependencies[*]}"
         IFS="${old_IFS}"
-        Command="apt-file search --regexp '/bin/(.*/)?(${DepsRegex})$'"
-        info "Running: ${C["RunningCommand"]}${Command}${NC}"
+
+        Command="apt-file search --regexp '/bin/(?:${DepsRegex})$'"
+        notice "Running: ${C["RunningCommand"]}${Command}${NC}"
         Packages="$(eval "2> /dev/null ${Command}")" ||
             fatal "Failed to find packages to install.\nFailing command: ${C["FailingCommand"]}${Command}"
         Packages="$(cut -d : -f 1 <<< "${Packages}")"
@@ -74,7 +81,7 @@ pm_apt_install_commands() {
         else
             notice "Installing packages."
             Command="sudo apt-get -y install ${Packages}"
-            info "Running: ${C["RunningCommand"]}${Command}${NC}"
+            notice "Running: ${C["RunningCommand"]}${Command}${NC}"
             eval "${REDIRECT}${Command}" ||
                 fatal "Failed to install dependencies from apt.\nFailing command: ${C["FailingCommand"]}${Command}"
         fi

--- a/.scripts/pm_apt_install_docker.sh
+++ b/.scripts/pm_apt_install_docker.sh
@@ -8,7 +8,7 @@ pm_apt_install_docker() {
     local RemovePackages="containerd docker docker-compose docker-engine docker.io runc"
     info "Removing conflicting Docker packages."
     local Command="sudo apt-get -y remove ${RemovePackages}"
-    info "Running: ${C["RunningCommand"]}${Command}${NC}"
+    notice "Running: ${C["RunningCommand"]}${Command}${NC}"
     eval "${Command}" > /dev/null 2>&1 || true
     run_script 'remove_snap_docker'
     run_script 'get_docker'

--- a/.scripts/pm_apt_repos.sh
+++ b/.scripts/pm_apt_repos.sh
@@ -17,12 +17,12 @@ pm_apt_repos() {
     if vergt "${MINIMUM_APT_TRANSPORT_HTTPS}" "${INSTALLED_APT_TRANSPORT_HTTPS:-0}"; then
         info "Updating repositories (before installing apt-transport-https)."
         COMMAND="sudo apt-get -y update"
-        info "Running: ${C["RunningCommand"]}${COMMAND}${NC}"
+        notice "Running: ${C["RunningCommand"]}${COMMAND}${NC}"
         eval "${REDIRECT}${COMMAND}" ||
             fatal "Failed to get updates from apt.\nFailing command: ${C["FailingCommand"]}${COMMAND}"
         info "Installing APT transport for downloading via the HTTP Secure protocol (HTTPS)."
         COMMAND="sudo apt-get -y install apt-transport-https"
-        info "Running: ${C["RunningCommand"]}${COMMAND}${NC}"
+        notice "Running: ${C["RunningCommand"]}${COMMAND}${NC}"
         eval "${REDIRECT}${COMMAND}" ||
             fatal "Failed to install apt-transport-https from apt.\nFailing command: ${C["FailingCommand"]}${COMMAND}"
     fi
@@ -39,13 +39,13 @@ pm_apt_repos() {
     fi
     info "Updating repositories."
     COMMAND="sudo apt-get -y update"
-    info "Running: ${C["RunningCommand"]}${COMMAND}${NC}"
+    notice "Running: ${C["RunningCommand"]}${COMMAND}${NC}"
     eval "${REDIRECT}${COMMAND}" ||
         fatal "Failed to get updates from apt.\nFailing command: ${C["FailingCommand"]}${COMMAND}"
     if vergt "${MINIMUM_LIBSECCOMP2}" "${INSTALLED_LIBSECCOMP2:-0}"; then
         info "Installing libseccomp2 from buster-backports repo."
         COMMAND="sudo apt-get -y install -t buster-backports libseccomp2"
-        info "Running: ${C["RunningCommand"]}${COMMAND}${NC}"
+        notice "Running: ${C["RunningCommand"]}${COMMAND}${NC}"
         eval "${REDIRECT}${COMMAND}" ||
             fatal "Failed to install libseccomp2 from buster-backports repo.\nFailing command: ${C["FailingCommand"]}${COMMAND}"
     fi

--- a/.scripts/pm_apt_upgrade.sh
+++ b/.scripts/pm_apt_upgrade.sh
@@ -12,7 +12,7 @@ pm_apt_upgrade() {
             #shellcheck disable=SC2016 # (info): Expressions don't expand in single quotes, use double quotes for that.
             REDIRECT='run_command_dialog "${Title}" "${COMMAND}" "" '
         fi
-        info "Running: ${C["RunningCommand"]}${COMMAND}${NC}"
+        notice "Running: ${C["RunningCommand"]}${COMMAND}${NC}"
         eval "${REDIRECT}${COMMAND}" ||
             fatal "Failed to upgrade packages from apt.\nFailing command: ${C["FailingCommand"]}${COMMAND}"
     fi

--- a/.scripts/pm_dnf_install_docker.sh
+++ b/.scripts/pm_dnf_install_docker.sh
@@ -7,7 +7,7 @@ pm_dnf_install_docker() {
     local RemovePackages="docker-client docker-client-latest docker-common docker-compose docker-engine docker-engine-selinux docker-latest docker-latest-logrotate docker-logrotate docker-selinux"
     info "Removing conflicting Docker packages."
     local Command="sudo dnf -y remove ${RemovePackages}"
-    info "Running: ${C["RunningCommand"]}${Command}${NC}"
+    notice "Running: ${C["RunningCommand"]}${Command}${NC}"
     eval "${Command}" > /dev/null 2>&1 || true
     run_script 'remove_snap_docker'
     run_script 'get_docker'

--- a/.scripts/pm_nala_clean.sh
+++ b/.scripts/pm_nala_clean.sh
@@ -4,11 +4,11 @@ IFS=$'\n\t'
 
 pm_nala_clean() {
     info "Removing unused packages."
-    info "Running: ${C["RunningCommand"]}sudo nala autoremove -y ${NC}"
+    notice "Running: ${C["RunningCommand"]}sudo nala autoremove -y ${NC}"
     sudo nala autoremove -y > /dev/null 2>&1 || fatal "Failed to remove unused packages from apt.\nFailing command: ${C["FailingCommand"]}sudo nala autoremove -y "
 
     info "Cleaning up package cache."
-    info "Running: ${C["RunningCommand"]}sudo nala clean${NC}"
+    notice "Running: ${C["RunningCommand"]}sudo nala clean${NC}"
     sudo nala clean > /dev/null 2>&1 || fatal "Failed to cleanup cache from nala.\nFailing command: ${C["FailingCommand"]}sudo nala clean"
 }
 

--- a/.scripts/pm_nala_install_docker.sh
+++ b/.scripts/pm_nala_install_docker.sh
@@ -8,7 +8,7 @@ pm_nala_install_docker() {
     local RemovePackages="containerd docker docker-compose docker-engine docker.io runc"
     info "Removing conflicting Docker packages."
     local Command="sudo nala remove -y ${RemovePackages}"
-    info "Running: ${C["RunningCommand"]}${Command}${NC}"
+    notice "Running: ${C["RunningCommand"]}${Command}${NC}"
     eval "${Command}" > /dev/null 2>&1 || true
     run_script 'remove_snap_docker'
     run_script 'get_docker'

--- a/.scripts/pm_nala_repos.sh
+++ b/.scripts/pm_nala_repos.sh
@@ -17,12 +17,12 @@ pm_nala_repos() {
     if vergt "${MINIMUM_APT_TRANSPORT_HTTPS}" "${INSTALLED_APT_TRANSPORT_HTTPS:-0}"; then
         info "Updating repositories (before installing apt-transport-https)."
         COMMAND="sudo nala update"
-        info "Running: ${C["RunningCommand"]}${COMMAND}${NC}"
+        notice "Running: ${C["RunningCommand"]}${COMMAND}${NC}"
         eval "${REDIRECT}${COMMAND}" ||
             fatal "Failed to get updates from nala.\nFailing command: ${C["FailingCommand"]}${COMMAND}"
         info "Installing APT transport for downloading via the HTTP Secure protocol (HTTPS)."
         COMMAND="sudo nala install -y apt-transport-https"
-        info "Running: ${C["RunningCommand"]}${COMMAND}${NC}"
+        notice "Running: ${C["RunningCommand"]}${COMMAND}${NC}"
         eval "${REDIRECT}${COMMAND}" ||
             fatal "Failed to install apt-transport-https from nala.\nFailing command: ${C["FailingCommand"]}${COMMAND}"
     fi
@@ -39,13 +39,13 @@ pm_nala_repos() {
     fi
     info "Updating repositories."
     COMMAND="sudo nala update"
-    info "Running: ${C["RunningCommand"]}${COMMAND}${NC}"
+    notice "Running: ${C["RunningCommand"]}${COMMAND}${NC}"
     eval "${REDIRECT}${COMMAND}" ||
         fatal "Failed to get updates from nala.\nFailing command: ${C["FailingCommand"]}${COMMAND}"
     if vergt "${MINIMUM_LIBSECCOMP2}" "${INSTALLED_LIBSECCOMP2:-0}"; then
         info "Installing libseccomp2 from buster-backports repo."
         COMMAND="sudo nala install -y -t buster-backports libseccomp2"
-        info "Running: ${C["RunningCommand"]}${COMMAND}${NC}"
+        notice "Running: ${C["RunningCommand"]}${COMMAND}${NC}"
         eval "${REDIRECT}${COMMAND}" ||
             fatal "Failed to install libseccomp2 from buster-backports repo.\nFailing command: ${C["FailingCommand"]}${COMMAND}"
     fi

--- a/.scripts/pm_nala_upgrade.sh
+++ b/.scripts/pm_nala_upgrade.sh
@@ -12,7 +12,7 @@ pm_nala_upgrade() {
             #shellcheck disable=SC2016 # (info): Expressions don't expand in single quotes, use double quotes for that.
             REDIRECT='run_command_dialog "${Title}" "${COMMAND}" "" '
         fi
-        info "Running: ${C["RunningCommand"]}${COMMAND}${NC}"
+        notice "Running: ${C["RunningCommand"]}${COMMAND}${NC}"
         eval "${REDIRECT}${COMMAND}" ||
             fatal "Failed to upgrade packages from nala.\nFailing command: ${C["FailingCommand"]}${COMMAND}"
     fi

--- a/.scripts/remove_snap_docker.sh
+++ b/.scripts/remove_snap_docker.sh
@@ -7,7 +7,7 @@ remove_snap_docker() {
         if snap services docker > /dev/null 2>&1; then
             info "Removing snap Docker package."
             local Command="sudo snap remove docker"
-            info "Running: ${C["RunningCommand"]}${Command}${NC}"
+            notice "Running: ${C["RunningCommand"]}${Command}${NC}"
             eval "${Command}" > /dev/null 2>&1 || true
         fi
     fi

--- a/main.sh
+++ b/main.sh
@@ -33,7 +33,7 @@ SCRIPTPATH=$(cd -P "$(dirname "$(get_scriptname)")" > /dev/null 2>&1 && pwd)
 readonly SCRIPTPATH
 SCRIPTNAME="${SCRIPTPATH}/$(basename "$(get_scriptname)")"
 readonly SCRIPTNAME
-declare -rx COMMAND_DEPS=(
+declare -arx COMMAND_DEPS=(
     "column"
     "curl"
     "dialog"
@@ -41,6 +41,14 @@ declare -rx COMMAND_DEPS=(
     "git"
     "grep"
     "sed"
+)
+
+declare -arx PM_PACKAGE_BLACKLIST=(
+    "9base"
+    "busybox-grep"
+    "busybox-sed"
+    "curl-minimal"
+    "gitlab-shell"
 )
 
 # System Information


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Introduce a global package blacklist and refactor package manager scripts to consistently apply it and standardize logging

New Features:
- Define a global PM_PACKAGE_BLACKLIST array in main.sh to list packages to exclude from installation

Enhancements:
- Load and apply IgnorePackages from PM_PACKAGE_BLACKLIST in each package manager install script
- Replace info-based "Running:" logs with notice for consistent severity across scripts
- Update regex patterns and dependency list construction for apt-file, repoquery, and pkgfile calls
- Use proper array declaration flags (declare -arx) for COMMAND_DEPS in main.sh