### PR TITLE
Add `1` as a boolean "true" along with `ON`, `TRUE` and `YES` for var…

### DIFF
--- a/.scripts/app_is_disabled.sh
+++ b/.scripts/app_is_disabled.sh
@@ -10,7 +10,7 @@ app_is_disabled() {
     fi
     local -u APP_ENABLED
     APP_ENABLED="$(run_script 'env_get' "${APPNAME}__ENABLED")"
-    [[ ! ${APP_ENABLED} =~ ON|TRUE|YES ]]
+    [[ ! ${APP_ENABLED} =~ ^(1|ON|TRUE|YES)$ ]]
 }
 
 test_app_is_disabled() {

--- a/.scripts/app_is_enabled.sh
+++ b/.scripts/app_is_enabled.sh
@@ -10,7 +10,7 @@ app_is_enabled() {
     fi
     local -u APP_ENABLED
     APP_ENABLED="$(run_script 'env_get' "${APPNAME}__ENABLED")"
-    [[ ${APP_ENABLED} =~ ON|TRUE|YES ]]
+    [[ ${APP_ENABLED} =~ ^(1|ON|TRUE|YES)$ ]]
 }
 
 test_app_is_enabled() {

--- a/.scripts/apply_theme.sh
+++ b/.scripts/apply_theme.sh
@@ -126,19 +126,19 @@ apply_theme() {
         LineCharacters="$(run_script 'config_get' LineCharacters "${DefaultMenuIniFile}")"
         run_script 'config_set' LineCharacters "${LineCharacters}" "${MENU_INI_FILE}"
     fi
-    if [[ ${Borders^^} =~ ON|TRUE|YES ]]; then
-        if [[ ! ${LineCharacters^^} =~ ON|TRUE|YES ]]; then
+    if [[ ${Borders^^} =~ ^(1|ON|TRUE|YES)$ ]]; then
+        if [[ ! ${LineCharacters^^} =~ ^(1|ON|TRUE|YES)$ ]]; then
             DialogOptions+=" --ascii-lines"
         fi
     else
         DialogOptions+=" --no-lines"
     fi
-    if [[ ${Scrollbar^^} =~ ON|TRUE|YES ]]; then
+    if [[ ${Scrollbar^^} =~ ^(1|ON|TRUE|YES)$ ]]; then
         DialogOptions+=" --scrollbar"
     else
         DialogOptions+=" --no-scrollbar"
     fi
-    if [[ ${Shadow^^} =~ ON|TRUE|YES ]]; then
+    if [[ ${Shadow^^} =~ ^(1|ON|TRUE|YES)$ ]]; then
         DialogOptions+=" --shadow"
         DC["WindowColsAdjust"]=$((DC["WindowColsAdjust"] + 2))
         DC["WindowRowsAdjust"]=$((DC["WindowRowsAdjust"] + 1))

--- a/.scripts/menu_options_display.sh
+++ b/.scripts/menu_options_display.sh
@@ -34,7 +34,7 @@ menu_options_display() {
         for Option in "${DrawLineOption}" "${ShowBordersOption}" "${ShowScrollbarOption}" "${ShowShadowOption}"; do
             local Value
             Value="$(run_script 'config_get' "${OptionVariable["${Option}"]}" "${MENU_INI_FILE}")"
-            if [[ ${Value^^} =~ ON|TRUE|YES ]]; then
+            if [[ ${Value^^} =~ ^(1|ON|TRUE|YES)$ ]]; then
                 EnabledOptions+=("${Option}")
                 Opts+=("${Option}" "${OptionDescription["${Option}"]}" ON)
             else

--- a/.scripts/yml_merge.sh
+++ b/.scripts/yml_merge.sh
@@ -67,14 +67,14 @@ commands_yml_merge() {
                 local MultipleStorage
                 MultipleStorage="$(run_script 'env_get' DOCKER_MULTIPLE_STORAGE)"
                 local -a StorageNumbers=('')
-                if [[ -n ${MultipleStorage-} && ${MultipleStorage^^} =~ ON|TRUE|YES ]]; then
+                if [[ -n ${MultipleStorage-} && ${MultipleStorage^^} =~ ^(1|ON|TRUE|YES)$ ]]; then
                     StorageNumbers+=(2 3 4)
                 fi
                 for Number in "${StorageNumbers[@]}"; do
                     local StorageOn
                     StorageOn="$(run_script 'env_get' "${APPNAME}__STORAGE${Number}_ON")"
                     StorageOn="${StorageOn:-$(run_script 'env_get' "DOCKER_STORAGE${Number}_ON")}"
-                    if [[ -n ${StorageOn-} && ${StorageOn^^} =~ ON|TRUE|YES ]]; then
+                    if [[ -n ${StorageOn-} && ${StorageOn^^} =~ ^(1|ON|TRUE|YES)$ ]]; then
                         local StorageVolume
                         StorageVolume="$(run_script 'env_get' "DOCKER_VOLUME_STORAGE${Number}")"
                         if [[ -n ${StorageVolume-} ]]; then
@@ -90,7 +90,7 @@ commands_yml_merge() {
                 done
                 local AppDevices
                 AppDevices="$(run_script 'env_get' "${APPNAME}__DEVICES")"
-                if [[ -n ${AppDevices-} && ${AppDevices^^} =~ ON|TRUE|YES ]]; then
+                if [[ -n ${AppDevices-} && ${AppDevices^^} =~ ^(1|ON|TRUE|YES)$ ]]; then
                     local devices_yml
                     devices_yml="$(run_script 'app_instance_file' "${appname}" "*.devices.yml")"
                     if [[ -f ${devices_yml} ]]; then


### PR DESCRIPTION
…iables

# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Recognize "1" as a valid true value in boolean checks for environment and configuration variables

Enhancements:
- Extend boolean regex checks in apply_theme.sh to include "1" for borders, scrollbar, and shadow
- Update yml_merge.sh to accept "1" in multiple storage, storage on/off, and devices checks
- Modify app_is_enabled.sh and app_is_disabled.sh to treat "1" as true for APP_ENABLED
- Adjust menu_options_display.sh to recognize "1" as true when displaying menu options