### PR TITLE
Update command line usage error notices slightly

### DIFF
--- a/.includes/cmdline.sh
+++ b/.includes/cmdline.sh
@@ -83,17 +83,11 @@ parse_arguments() {
                         FailingOption="$(quote_elements_with_spaces "${OPTION}")"
                         FailingCommand="$(printf "'${C["UserCommand"]-}%s${NC-} ${C["UserCommandError"]-}%s${NC-}'" "${FailingCommand}" "${FailingOption}")"
                         FailingOption="$(printf "'${C["UserCommand"]-}%s${NC-}%s${NC-}'" "${OPTION}")"
-                        error \
-                            "Error in command line:\n" \
-                            "\n" \
-                            "   ${FailingCommand}\n" \
-                            "\n" \
-                            "   Option ${FailingOption} requires a paramenter.\n" \
-                            "\n" \
-                            "Usage is:\n" \
-                            "\n" \
-                            "$(usage "${OPTION}")\n" \
-                            "\n"
+                        local FailingMessage
+                        FailingMessage=$(
+                            printf '%s\n\nOption %s requires a parameter.\n' "${FailingCommand}" "${FailingOption}"
+                        )
+                        error "$(cmdline_error "${OPTION}" "${FailingMessage}")"
                         exit 1
                     fi
                     CurrentCommand+=("${OPTION}" "${!OPTIND}")
@@ -130,17 +124,11 @@ parse_arguments() {
                         FailingCommandOption="$(quote_elements_with_spaces "${FailingCommandOption}")"
                         FailingCommand="$(printf "${NC-}'${C["UserCommand"]-}%s %s${NC-}'" "${FailingCommand}" "${FailingCommandOption}")"
                         FailingOption="$(printf "${NC-}'${C["UserCommand"]-}%s${NC-}'" "${Command}")"
-                        error \
-                            "Error in command line:\n" \
-                            "\n" \
-                            "   ${FailingCommand}\n" \
-                            "\n" \
-                            "   Option ${FailingOption} requires a variable.\n" \
-                            "\n" \
-                            "Usage is:\n" \
-                            "\n" \
-                            "$(usage "${Command}")\n" \
-                            "\n"
+                        local FailingMessage
+                        FailingMessage=$(
+                            printf '%s\n\nOption %s requires a variable.\n' "${FailingCommand}" "${FailingOption}"
+                        )
+                        error "$(cmdline_error "${OPTION}" "${FailingMessage}")"
                         exit 1
                     fi
                     CurrentCommand+=("${OPTION}")
@@ -162,17 +150,11 @@ parse_arguments() {
                         FailingCommandOption="$(quote_elements_with_spaces "${FailingCommandOption}")"
                         FailingCommand="$(printf "${NC-}'${C["UserCommand"]-}%s %s${NC-}'" "${FailingCommand}" "${FailingCommandOption}")"
                         FailingOption="$(printf "${NC-}'${C["UserCommand"]-}%s${NC-}'" "${Command}")"
-                        error \
-                            "Error in command line:\n" \
-                            "\n" \
-                            "   ${FailingCommand}\n" \
-                            "\n" \
-                            "   Option ${FailingOption} requires a variable and a value.\n" \
-                            "\n" \
-                            "Usage is:\n" \
-                            "\n" \
-                            "$(usage "${Command}")\n" \
-                            "\n"
+                        local FailingMessage
+                        FailingMessage=$(
+                            printf '%s\n\nOption %s requires a variable and a value.\n' "${FailingCommand}" "${FailingOption}"
+                        )
+                        error "$(cmdline_error "${OPTION}" "${FailingMessage}")"
                         exit 1
                     fi
                     CurrentCommand+=("${OPTION}")
@@ -187,17 +169,11 @@ parse_arguments() {
                         FailingOption="$(quote_elements_with_spaces "${OPTION}")"
                         FailingCommand="$(printf "'${C["UserCommand"]-}%s${NC-} ${C["UserCommandError"]-}%s${NC-}'" "${FailingCommand}" "${FailingOption}")"
                         FailingOption="$(printf "'${C["UserCommand"]-}%s${NC-}%s${NC-}'" "${OPTION}")"
-                        error \
-                            "Error in command line:\n" \
-                            "\n" \
-                            "   ${FailingCommand}\n" \
-                            "\n" \
-                            "   Option ${FailingOption} requires a variable and a value.\n" \
-                            "\n" \
-                            "Usage is:\n" \
-                            "\n" \
-                            "$(usage "${OPTION}")\n" \
-                            "\n"
+                        local FailingMessage
+                        FailingMessage=$(
+                            printf '%s\n\nOption %s requires a variable and a value.\n' "${FailingCommand}" "${FailingOption}"
+                        )
+                        error "$(cmdline_error "${OPTION}" "${FailingMessage}")"
                         exit 1
                     fi
                     CurrentCommand+=("${OPTION}" "${!OPTIND}")
@@ -219,17 +195,11 @@ parse_arguments() {
                         FailingOption="$(quote_elements_with_spaces "${OPTION}")"
                         FailingCommand="$(printf "'${C["UserCommand"]-}%s${NC-} ${C["UserCommandError"]-}%s${NC-}'" "${FailingCommand}" "${FailingOption}")"
                         FailingOption="$(printf "'${C["UserCommand"]-}%s${NC-}%s${NC-}'" "${OPTION}")"
-                        error \
-                            "Error in command line:\n" \
-                            "\n" \
-                            "   ${FailingCommand}\n" \
-                            "\n" \
-                            "   Option ${FailingOption} requires a parameter.\n" \
-                            "\n" \
-                            "Usage is:\n" \
-                            "\n" \
-                            "$(usage "${OPTION}")\n" \
-                            "\n"
+                        local FailingMessage
+                        FailingMessage=$(
+                            printf '%s\n\nOption %s requires a parameter.\n' "${FailingCommand}" "${FailingOption}"
+                        )
+                        error "$(cmdline_error "${OPTION}" "${FailingMessage}")"
                         exit 1
                     fi
                     CurrentCommand+=("${OPTION}")
@@ -267,17 +237,9 @@ parse_arguments() {
                                 local PreviousArgsString
                                 PreviousArgsString="${APPLICATION_COMMAND} $(xargs <<< "${ParsedArgs[@]-}")"
                                 PreviousArgsString="$(xargs <<< "${PreviousArgsString}") ${OPTION}"
-                                error \
-                                    "Error in command line:\n" \
-                                    "\n" \
-                                    "   '${C["UserCommand"]-}${PreviousArgsString}${NC-} ${C["UserCommandError"]-}${!OPTIND}${NC-}'\n" \
-                                    "\n" \
-                                    "   Invalid compose option '${C["UserCommand"]-}${!OPTIND}${NC-}'.\n" \
-                                    "\n" \
-                                    "Usage is:\n" \
-                                    "\n" \
-                                    "$(usage "${OPTION}")\n" \
-                                    "\n"
+                                local FailingMessage
+                                FailingMessage="'${C["UserCommand"]-}${PreviousArgsString}${NC-} ${C["UserCommandError"]-}${!OPTIND}${NC-}'\n\nInvalid compose option '${C["UserCommand"]-}${!OPTIND}${NC-}'."
+                                error "$(cmdline_error "${OPTION}" "${FailingMessage}")"
                                 exit 1
                                 ;;
                         esac
@@ -876,4 +838,30 @@ unset_flags() {
     set +x
     declare -gx PROMPT="CLI"
     unset FORCE VERBOSE DEBUG TRACE
+}
+
+cmdline_error() {
+    local Command=${1-}
+    local Message=${2-}
+
+    local -i UsageIndent=3
+
+    Message=${Message//\\n/$'\n'}
+    Message="$(pr -e -t -o "${UsageIndent}" <<< "${Message}" | sed 's/[[:space:]]\+$//')"
+
+    local UsageText
+    if [[ -z ${Command} ]]; then
+        UsageText="Run '${C["UserCommand"]-}ds --help${NC-}' for usage."
+    else
+        local CommandUsage
+        CommandUsage="$(usage "${Command}")"
+        UsageText="Usage is:\n$(pr -e -t -o "${UsageIndent}" <<< "${CommandUsage}")"
+    fi
+    cat << EOF
+Error in command line:
+
+${Message}
+
+${UsageText}
+EOF
 }

--- a/.includes/usage.sh
+++ b/.includes/usage.sh
@@ -158,7 +158,7 @@ EOF
     Get the literal value (including quotes) of a <var>iable
 EOF
             ;;&
-        "")
+        --env-set | --env-set= | "")
             Found=1
             cat << EOF
 --env-set <var>=<val>


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Refactor command-line argument error handling to use a centralized helper for consistent formatting and simplify error notice logic

Enhancements:
- Add cmdline_error function to generate standardized error messages with usage instructions
- Replace multiple inline error message blocks in parse_arguments with calls to cmdline_error
- Update usage.sh to group the --env-set case with an empty pattern for consistent usage output