### PR TITLE
Fix naming of `handbreak.devices.yml` to `handbrake.devices.yml`

### DIFF
--- a/compose/.apps/handbrake/handbrake.devices.yml
+++ b/compose/.apps/handbrake/handbrake.devices.yml
@@ -1,0 +1,7 @@
+services:
+  handbrake<__instance>:
+    devices:
+      - ${HANDBRAKE<__INSTANCE>__DEVICE_DEV1}
+      - ${HANDBRAKE<__INSTANCE>__DEVICE_DEV2}
+      - ${HANDBRAKE<__INSTANCE>__DEVICE_DEV3}
+      - ${HANDBRAKE<__INSTANCE>__DEVICE_DEV4}

--- a/compose/.apps/handbrake/handbreak.devices.yml
+++ b/compose/.apps/handbrake/handbreak.devices.yml
@@ -1,7 +1,0 @@
-services:
-  handbreak<__instance>:
-    devices:
-      - ${HANDBREAK<__INSTANCE>__DEVICE_DEV1}
-      - ${HANDBREAK<__INSTANCE>__DEVICE_DEV2}
-      - ${HANDBREAK<__INSTANCE>__DEVICE_DEV3}
-      - ${HANDBREAK<__INSTANCE>__DEVICE_DEV4}


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).
