### PR TITLE
Fix handling of comments on variable lines in `env_set`

### DIFF
--- a/.scripts/env_get.sh
+++ b/.scripts/env_get.sh
@@ -23,7 +23,7 @@ env_get() {
         GET_VAR=${GET_VAR#"${APPNAME}:"}
     fi
     if [[ -f ${VAR_FILE} ]]; then
-        grep --color=never -Po "^\s*${GET_VAR}\s*=\K.*" "${VAR_FILE}" | tail -1 | xargs || true
+        grep --color=never -Po "^\s*${GET_VAR}\s*=\K[^#]*" "${VAR_FILE}" | tail -1 | xargs || true
     else
         # VAR_FILE does not exist, give a warning
         warn "File '${C["File"]}${VAR_FILE}${NC}' does not exist."


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Bug Fixes:
- Refine grep regex in env_get.sh to ignore trailing comments when extracting variable values