### PR TITLE
Add color to the usage text

### DIFF
--- a/.includes/usage.sh
+++ b/.includes/usage.sh
@@ -87,7 +87,7 @@ EOF
         -a | --add | "")
             Found=1
             cat << EOF
-${C["UserCommand"]-}-a --add${NC-} <app> [<app> ...]${NC-}
+${C["UserCommand"]-}-a --add${NC-} ${C["App"]-}<app>${NC-} [${C["App"]-}<app>${NC-} ...]${NC-}
     Add the default variables for the app(s) specified
 EOF
             ;;&

--- a/.includes/usage.sh
+++ b/.includes/usage.sh
@@ -18,8 +18,8 @@ usage() {
                     APPLICATION_HEADING+=" (${C["Update"]-}Update Available${NC-})"
                 fi
                 cat << EOF
-Usage: ${C["UserCommand"]-}${APPLICATION_COMMAND}${NC-} [${C["UserCommand"]-}<Flags>${NC-}] [${C["UserCommand"]-}<Command>${NC-}] ...
-NOTE: The '${C["UserCommand"]-}${APPLICATION_COMMAND}${NC-}' shortcut is only available after the first run of
+Usage: ${C["UsageCommand"]-}${APPLICATION_COMMAND}${NC-} [${C["UsageCommand"]-}<Flags>${NC-}] [${C["UsageCommand"]-}<Command>${NC-}] ...
+NOTE: The '${C["UsageCommand"]-}${APPLICATION_COMMAND}${NC-}' shortcut is only available after the first run of
     bash main.sh
 
 ${APPLICATION_HEADING}
@@ -31,9 +31,9 @@ the order given, only stopping on an error. Any flags included only apply to the
 following command, and get reset before the next command.
 
 Any command that takes a variable name, the variable will by default be looked for
-in the global '${C["File"]-}.env${NC-}' file. If the variable name used is in form of '${C["Var"]-}app:var${NC-}', it
-will instead refer to the variable '${C["Var"]-}<var>${NC-}' in '${C["File"]-}.env.app.<app>${NC-}'.  Some commands
-that take app names can use the form '${C["Var"]-}app:${NC-}' to refer to the same file.
+in the global '${C["UsageFile"]-}.env${NC-}' file. If the variable name used is in form of '${C["UsageVar"]-}app:var${NC-}', it
+will instead refer to the variable '${C["UsageVar"]-}${C["UsageVar"]-}<var>${NC-}' in '${C["UsageFile"]-}.env.app.<app>${NC-}'.  Some commands
+that take app names can use the form '${C["UsageVar"]-}app:${NC-}' to refer to the same file.
 
 EOF
             fi
@@ -50,28 +50,28 @@ EOF
         -f | --force | "")
             Found=1
             cat << EOF
-${C["UserCommand"]-}-f --force${NC-}
+${C["UsageCommand"]-}-f --force${NC-}
     Force certain install/upgrade actions to run even if they would not be needed.
 EOF
             ;;&
         -g | --gui | "")
             Found=1
             cat << EOF
-${C["UserCommand"]-}-g --gui${NC-}
+${C["UsageCommand"]-}-g --gui${NC-}
     Use dialog boxes
 EOF
             ;;&
         -v | --verbose | "")
             Found=1
             cat << EOF
-${C["UserCommand"]-}-v --verbose${NC-}
+${C["UsageCommand"]-}-v --verbose${NC-}
     Verbose
 EOF
             ;;&
         -x | --debug | "")
             Found=1
             cat << EOF
-${C["UserCommand"]-}-x --debug${NC-}
+${C["UsageCommand"]-}-x --debug${NC-}
     Debug
 EOF
             ;;&
@@ -87,103 +87,103 @@ EOF
         -a | --add | "")
             Found=1
             cat << EOF
-${C["UserCommand"]-}-a --add${NC-} ${C["App"]-}<app>${NC-} [${C["App"]-}<app>${NC-} ...]${NC-}
+${C["UsageCommand"]-}-a --add${NC-} ${C["UsageApp"]-}<app>${NC-} [${C["UsageApp"]-}<app>${NC-} ...]${NC-}
     Add the default variables for the app(s) specified
 EOF
             ;;&
         -c | --compose | "")
             Found=1
             cat << EOF
-${C["UserCommand"]-}-c --compose${NC-} < pull | up | down | stop | restart | update > [<app> ...]${NC-}
+${C["UsageCommand"]-}-c --compose${NC-} < ${C["UsageOption"]-}pull${NC-} | ${C["UsageOption"]-}up${NC-} | ${C["UsageOption"]-}down${NC-} | ${C["UsageOption"]-}stop${NC-} | ${C["UsageOption"]-}restart${NC-} | ${C["UsageOption"]-}update${NC-} > [${C["UsageApp"]-}<app>${NC-} ...]${NC-}
     Run docker compose commands. If no command is given, does an update.
-    Update is the same as a 'pull' followed by an 'up'
-${C["UserCommand"]-}-c --compose${NC-} < generate | merge >${NC-}
-    Generates the docker-compose.yml file
+    The '${C["UsageOption"]-}update${NC-}' command is the same as a '${C["UsageOption"]-}pull${NC-}' followed by an '${C["UsageOption"]-}up${NC-}'
+${C["UsageCommand"]-}-c --compose${NC-} < ${C["UsageOption"]-}generate${NC-} | ${C["UsageOption"]-}merge${NC-} >${NC-}
+    Generates the '${C["UsageFile"]-}docker-compose.yml${NC-} file
 EOF
             ;;&
         -e | --env | "")
             Found=1
             cat << EOF
-${C["UserCommand"]-}-e --env${NC-}
-    Update your '${C["File"]-}.env${NC-}' files with new variables
+${C["UsageCommand"]-}-e --env${NC-}
+    Update your '${C["UsageFile"]-}.env${NC-}' files with new variables
 EOF
             ;;&
         --env-appvars | "")
             Found=1
             cat << EOF
-${C["UserCommand"]-}--env-appvars${NC-} <app> [<app> ...]${NC-}
+${C["UsageCommand"]-}--env-appvars${NC-} ${C["UsageApp"]-}<app>${NC-} [${C["UsageApp"]-}<app>${NC-} ...]${NC-}
     List all variable names for the app(s) specified
 EOF
             ;;&
         --env-appvars-lines | "")
             Found=1
             cat << EOF
-${C["UserCommand"]-}--env-appvars-lines${NC-} <app> [<app> ...]${NC-}
+${C["UsageCommand"]-}--env-appvars-lines${NC-} ${C["UsageApp"]-}<app>${NC-} [${C["UsageApp"]-}<app>${NC-} ...]${NC-}
     List all variables and values for the app(s) specified
 EOF
             ;;&
         --env-get | --env-get= | "")
             Found=1
             cat << EOF
-${C["UserCommand"]-}--env-get${NC-} <var> [<var> ...]${NC-}
-${C["UserCommand"]-}--env-get=${NC-}<var>${NC-}
-    Get the value of a <var>iable (variable name is forced to UPPER CASE)
+${C["UsageCommand"]-}--env-get${NC-} ${C["UsageVar"]-}<var>${NC-} [${C["UsageVar"]-}<var>${NC-} ...]${NC-}
+${C["UsageCommand"]-}--env-get=${NC-}${C["UsageVar"]-}<var>${NC-}
+    Get the value of a ${C["UsageVar"]-}<var>${NC-}iable (variable name is forced to UPPER CASE)
 EOF
             ;;&
         --env-get-line | --env-get-line= | "")
             Found=1
             cat << EOF
-${C["UserCommand"]-}--env-get-line${NC-} <var> [<var> ...]${NC-}
-${C["UserCommand"]-}--env-get-line=${NC-}<var>${NC-}
-    Get the line of a <var>iable (variable name is forced to UPPER CASE)
+${C["UsageCommand"]-}--env-get-line${NC-} ${C["UsageVar"]-}<var>${NC-} [${C["UsageVar"]-}<var>${NC-} ...]${NC-}
+${C["UsageCommand"]-}--env-get-line=${NC-}${C["UsageVar"]-}<var>${NC-}
+    Get the line of a ${C["UsageVar"]-}<var>${NC-}iable (variable name is forced to UPPER CASE)
 EOF
             ;;&
         --env-get-literal | --env-get-literal= | "")
             Found=1
             cat << EOF
-${C["UserCommand"]-}--env-get-literal${NC-} <var> [<var> ...]${NC-}
-${C["UserCommand"]-}--env-get-literal${NC-}=<var>${NC-}
-    Get the literal value (including quotes) of a <var>iable (variable name is forced to UPPER CASE)
+${C["UsageCommand"]-}--env-get-literal${NC-} ${C["UsageVar"]-}<var>${NC-} [${C["UsageVar"]-}<var>${NC-} ...]${NC-}
+${C["UsageCommand"]-}--env-get-literal${NC-}=${C["UsageVar"]-}<var>${NC-}
+    Get the literal value (including quotes) of a ${C["UsageVar"]-}<var>${NC-}iable (variable name is forced to UPPER CASE)
 EOF
             ;;&
         --env-get-lower | --env-get-lower= | "")
             Found=1
             cat << EOF
-${C["UserCommand"]-}--env-get-lower${NC-} <var> [<var> ...]${NC-}
-${C["UserCommand"]-}--env-get-lower${NC-}=<var>${NC-}
-    Get the value of a <var>iable
+${C["UsageCommand"]-}--env-get-lower${NC-} ${C["UsageVar"]-}<var>${NC-} [${C["UsageVar"]-}<var>${NC-} ...]${NC-}
+${C["UsageCommand"]-}--env-get-lower${NC-}=${C["UsageVar"]-}<var>${NC-}
+    Get the value of a ${C["UsageVar"]-}<var>${NC-}iable
 EOF
             ;;&
         --env-get-lower-line | --env-get-lower-line= | "")
             Found=1
             cat << EOF
-${C["UserCommand"]-}--env-get-lower-line${NC-} <var> [<var> ...]
-${C["UserCommand"]-}--env-get-lower-line=<var>${NC-}
-    Get the line of a <var>iable
+${C["UsageCommand"]-}--env-get-lower-line${NC-} ${C["UsageVar"]-}<var>${NC-} [${C["UsageVar"]-}<var>${NC-} ...]
+${C["UsageCommand"]-}--env-get-lower-line=${NC-}${C["UsageVar"]-}<var>${NC-}
+    Get the line of a ${C["UsageVar"]-}<var>${NC-}iable
 EOF
             ;;&
         --env-get-lower-literal | --env-get-lower-literal= | "")
             Found=1
             cat << EOF
-${C["UserCommand"]-}--env-get-lower-literal${NC-} <var> [<var> ...]${NC-}
-${C["UserCommand"]-}--env-get-lower-literal=${NC-}<var>${NC-}
-    Get the literal value (including quotes) of a <var>iable
+${C["UsageCommand"]-}--env-get-lower-literal${NC-} ${C["UsageVar"]-}<var>${NC-} [${C["UsageVar"]-}<var>${NC-} ...]${NC-}
+${C["UsageCommand"]-}--env-get-lower-literal=${NC-}${C["UsageVar"]-}<var>${NC-}
+    Get the literal value (including quotes) of a ${C["UsageVar"]-}<var>${NC-}iable
 EOF
             ;;&
         --env-set | --env-set= | "")
             Found=1
             cat << EOF
-${C["UserCommand"]-}--env-set${NC-} <var>=<val>${NC-}
-${C["UserCommand"]-}--env-set=${NC-}<var>,<val>${NC-}
-    Set the <val>ue of a <var>iable in '${C["File"]-}.env${NC-}' (variable name is forced to UPPER CASE).
+${C["UsageCommand"]-}--env-set${NC-} ${C["UsageVar"]-}<var>=<val>${NC-}
+${C["UsageCommand"]-}--env-set=${NC-}${C["UsageVar"]-}<var>,<val>${NC-}
+    Set the ${C["UsageVar"]-}<val>${NC-}ue of a ${C["UsageVar"]-}<var>${NC-}iable (variable name is forced to UPPER CASE).
 EOF
             ;;&
         --env-set-lower | --env-set-lower= | "")
             Found=1
             cat << EOF
-${C["UserCommand"]-}--env-set-lower${NC-} <var>=<val>${NC-}
-${C["UserCommand"]-}--env-set-lower=${NC-}<var>,<val>${NC-}
-    Set the <val>ue of a <var>iable in .env
+${C["UsageCommand"]-}--env-set-lower${NC-} ${C["UsageVar"]-}<var>${NC-}=${C["UsageVar"]-}<val>${NC-}
+${C["UsageCommand"]-}--env-set-lower=${NC-}${C["UsageVar"]-}<var>${NC-},${C["UsageVar"]-}<val>${NC-}
+    Set the ${C["UsageVar"]-}<val>${NC-}ue of a ${C["UsageVar"]-}<var>${NC-}iable
 EOF
             ;;&
         -l | --list) ;&
@@ -197,62 +197,62 @@ EOF
         "")
             Found=1
             cat << EOF
-${C["UserCommand"]-}-l --list${NC-}
+${C["UsageCommand"]-}-l --list${NC-}
     List all apps
-${C["UserCommand"]-}--list-added${NC-}
+${C["UsageCommand"]-}--list-added${NC-}
     List added apps
-${C["UserCommand"]-}--list-builtin${NC-}
+${C["UsageCommand"]-}--list-builtin${NC-}
     List builtin apps
-${C["UserCommand"]-}--list-deprecated${NC-}
+${C["UsageCommand"]-}--list-deprecated${NC-}
     List deprecated apps
-${C["UserCommand"]-}--list-enabled${NC-}
+${C["UsageCommand"]-}--list-enabled${NC-}
     List enabled apps
-${C["UserCommand"]-}--list-disabled${NC-}
+${C["UsageCommand"]-}--list-disabled${NC-}
     List disabled apps
-${C["UserCommand"]-}--list-nondeprecated${NC-}
+${C["UsageCommand"]-}--list-nondeprecated${NC-}
     List non-deprecated apps
-${C["UserCommand"]-}--list-referenced${NC-}
+${C["UsageCommand"]-}--list-referenced${NC-}
     List referenced apps (whether they are "built in" or not).
     An app is considered "referenced" if there is a variable matching the app's name in the
-    global '${C["File"]-}.env${NC-}' file, or there are any variables in the file '${C["File"]-}.env.app.<app>${NC-}'.
+    global '${C["UsageFile"]-}.env${NC-}' file, or there are any variables in the file '${C["UsageFile"]-}.env.app.<app>${NC-}'.
 EOF
             ;;&
         -h | --help | "")
             Found=1
             cat << EOF
-${C["UserCommand"]-}-h --help${NC-}
+${C["UsageCommand"]-}-h --help${NC-}
     Show this usage information
-${C["UserCommand"]-}-h --help${NC-} <option>${NC-}
+${C["UsageCommand"]-}-h --help${NC-} ${C["UsageOption"]-}<option>${NC-}
     Show the usage of the specified option
 EOF
             ;;&
         -i | --install | "")
             Found=1
             cat << EOF
-${C["UserCommand"]-}-i --install${NC-}
+${C["UsageCommand"]-}-i --install${NC-}
     Install/update all dependencies
 EOF
             ;;&
         -p | --prune | "")
             Found=1
             cat << EOF
-${C["UserCommand"]-}-p --prune${NC-}
+${C["UsageCommand"]-}-p --prune${NC-}
     Remove unused docker resources
 EOF
             ;;&
         -r | --remove | "")
             Found=1
             cat << EOF
-${C["UserCommand"]-}-r --remove${NC-}
+${C["UsageCommand"]-}-r --remove${NC-}
     Prompt to remove variables for all disabled apps
-${C["UserCommand"]-}-r --remove${NC-} <app>${NC-}
+${C["UsageCommand"]-}-r --remove${NC-} ${C["UsageApp"]-}<app>${NC-} [${C["UsageApp"]-}<app>${NC-} ...]${NC-}
     Prompt to remove the variables for the app specified
 EOF
             ;;&
         -R | --reset | "")
             Found=1
             cat << EOF
-${C["UserCommand"]-}-R --reset${NC-}
+${C["UsageCommand"]-}-R --reset${NC-}
     Resets ${APPLICATION_NAME} to always process environment files.
     This is usually not needed unless you have modified application templates yourself.
 EOF
@@ -260,7 +260,7 @@ EOF
         -s | --status | "")
             Found=1
             cat << EOF
-${C["UserCommand"]-}-s --status${NC-} <app>${NC-}
+${C["UsageCommand"]-}-s --status${NC-} ${C["UsageApp"]-}<app>${NC-} [${C["UsageApp"]-}<app>${NC-} ...]${NC-}
     Returns the enabled/disabled status for the app specified
 EOF
             ;;&
@@ -269,25 +269,25 @@ EOF
         "")
             Found=1
             cat << EOF
-${C["UserCommand"]-}--status-disable${NC-} <app>${NC-}
+${C["UsageCommand"]-}--status-disable${NC-} ${C["UsageApp"]-}<app>${NC-} [${C["UsageApp"]-}<app>${NC-} ...]${NC-}
     Disable the app specified
-${C["UserCommand"]-}--status-enable${NC-} <app>${NC-}
+${C["UsageCommand"]-}--status-enable${NC-} ${C["UsageApp"]-}<app>${NC-} [${C["UsageApp"]-}<app>${NC-} ...]${NC-}
     Enable the app specified
 EOF
             ;;&
         -t | --test | "")
             Found=1
             cat << EOF
-${C["UserCommand"]-}-t --test${NC-} <test_name>${NC-}
+${C["UsageCommand"]-}-t --test${NC-} ${C["UsageFile"]-}<test_name>${NC-}
     Run tests to check the program
 EOF
             ;;&
         -T | --theme | "")
             Found=1
             cat << EOF
-${C["UserCommand"]-}-T --theme${NC-}
+${C["UsageCommand"]-}-T --theme${NC-}
     Re-applies the current theme to the GUI
-${C["UserCommand"]-}-T --theme${NC-} <themename>${NC-}
+${C["UsageCommand"]-}-T --theme${NC-} ${C["UsageTheme"]-}<themename>${NC-}
     Applies the specified theme to the GUI
 EOF
             ;;&
@@ -295,7 +295,7 @@ EOF
         --theme-list | "")
             Found=1
             cat << EOF
-${C["UserCommand"]-}--theme-list${NC-}
+${C["UsageCommand"]-}--theme-list${NC-}
     Lists the available themes
 EOF
             ;;&
@@ -303,7 +303,7 @@ EOF
         --theme-table | "")
             Found=1
             cat << EOF
-${C["UserCommand"]-}--theme-table${NC-}
+${C["UsageCommand"]-}--theme-table${NC-}
     Lists the available themes in a table format
 EOF
             ;;&
@@ -311,8 +311,8 @@ EOF
         --theme-lines | --theme-no-lines | "")
             Found=1
             cat << EOF
-${C["UserCommand"]-}--theme-lines${NC-}
-${C["UserCommand"]-}--theme-no-lines${NC-}
+${C["UsageCommand"]-}--theme-lines${NC-}
+${C["UsageCommand"]-}--theme-no-lines${NC-}
     Turn the line drawing characters on or off in the GUI
 EOF
             ;;&
@@ -320,8 +320,8 @@ EOF
         --theme-borders | --theme-no-borders | "")
             Found=1
             cat << EOF
-${C["UserCommand"]-}--theme-borders${NC-}
-${C["UserCommand"]-}--theme-no-borders${NC-}
+${C["UsageCommand"]-}--theme-borders${NC-}
+${C["UsageCommand"]-}--theme-no-borders${NC-}
     Turn the borders on and off in the GUI
 EOF
             ;;&
@@ -329,8 +329,8 @@ EOF
         --theme-shadows | --theme-no-shadows | "")
             Found=1
             cat << EOF
-${C["UserCommand"]-}--theme-shadows${NC-}
-${C["UserCommand"]-}--theme-no-shadows${NC-}
+${C["UsageCommand"]-}--theme-shadows${NC-}
+${C["UsageCommand"]-}--theme-no-shadows${NC-}
     Turn the shadows on or off in the GUI
 EOF
             ;;&
@@ -338,24 +338,24 @@ EOF
         --theme-scrollbar | --theme-no-scrollbar | "")
             Found=1
             cat << EOF
-${C["UserCommand"]-}--theme-scrollbar${NC-}
-${C["UserCommand"]-}--theme-no-scrollbar${NC-}
+${C["UsageCommand"]-}--theme-scrollbar${NC-}
+${C["UsageCommand"]-}--theme-no-scrollbar${NC-}
     Turn the scrollbar on or off in the GUI
 EOF
             ;;&
         -u | --update | "")
             Found=1
             cat << EOF
-${C["UserCommand"]-}-u --update${NC-}
+${C["UsageCommand"]-}-u --update${NC-}
     Update ${APPLICATION_NAME} to the latest stable commits
-${C["UserCommand"]-}-u --update${NC-} <branch>${NC-}
+${C["UsageCommand"]-}-u --update${NC-} ${C["UsageBranch"]-}<branch>${NC-}
     Update ${APPLICATION_NAME} to the latest commits from the specified branch
 EOF
             ;;&
         -V | --version | "")
             Found=1
             cat << EOF
-${C["UserCommand"]-}-V --version${NC-}
+${C["UsageCommand"]-}-V --version${NC-}
     Display version information
 EOF
             ;;&
@@ -370,35 +370,35 @@ EOF
             ;;&
         -M | --menu | "")
             Found=1
-            #${C["UserCommand"]-}-M --menu${NC-} < config-global | global >${NC-}
+            #${C["UsageCommand"]-}-M --menu${NC-} < config-global | global >${NC-}
             #    Load the Global Configutation page in the menu.
             cat << EOF
-${C["UserCommand"]-}-M --menu${NC-}
+${C["UsageCommand"]-}-M --menu${NC-}
     Start the menu system.
-    This is the same as typing 'ds'.
-${C["UserCommand"]-}-M --menu${NC-} < main | config | options >${NC-}
+    This is the same as typing '${C["UsageCommand"]-}ds${NC-}'.
+${C["UsageCommand"]-}-M --menu${NC-} < ${C["UsageOption"]-}main${NC-} | ${C["UsageOption"]-}config${NC-} | ${C["UsageOption"]-}options${NC-} >${NC-}
     Load the specified page in the menu.
-${C["UserCommand"]-}-M --menu${NC-} < config-apps | apps >${NC-}
-    Load the Application Configuration page in the menu.
-${C["UserCommand"]-}-M --menu${NC-} < options-display | display >${NC-}
-    Load the Display Options page in the menu.
-${C["UserCommand"]-}-M --menu${NC-} < options-theme | theme >${NC-}
-    Load the Theme Chooser page in the menu.
-${C["UserCommand"]-}-M --menu${NC-} < config-app-select | app-select | select >${NC-}
-    Load the Theme Chooser page in the menu.
+${C["UsageCommand"]-}-M --menu${NC-} < ${C["UsageOption"]-}config-apps${NC-} | ${C["UsageOption"]-}apps${NC-} >${NC-}
+    Load the ${C["UsagePage"]-}Application Configuration${NC-} page in the menu.
+${C["UsageCommand"]-}-M --menu${NC-} < ${C["UsageOption"]-}options-display${NC-} | ${C["UsageOption"]-}display${NC-} >${NC-}
+    Load the ${C["UsagePage"]-}Display Option${NC-}s page in the menu.
+${C["UsageCommand"]-}-M --menu${NC-} < ${C["UsageOption"]-}options-theme${NC-} | ${C["UsageOption"]-}theme${NC-} >${NC-}
+    Load the ${C["UsagePage"]-}Theme Chooser${NC-} page in the menu.
+${C["UsageCommand"]-}-M --menu${NC-} < ${C["UsageOption"]-}config-app-select${NC-} | ${C["UsageOption"]-}app-select${NC-} | ${C["UsageOption"]-}select${NC-} >${NC-}
+    Load the ${C["UsagePage"]-}Theme Chooser${NC-} page in the menu.
 EOF
             ;;&
         -S | --select | --menu-config-app-select | --menu-app-select | "")
             Found=1
             cat << EOF
-${C["UserCommand"]-}-S --select${NC-}
-    Load the Application Selection page in the menu.
+${C["UsageCommand"]-}-S --select${NC-}
+    Load the ${C["UsagePage"]-}Application Selection${NC-} page in the menu.
 EOF
             ;;&
         *)
             if [[ -z ${Found-} ]]; then
                 cat << EOF
-Unknown option '${C["UserCommand"]-}${Option}${NC-}'.
+Unknown option '${C["UsageCommand"]-}${Option}${NC-}'.
 EOF
             fi
             ;;

--- a/.includes/usage.sh
+++ b/.includes/usage.sh
@@ -10,7 +10,7 @@ usage() {
     case "${Option}" in
         *)
             if [[ -z ${NoHeading-} ]]; then
-                local APPLICATION_HEADING="${APPLICATION_NAME}"
+                local APPLICATION_HEADING="${C["Version"]-}${APPLICATION_NAME}${NC-}"
                 if [[ ${APPLICATION_VERSION-} ]]; then
                     APPLICATION_HEADING+=" [${C["Version"]-}${APPLICATION_VERSION}${NC-}]"
                 fi
@@ -18,8 +18,8 @@ usage() {
                     APPLICATION_HEADING+=" (${C["Update"]-}Update Available${NC-})"
                 fi
                 cat << EOF
-Usage: ${APPLICATION_COMMAND} [<Flags>] [<Command>] ...
-NOTE: ${APPLICATION_COMMAND} shortcut is only available after the first run of
+Usage: ${C["UserCommand"]-}${APPLICATION_COMMAND}${NC-} [${C["UserCommand"]-}<Flags>${NC-}] [${C["UserCommand"]-}<Command>${NC-}] ...
+NOTE: The '${C["UserCommand"]-}${APPLICATION_COMMAND}${NC-}' shortcut is only available after the first run of
     bash main.sh
 
 ${APPLICATION_HEADING}
@@ -31,9 +31,9 @@ the order given, only stopping on an error. Any flags included only apply to the
 following command, and get reset before the next command.
 
 Any command that takes a variable name, the variable will by default be looked for
-in the global '.env' file. If the variable name used is in form of 'app:var', it
-will instead refer to the variable '<var>' in '.env.app.<app>'.  Some commands
-that take app names can use the form 'app:' to refer to the same file.
+in the global '${C["File"]-}.env${NC-}' file. If the variable name used is in form of '${C["Var"]-}app:var${NC-}', it
+will instead refer to the variable '${C["Var"]-}<var>${NC-}' in '${C["File"]-}.env.app.<app>${NC-}'.  Some commands
+that take app names can use the form '${C["Var"]-}app:${NC-}' to refer to the same file.
 
 EOF
             fi
@@ -50,28 +50,28 @@ EOF
         -f | --force | "")
             Found=1
             cat << EOF
--f --force
+${C["UserCommand"]-}-f --force${NC-}
     Force certain install/upgrade actions to run even if they would not be needed.
 EOF
             ;;&
         -g | --gui | "")
             Found=1
             cat << EOF
--g --gui
+${C["UserCommand"]-}-g --gui${NC-}
     Use dialog boxes
 EOF
             ;;&
         -v | --verbose | "")
             Found=1
             cat << EOF
--v --verbose
+${C["UserCommand"]-}-v --verbose${NC-}
     Verbose
 EOF
             ;;&
         -x | --debug | "")
             Found=1
             cat << EOF
--x --debug
+${C["UserCommand"]-}-x --debug${NC-}
     Debug
 EOF
             ;;&
@@ -87,102 +87,102 @@ EOF
         -a | --add | "")
             Found=1
             cat << EOF
--a --add <app> [<app> ...]
+${C["UserCommand"]-}-a --add${NC-} <app> [<app> ...]${NC-}
     Add the default variables for the app(s) specified
 EOF
             ;;&
         -c | --compose | "")
             Found=1
             cat << EOF
--c --compose < pull | up | down | stop | restart | update > [<app> ...]
+${C["UserCommand"]-}-c --compose${NC-} < pull | up | down | stop | restart | update > [<app> ...]${NC-}
     Run docker compose commands. If no command is given, does an update.
     Update is the same as a 'pull' followed by an 'up'
--c --compose < generate | merge >
+${C["UserCommand"]-}-c --compose${NC-} < generate | merge >${NC-}
     Generates the docker-compose.yml file
 EOF
             ;;&
         -e | --env | "")
             Found=1
             cat << EOF
--e --env
-    Update your '.env' files with new variables
+${C["UserCommand"]-}-e --env${NC-}
+    Update your '${C["File"]-}.env${NC-}' files with new variables
 EOF
             ;;&
         --env-appvars | "")
             Found=1
             cat << EOF
---env-appvars <app> [<app> ...]
+${C["UserCommand"]-}--env-appvars${NC-} <app> [<app> ...]${NC-}
     List all variable names for the app(s) specified
 EOF
             ;;&
         --env-appvars-lines | "")
             Found=1
             cat << EOF
---env-appvars-lines <app> [<app> ...]
+${C["UserCommand"]-}--env-appvars-lines${NC-} <app> [<app> ...]${NC-}
     List all variables and values for the app(s) specified
 EOF
             ;;&
         --env-get | --env-get= | "")
             Found=1
             cat << EOF
---env-get <var> [<var> ...]
---env-get=<var>
+${C["UserCommand"]-}--env-get${NC-} <var> [<var> ...]${NC-}
+${C["UserCommand"]-}--env-get=${NC-}<var>${NC-}
     Get the value of a <var>iable (variable name is forced to UPPER CASE)
 EOF
             ;;&
         --env-get-line | --env-get-line= | "")
             Found=1
             cat << EOF
---env-get-line <var> [<var> ...]
---env-get-line=<var>
+${C["UserCommand"]-}--env-get-line${NC-} <var> [<var> ...]${NC-}
+${C["UserCommand"]-}--env-get-line=${NC-}<var>${NC-}
     Get the line of a <var>iable (variable name is forced to UPPER CASE)
 EOF
             ;;&
         --env-get-literal | --env-get-literal= | "")
             Found=1
             cat << EOF
---env-get-literal <var> [<var> ...]
---env-get-literal=<var>
+${C["UserCommand"]-}--env-get-literal${NC-} <var> [<var> ...]${NC-}
+${C["UserCommand"]-}--env-get-literal${NC-}=<var>${NC-}
     Get the literal value (including quotes) of a <var>iable (variable name is forced to UPPER CASE)
 EOF
             ;;&
         --env-get-lower | --env-get-lower= | "")
             Found=1
             cat << EOF
---env-get-lower <var> [<var> ...]
---env-get-lower=<var>
+${C["UserCommand"]-}--env-get-lower${NC-} <var> [<var> ...]${NC-}
+${C["UserCommand"]-}--env-get-lower${NC-}=<var>${NC-}
     Get the value of a <var>iable
 EOF
             ;;&
         --env-get-lower-line | --env-get-lower-line= | "")
             Found=1
             cat << EOF
---env-get-lower-line <var> [<var> ...]
---env-get-lower-line=<var>
+${C["UserCommand"]-}--env-get-lower-line${NC-} <var> [<var> ...]
+${C["UserCommand"]-}--env-get-lower-line=<var>${NC-}
     Get the line of a <var>iable
 EOF
             ;;&
         --env-get-lower-literal | --env-get-lower-literal= | "")
             Found=1
             cat << EOF
---env-get-lower-literal <var> [<var> ...]
---env-get-lower-literal=<var>
+${C["UserCommand"]-}--env-get-lower-literal${NC-} <var> [<var> ...]${NC-}
+${C["UserCommand"]-}--env-get-lower-literal=${NC-}<var>${NC-}
     Get the literal value (including quotes) of a <var>iable
 EOF
             ;;&
         --env-set | --env-set= | "")
             Found=1
             cat << EOF
---env-set <var>=<val>
---env-set=<var>,<val>
-    Set the <val>ue of a <var>iable in '.env' (variable name is forced to UPPER CASE).
+${C["UserCommand"]-}--env-set${NC-} <var>=<val>${NC-}
+${C["UserCommand"]-}--env-set=${NC-}<var>,<val>${NC-}
+    Set the <val>ue of a <var>iable in '${C["File"]-}.env${NC-}' (variable name is forced to UPPER CASE).
 EOF
             ;;&
         --env-set-lower | --env-set-lower= | "")
             Found=1
             cat << EOF
---env-set-lower <var>=<val>
---env-set-lower=<var>,<val>
+${C["UserCommand"]-}--env-set-lower${NC-} <var>=<val>${NC-}
+${C["UserCommand"]-}--env-set-lower=${NC-}<var>,<val>${NC-}
     Set the <val>ue of a <var>iable in .env
 EOF
             ;;&
@@ -197,62 +197,62 @@ EOF
         "")
             Found=1
             cat << EOF
--l --list
+${C["UserCommand"]-}-l --list${NC-}
     List all apps
---list-added
+${C["UserCommand"]-}--list-added${NC-}
     List added apps
---list-builtin
+${C["UserCommand"]-}--list-builtin${NC-}
     List builtin apps
---list-deprecated
+${C["UserCommand"]-}--list-deprecated${NC-}
     List deprecated apps
---list-enabled
+${C["UserCommand"]-}--list-enabled${NC-}
     List enabled apps
---list-disabled
+${C["UserCommand"]-}--list-disabled${NC-}
     List disabled apps
---list-nondeprecated
+${C["UserCommand"]-}--list-nondeprecated${NC-}
     List non-deprecated apps
---list-referenced
+${C["UserCommand"]-}--list-referenced${NC-}
     List referenced apps (whether they are "built in" or not).
     An app is considered "referenced" if there is a variable matching the app's name in the
-    global '.env' file, or there are any variables in the file '.env.app<appname>'.
+    global '${C["File"]-}.env${NC-}' file, or there are any variables in the file '${C["File"]-}.env.app.<app>${NC-}'.
 EOF
             ;;&
         -h | --help | "")
             Found=1
             cat << EOF
--h --help
+${C["UserCommand"]-}-h --help${NC-}
     Show this usage information
--h --help < Option >
+${C["UserCommand"]-}-h --help${NC-} <option>${NC-}
     Show the usage of the specified option
 EOF
             ;;&
         -i | --install | "")
             Found=1
             cat << EOF
--i --install
+${C["UserCommand"]-}-i --install${NC-}
     Install/update all dependencies
 EOF
             ;;&
         -p | --prune | "")
             Found=1
             cat << EOF
--p --prune
+${C["UserCommand"]-}-p --prune${NC-}
     Remove unused docker resources
 EOF
             ;;&
         -r | --remove | "")
             Found=1
             cat << EOF
--r --remove
-    Prompt to remove '.env' variables for all disabled apps
--r --remove <appname>
-    Prompt to remove the '.env' variables for the app specified
+${C["UserCommand"]-}-r --remove${NC-}
+    Prompt to remove variables for all disabled apps
+${C["UserCommand"]-}-r --remove${NC-} <app>${NC-}
+    Prompt to remove the variables for the app specified
 EOF
             ;;&
         -R | --reset | "")
             Found=1
             cat << EOF
--R --reset
+${C["UserCommand"]-}-R --reset${NC-}
     Resets ${APPLICATION_NAME} to always process environment files.
     This is usually not needed unless you have modified application templates yourself.
 EOF
@@ -260,7 +260,7 @@ EOF
         -s | --status | "")
             Found=1
             cat << EOF
--s --status <appname>
+${C["UserCommand"]-}-s --status${NC-} <app>${NC-}
     Returns the enabled/disabled status for the app specified
 EOF
             ;;&
@@ -269,23 +269,25 @@ EOF
         "")
             Found=1
             cat << EOF
---status-disable <appname>
+${C["UserCommand"]-}--status-disable${NC-} <app>${NC-}
     Disable the app specified
---status-enable <appname>
+${C["UserCommand"]-}--status-enable${NC-} <app>${NC-}
     Enable the app specified
 EOF
             ;;&
         -t | --test | "")
             Found=1
             cat << EOF
--t --test <test_name>
+${C["UserCommand"]-}-t --test${NC-} <test_name>${NC-}
     Run tests to check the program
 EOF
             ;;&
         -T | --theme | "")
             Found=1
             cat << EOF
--T --theme <themename>
+${C["UserCommand"]-}-T --theme${NC-}
+    Re-applies the current theme to the GUI
+${C["UserCommand"]-}-T --theme${NC-} <themename>${NC-}
     Applies the specified theme to the GUI
 EOF
             ;;&
@@ -293,7 +295,7 @@ EOF
         --theme-list | "")
             Found=1
             cat << EOF
---theme-list
+${C["UserCommand"]-}--theme-list${NC-}
     Lists the available themes
 EOF
             ;;&
@@ -301,7 +303,7 @@ EOF
         --theme-table | "")
             Found=1
             cat << EOF
---theme-table
+${C["UserCommand"]-}--theme-table${NC-}
     Lists the available themes in a table format
 EOF
             ;;&
@@ -309,8 +311,8 @@ EOF
         --theme-lines | --theme-no-lines | "")
             Found=1
             cat << EOF
---theme-lines
---theme-no-lines
+${C["UserCommand"]-}--theme-lines${NC-}
+${C["UserCommand"]-}--theme-no-lines${NC-}
     Turn the line drawing characters on or off in the GUI
 EOF
             ;;&
@@ -318,8 +320,8 @@ EOF
         --theme-borders | --theme-no-borders | "")
             Found=1
             cat << EOF
---theme-borders
---theme-no-borders
+${C["UserCommand"]-}--theme-borders${NC-}
+${C["UserCommand"]-}--theme-no-borders${NC-}
     Turn the borders on and off in the GUI
 EOF
             ;;&
@@ -327,8 +329,8 @@ EOF
         --theme-shadows | --theme-no-shadows | "")
             Found=1
             cat << EOF
---theme-shadows
---theme-no-shadows
+${C["UserCommand"]-}--theme-shadows${NC-}
+${C["UserCommand"]-}--theme-no-shadows${NC-}
     Turn the shadows on or off in the GUI
 EOF
             ;;&
@@ -336,24 +338,24 @@ EOF
         --theme-scrollbar | --theme-no-scrollbar | "")
             Found=1
             cat << EOF
---theme-scrollbar
---theme-no-scrollbar
+${C["UserCommand"]-}--theme-scrollbar${NC-}
+${C["UserCommand"]-}--theme-no-scrollbar${NC-}
     Turn the scrollbar on or off in the GUI
 EOF
             ;;&
         -u | --update | "")
             Found=1
             cat << EOF
--u --update
+${C["UserCommand"]-}-u --update${NC-}
     Update ${APPLICATION_NAME} to the latest stable commits
--u --update <branch>
+${C["UserCommand"]-}-u --update${NC-} <branch>${NC-}
     Update ${APPLICATION_NAME} to the latest commits from the specified branch
 EOF
             ;;&
         -V | --version | "")
             Found=1
             cat << EOF
--V --version
+${C["UserCommand"]-}-V --version${NC-}
     Display version information
 EOF
             ;;&
@@ -368,35 +370,35 @@ EOF
             ;;&
         -M | --menu | "")
             Found=1
-            #-M --menu < config-global | global >
+            #${C["UserCommand"]-}-M --menu${NC-} < config-global | global >${NC-}
             #    Load the Global Configutation page in the menu.
             cat << EOF
--M --menu
+${C["UserCommand"]-}-M --menu${NC-}
     Start the menu system.
     This is the same as typing 'ds'.
--M --menu < main | config | options >
+${C["UserCommand"]-}-M --menu${NC-} < main | config | options >${NC-}
     Load the specified page in the menu.
--M --menu < config-apps | apps >
+${C["UserCommand"]-}-M --menu${NC-} < config-apps | apps >${NC-}
     Load the Application Configuration page in the menu.
--M --menu < options-display | display >
+${C["UserCommand"]-}-M --menu${NC-} < options-display | display >${NC-}
     Load the Display Options page in the menu.
--M --menu < options-theme | theme >
+${C["UserCommand"]-}-M --menu${NC-} < options-theme | theme >${NC-}
     Load the Theme Chooser page in the menu.
--M --menu < config-app-select | app-select | select >
+${C["UserCommand"]-}-M --menu${NC-} < config-app-select | app-select | select >${NC-}
     Load the Theme Chooser page in the menu.
 EOF
             ;;&
         -S | --select | --menu-config-app-select | --menu-app-select | "")
             Found=1
             cat << EOF
--S --select
+${C["UserCommand"]-}-S --select${NC-}
     Load the Application Selection page in the menu.
 EOF
             ;;&
         *)
             if [[ -z ${Found-} ]]; then
                 cat << EOF
-Unknown option '${Option}'.
+Unknown option '${C["UserCommand"]-}${Option}${NC-}'.
 EOF
             fi
             ;;

--- a/main.sh
+++ b/main.sh
@@ -123,6 +123,15 @@ declare -Agr C=( # Pre-defined colors
     ["Version"]="${F[C]}"
     ["Yes"]="${F[G]}"
     ["No"]="${F[R]}"
+
+    ["UsageCommand"]="${F[Y]}${BD}"
+    ["UsageOption"]="${F[Y]}"
+    ["UsageApp"]="${F[C]}"
+    ["UsageBranch"]="${F[C]}"
+    ["UsageFile"]="${F[C]}${BD}"
+    ["UsagePage"]="${F[C]}${BD}"
+    ["UsageTheme"]="${F[C]}"
+    ["UsageVar"]="${F[M]}"
 )
 
 # Log Functions


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Colorize the CLI usage output by defining and applying distinct color variables for commands, flags, file names, app names, branches, pages, themes, and variable names

Enhancements:
- Define new color codes for usage elements (commands, options, apps, branches, files, pages, themes, and variables) in main.sh
- Wrap commands, flags, and parameters in usage.sh with the corresponding color tokens to enhance readability of the usage text