### PR TITLE
Change from using `((++LineNumber))` to using `LineNumber+=1`

### DIFF
--- a/.scripts/menu_config_vars.sh
+++ b/.scripts/menu_config_vars.sh
@@ -46,7 +46,7 @@ menu_config_vars() {
 
         # Add lines from global .env file to the dialog
         if [[ -n ${APPNAME-} ]]; then
-            ((++LineNumber))
+            LineNumber+=1
             LineColor[LineNumber]="${DC["LineHeading"]-}"
             CurrentValueOnLine[LineNumber]="*** ${COMPOSE_ENV} ***"
         fi
@@ -56,7 +56,7 @@ menu_config_vars() {
             run_script 'env_format_lines' "${CurrentGlobalEnvFile}" "${DefaultGlobalEnvFile}" "${APPNAME}"
         )
         for line in "${CurrentGlobalEnvLines[@]-}"; do
-            ((++LineNumber))
+            LineNumber+=1
             CurrentValueOnLine[LineNumber]="${line}"
             local VarName
             VarName="$(grep -o -P '^\w+(?=)' <<< "${line}")"
@@ -81,17 +81,17 @@ menu_config_vars() {
                 LineColor[LineNumber]="${DC["LineAddVariable"]-}"
             fi
         done
-        ((LineNumber++))
+        LineNumber+=1
         local AddGlobalVariableLineNumber=${LineNumber}
         CurrentValueOnLine[LineNumber]="${AddVariableText}"
         LineColor[LineNumber]="${DC["LineAddVariable"]-}"
 
         if [[ -n ${APPNAME-} ]]; then
             # Add lines from appvar.env file to the dialog
-            ((++LineNumber))
+            LineNumber+=1
             CurrentValueOnLine[LineNumber]=""
             LineColor[LineNumber]="${DC["LineOther"]-}"
-            ((++LineNumber))
+            LineNumber+=1
             CurrentValueOnLine[LineNumber]="*** $(run_script 'app_env_file' "${APPNAME}") ***"
             LineColor[LineNumber]="${DC["LineHeading"]-}"
             run_script 'appvars_lines' "${APPNAME}:" > "${CurrentAppEnvFile}"
@@ -100,7 +100,7 @@ menu_config_vars() {
                 run_script 'env_format_lines' "${CurrentAppEnvFile}" "${DefaultAppEnvFile}" "${APPNAME}"
             )
             for line in "${CurrentAppEnvLines[@]}"; do
-                ((++LineNumber))
+                LineNumber+=1
                 CurrentValueOnLine[LineNumber]="${line}"
                 local VarName
                 VarName="$(grep -o -P '^\w+(?=)' <<< "${line}")"
@@ -125,7 +125,7 @@ menu_config_vars() {
                     LineColor[LineNumber]="${DC["LineOther"]-}"
                 fi
             done
-            ((LineNumber++))
+            LineNumber+=1
             local AddAppEnvVariableLineNumber=${LineNumber}
             CurrentValueOnLine[LineNumber]="${AddVariableText}"
             LineColor[LineNumber]="${DC["LineAddVariable"]-}"


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Enhancements:
- Replace all instances of ((++LineNumber)) and ((LineNumber++)) with LineNumber+=1 for consistency