### PR TITLE
Use bash regex instead of grep when searching for dependencies with apt-file

### DIFF
--- a/.includes/dialog_functions.sh
+++ b/.includes/dialog_functions.sh
@@ -71,7 +71,6 @@ _dialog_backtitle_() {
 _dialog_() {
     _dialog_backtitle_
     ${DIALOG} --file "${DIALOG_OPTIONS_FILE}" --backtitle "${BACKTITLE}" "$@"
-    echo -n "${BS}"
 }
 
 # Check to see if we should use a dialog box
@@ -94,6 +93,7 @@ dialog_pipe() {
         --timeout "${TimeOut}" \
         --programbox "${DC["Subtitle"]-}${SubTitle}" \
         "$((LINES - DC["WindowRowsAdjust"]))" "$((COLUMNS - DC["WindowColsAdjust"]))" || true
+    echo -n "${BS}"
 }
 # Script Dialog Runner Function
 run_script_dialog() {
@@ -154,6 +154,7 @@ dialog_info() {
         --title "${Title}" \
         --infobox "${Message}" \
         "$((LINES - DC["WindowRowsAdjust"]))" "$((COLUMNS - DC["WindowColsAdjust"]))"
+    echo -n "${BS}"
 }
 dialog_message() {
     local Title=${1:-}
@@ -169,6 +170,7 @@ dialog_message() {
         --timeout "${TimeOut}" \
         --msgbox "${Message}" \
         "$((LINES - DC["WindowRowsAdjust"]))" "$((COLUMNS - DC["WindowColsAdjust"]))"
+    echo -n "${BS}"
 }
 dialog_error() {
     local Title=${1:-}

--- a/.scripts/pm_nala_install.sh
+++ b/.scripts/pm_nala_install.sh
@@ -55,30 +55,9 @@ pm_nala_install_commands() {
             fatal "Failed to get updates from apt.\nFailing command: ${C["FailingCommand"]}${Command}"
 
         notice "Determining packages to install."
+        local Packages
+        Packages="$(detect_packages "${Dependencies[@]}" | xargs)"
 
-        local IgnorePackages
-        local old_IFS="${IFS}"
-        IFS='|'
-        IgnorePackages="${PM_PACKAGE_BLACKLIST[*]}"
-        IFS="${old_IFS}"
-
-        local Packages=''
-        for Dep in "${Dependencies[@]}"; do
-            Command="apt-file search bin/${Dep}"
-            notice "Running: ${C["RunningCommand"]}${Command}${NC}"
-            local NewPackages
-            NewPackages="$(eval "${Command}" 2> /dev/null)" ||
-                fatal "Failed to find packages to install.\nFailing command: ${C["FailingCommand"]}${Command}"
-            NewPackages="$(grep -E "s?bin/${Dep}$" <<< "${NewPackages}")"
-            NewPackages="$(cut -d : -f 1 <<< "${NewPackages}")"
-            Packages+="${NewPackages}"
-            Packages+=$'\n'
-        done
-
-        if [[ -n ${IgnorePackages} ]]; then
-            Packages="$(grep -E -v "\b(${IgnorePackages})\b" <<< "${Packages}")"
-        fi
-        Packages="$(sort -u <<< "${Packages}" | xargs)"
         if [[ -z ${Packages} ]]; then
             notice "No packages found to install."
         else
@@ -90,6 +69,32 @@ pm_nala_install_commands() {
         fi
     fi
 }
+
+detect_packages() {
+    local -a Dependencies=("$@")
+
+    Old_IFS="${IFS}"
+    IFS='|'
+    RegEx_Dependencies="(${Dependencies[*]})"
+    RegEx_Package_Blacklist="(${PM_PACKAGE_BLACKLIST[*]-})"
+    IFS="${Old_IFS}"
+
+    local RegEx_AptFile="^(.*):.*/s?bin/${RegEx_Dependencies}$"
+
+    for Dep in "${Dependencies[@]}"; do
+        local Command="apt-file search bin/${Dep}"
+        notice "Running: ${C["RunningCommand"]}${Command}${NC}"
+        eval "${Command}" 2> /dev/null
+    done | while IFS= read -r line; do
+        if [[ ${line} =~ ${RegEx_AptFile} ]]; then
+            local Package="${BASH_REMATCH[1]}"
+            if [[ ! ${Package} =~ ^${RegEx_Package_Blacklist}$ ]]; then
+                echo "${Package}"
+            fi
+        fi
+    done | sort -u
+}
+
 test_pm_nala_install() {
     #run_script 'pm_nala_repos'
     #run_script 'pm_nala_install'


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Refactor dependency detection in apt-based installers to use a shared function with bash regex filtering

Enhancements:
- Extract repeated apt-file search and filtering logic into a new detect_packages function
- Replace inline grep-based dependency matching and blacklist filtering with bash regex in both pm_apt_install and pm_nala_install scripts