### PR TITLE
Strip ANSI colors in dialog box when updating DockSTARTer

### DIFF
--- a/.includes/dialog_functions.sh
+++ b/.includes/dialog_functions.sh
@@ -71,7 +71,6 @@ _dialog_backtitle_() {
 _dialog_() {
     _dialog_backtitle_
     ${DIALOG} --file "${DIALOG_OPTIONS_FILE}" --backtitle "${BACKTITLE}" "$@"
-    echo -n "${BS}"
 }
 
 # Check to see if we should use a dialog box
@@ -94,6 +93,7 @@ dialog_pipe() {
         --timeout "${TimeOut}" \
         --programbox "${DC["Subtitle"]-}${SubTitle}" \
         "$((LINES - DC["WindowRowsAdjust"]))" "$((COLUMNS - DC["WindowColsAdjust"]))" || true
+    echo -n "${BS}"
 }
 # Script Dialog Runner Function
 run_script_dialog() {
@@ -154,6 +154,7 @@ dialog_info() {
         --title "${Title}" \
         --infobox "${Message}" \
         "$((LINES - DC["WindowRowsAdjust"]))" "$((COLUMNS - DC["WindowColsAdjust"]))"
+    echo -n "${BS}"
 }
 dialog_message() {
     local Title=${1:-}
@@ -169,6 +170,7 @@ dialog_message() {
         --timeout "${TimeOut}" \
         --msgbox "${Message}" \
         "$((LINES - DC["WindowRowsAdjust"]))" "$((COLUMNS - DC["WindowColsAdjust"]))"
+    echo -n "${BS}"
 }
 dialog_error() {
     local Title=${1:-}

--- a/.scripts/update_self.sh
+++ b/.scripts/update_self.sh
@@ -79,6 +79,7 @@ update_self() {
     fi
 
     if use_dialog_box; then
+        YesNotice="$(strip_ansi_colors "${YesNotice}")"
         commands_update_self "${BRANCH}" "${YesNotice}" "$@" |&
             dialog_pipe "${DC["TitleSuccess"]-}${Title}" "${YesNotice}\n${DC["CommandLine"]-} ${APPLICATION_COMMAND} --update $*"
     else


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Ensure dialog boxes display clean messages by stripping ANSI color codes and resetting the prompt state after each invocation

Enhancements:
- Add echo of backspace sequence after each dialog function to clear residual characters
- Strip ANSI escape codes from update notification messages before piping them into dialog boxes in update_self.sh