### PR TITLE
Search for packages one at a time instead of all at once with `apt-file`

### DIFF
--- a/.scripts/pm_apt_install.sh
+++ b/.scripts/pm_apt_install.sh
@@ -62,16 +62,19 @@ pm_apt_install_commands() {
         IgnorePackages="${PM_PACKAGE_BLACKLIST[*]}"
         IFS="${old_IFS}"
 
-        local old_IFS="${IFS}"
-        IFS='|'
-        local DepsRegex="${Dependencies[*]}"
-        IFS="${old_IFS}"
+        local Packages=''
+        for Dep in "${Dependencies[@]}"; do
+            Command="apt-file search bin/${Dep}"
+            notice "Running: ${C["RunningCommand"]}${Command}${NC}"
+            local NewPackages
+            NewPackages="$(eval "${Command}" 2> /dev/null)" ||
+                fatal "Failed to find packages to install.\nFailing command: ${C["FailingCommand"]}${Command}"
+            NewPackages="$(grep -E "s?bin/${Dep}$" <<< "${NewPackages}")"
+            NewPackages="$(cut -d : -f 1 <<< "${NewPackages}")"
+            Packages+="${NewPackages}"
+            Packages+=$'\n'
+        done
 
-        Command="apt-file search --regexp '/bin/(?:${DepsRegex})$'"
-        notice "Running: ${C["RunningCommand"]}${Command}${NC}"
-        Packages="$(eval "2> /dev/null ${Command}")" ||
-            fatal "Failed to find packages to install.\nFailing command: ${C["FailingCommand"]}${Command}"
-        Packages="$(cut -d : -f 1 <<< "${Packages}")"
         if [[ -n ${IgnorePackages} ]]; then
             Packages="$(grep -E -v "\b(${IgnorePackages})\b" <<< "${Packages}")"
         fi


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Use individual apt-file searches for each dependency in both apt and nala install scripts instead of a single bulk regex query

Enhancements:
- Iterate over dependencies and run separate apt-file search commands to collect packages
- Remove combined regex-based search logic and simplify package name extraction