### PR TITLE
Rename `COMMAND_DEPS` to `PM_COMMAND_DEPS`

### DIFF
--- a/.scripts/package_manager_run.sh
+++ b/.scripts/package_manager_run.sh
@@ -39,7 +39,7 @@ package_manager_run() {
     run_script "pm_${pm}_${action}"
 
     if [[ ${action} == "install" ]]; then
-        for CommandDep in "${COMMAND_DEPS[@]}"; do
+        for CommandDep in "${PM_COMMAND_DEPS[@]}"; do
             if [[ -z "$(command -v "${CommandDep}")" ]]; then
                 fatal "'${C["Program"]}${CommandDep}${NC}' is not available. Please install '${C["Program"]}${CommandDep}${NC}' and try again."
             fi

--- a/.scripts/pm_apk_install.sh
+++ b/.scripts/pm_apk_install.sh
@@ -27,7 +27,7 @@ pm_apk_install_commands() {
         REDIRECT='2>&1 '
     fi
 
-    local -a Dependencies=("${COMMAND_DEPS[@]}")
+    local -a Dependencies=("${PM_COMMAND_DEPS[@]}")
     if [[ ${FORCE-} != true ]]; then
         for index in "${!Dependencies[@]}"; do
             if [[ -n $(command -v "${Dependencies[index]}") ]]; then

--- a/.scripts/pm_apt_install.sh
+++ b/.scripts/pm_apt_install.sh
@@ -27,7 +27,7 @@ pm_apt_install_commands() {
         REDIRECT='2>&1 '
     fi
 
-    local -a Dependencies=("${COMMAND_DEPS[@]}")
+    local -a Dependencies=("${PM_COMMAND_DEPS[@]}")
     if [[ ${FORCE-} != true ]]; then
         for index in "${!Dependencies[@]}"; do
             if [[ -n $(command -v "${Dependencies[index]}") ]]; then

--- a/.scripts/pm_dnf_install.sh
+++ b/.scripts/pm_dnf_install.sh
@@ -27,7 +27,7 @@ pm_dnf_install_commands() {
         REDIRECT='2>&1 '
     fi
 
-    local -a Dependencies=("${COMMAND_DEPS[@]}")
+    local -a Dependencies=("${PM_COMMAND_DEPS[@]}")
     if [[ ${FORCE-} != true ]]; then
         for index in "${!Dependencies[@]}"; do
             if [[ -n $(command -v "${Dependencies[index]}") ]]; then

--- a/.scripts/pm_nala_install.sh
+++ b/.scripts/pm_nala_install.sh
@@ -27,7 +27,7 @@ pm_nala_install_commands() {
         REDIRECT='2>&1 '
     fi
 
-    local -a Dependencies=("${COMMAND_DEPS[@]}")
+    local -a Dependencies=("${PM_COMMAND_DEPS[@]}")
     if [[ ${FORCE-} != true ]]; then
         for index in "${!Dependencies[@]}"; do
             if [[ -n $(command -v "${Dependencies[index]}") ]]; then

--- a/.scripts/pm_pacman_install.sh
+++ b/.scripts/pm_pacman_install.sh
@@ -27,7 +27,7 @@ pm_pacman_install_commands() {
         REDIRECT='2>&1 '
     fi
 
-    local -a Dependencies=("${COMMAND_DEPS[@]}")
+    local -a Dependencies=("${PM_COMMAND_DEPS[@]}")
     if [[ ${FORCE-} != true ]]; then
         for index in "${!Dependencies[@]}"; do
             if [[ -n $(command -v "${Dependencies[index]}") ]]; then

--- a/.scripts/pm_yum_install.sh
+++ b/.scripts/pm_yum_install.sh
@@ -27,7 +27,7 @@ pm_yum_install_commands() {
         REDIRECT='2>&1 '
     fi
 
-    local -a Dependencies=("${COMMAND_DEPS[@]}")
+    local -a Dependencies=("${PM_COMMAND_DEPS[@]}")
     if [[ ${FORCE-} != true ]]; then
         for index in "${!Dependencies[@]}"; do
             if [[ -n $(command -v "${Dependencies[index]}") ]]; then

--- a/main.sh
+++ b/main.sh
@@ -33,7 +33,7 @@ SCRIPTPATH=$(cd -P "$(dirname "$(get_scriptname)")" > /dev/null 2>&1 && pwd)
 readonly SCRIPTPATH
 SCRIPTNAME="${SCRIPTPATH}/$(basename "$(get_scriptname)")"
 readonly SCRIPTNAME
-declare -arx COMMAND_DEPS=(
+declare -arx PM_COMMAND_DEPS=(
     "column"
     "curl"
     "dialog"


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Clarify the dependency variable by renaming COMMAND_DEPS to PM_COMMAND_DEPS across all package manager scripts

Enhancements:
- Rename the COMMAND_DEPS array to PM_COMMAND_DEPS in main.sh
- Update all references in package_manager_run.sh and pm_*_install.sh to use PM_COMMAND_DEPS