### PR TITLE
Move cursor to bottom of screen after dialog exits

### DIFF
--- a/.includes/dialog_functions.sh
+++ b/.includes/dialog_functions.sh
@@ -71,6 +71,7 @@ _dialog_backtitle_() {
 _dialog_() {
     _dialog_backtitle_
     ${DIALOG} --file "${DIALOG_OPTIONS_FILE}" --backtitle "${BACKTITLE}" "$@"
+    echo -n "${BS}"
 }
 
 # Check to see if we should use a dialog box
@@ -93,7 +94,6 @@ dialog_pipe() {
         --timeout "${TimeOut}" \
         --programbox "${DC["Subtitle"]-}${SubTitle}" \
         "$((LINES - DC["WindowRowsAdjust"]))" "$((COLUMNS - DC["WindowColsAdjust"]))" || true
-    echo -n "${BS}"
 }
 # Script Dialog Runner Function
 run_script_dialog() {
@@ -154,7 +154,6 @@ dialog_info() {
         --title "${Title}" \
         --infobox "${Message}" \
         "$((LINES - DC["WindowRowsAdjust"]))" "$((COLUMNS - DC["WindowColsAdjust"]))"
-    echo -n "${BS}"
 }
 dialog_message() {
     local Title=${1:-}
@@ -170,7 +169,6 @@ dialog_message() {
         --timeout "${TimeOut}" \
         --msgbox "${Message}" \
         "$((LINES - DC["WindowRowsAdjust"]))" "$((COLUMNS - DC["WindowColsAdjust"]))"
-    echo -n "${BS}"
 }
 dialog_error() {
     local Title=${1:-}


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Centralize cursor repositioning by moving the echo of the backspace sequence to the main _dialog_ function and removing redundant calls from individual dialog helpers

Enhancements:
- Add cursor-reset echo to the core _dialog_ function
- Remove duplicate cursor-reset calls from dialog_pipe, dialog_info, dialog_message, and dialog_error