### PR TITLE
Fix format of `--env-set-lower` usage text

### DIFF
--- a/.includes/usage.sh
+++ b/.includes/usage.sh
@@ -181,8 +181,8 @@ EOF
         --env-set-lower | --env-set-lower= | "")
             Found=1
             cat << EOF
-${C["UsageCommand"]-}--env-set-lower${NC-} ${C["UsageVar"]-}<var>${NC-}=${C["UsageVar"]-}<val>${NC-}
-${C["UsageCommand"]-}--env-set-lower=${NC-}${C["UsageVar"]-}<var>${NC-},${C["UsageVar"]-}<val>${NC-}
+${C["UsageCommand"]-}--env-set-lower${NC-} ${C["UsageVar"]-}<var>=<val>${NC-}
+${C["UsageCommand"]-}--env-set-lower=${NC-}${C["UsageVar"]-}<var>,<val>${NC-}
     Set the ${C["UsageVar"]-}<val>${NC-}ue of a ${C["UsageVar"]-}<var>${NC-}iable
 EOF
             ;;&


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Bug Fixes:
- Correct the syntax of `--env-set-lower` usage lines to consistently use `<var>=<val>` and `<var>,<val>` formatting