### PR TITLE
Fix comments for force pass in `env_get` testing

### DIFF
--- a/.scripts/env_get.sh
+++ b/.scripts/env_get.sh
@@ -34,6 +34,8 @@ env_get() {
 }
 
 test_env_get() {
+    # Return a "pass" for now.
+    # There is an error to be fixed in "Var_15=  Va# lue# Not a Comment"
     local ForcePass=1
     local -i result=0
     local -a Test=(
@@ -55,7 +57,7 @@ test_env_get() {
         Var_16 "Var_16=  Va# lue # Comment" "Va# lue"
     )
     VarFile=$(mktemp -t "${APPLICATION_NAME}.${FUNCNAME[0]}.VarFile.XXXXXXXXXX") ||
-        fatal "Failed to create temporary file '${C["File"]}.env${NC}' file.\nFailing command: ${C["FailingCommand"]}mktemp -t \"${APPLICATION_NAME}.${FUNCNAME[0]}.VarFile.XXXXXXXXXX\""
+        fatal "Failed to create temporary file.\nFailing command: ${C["FailingCommand"]}mktemp -t \"${APPLICATION_NAME}.${FUNCNAME[0]}.VarFile.XXXXXXXXXX\""
     {
         printf '### %s\n' \
             "" \
@@ -80,8 +82,6 @@ test_env_get() {
     rm -f "${VarFile}" ||
         warn "Failed to remove temporary file.\nFailing command: ${C["FailingCommand"]}rm -f \"${VarFile}\""
 
-    # Return a "pass" for now.
-    # There is an error to be fixed in "Test=  Va# lue# Not a Comment"
     [[ -n ${ForcePass-} ]] && return 0
     return ${result}
 }

--- a/.scripts/env_get_line.sh
+++ b/.scripts/env_get_line.sh
@@ -53,7 +53,7 @@ test_env_get_line() {
         Var_16 "Var_16=  Va# lue # Comment" "Var_16=  Va# lue # Comment"
     )
     VarFile=$(mktemp -t "${APPLICATION_NAME}.${FUNCNAME[0]}.VarFile.XXXXXXXXXX") ||
-        fatal "Failed to create temporary file '${C["File"]}.env${NC}' file.\nFailing command: ${C["FailingCommand"]}mktemp -t \"${APPLICATION_NAME}.${FUNCNAME[0]}.VarFile.XXXXXXXXXX\""
+        fatal "Failed to create temporary file.\nFailing command: ${C["FailingCommand"]}mktemp -t \"${APPLICATION_NAME}.${FUNCNAME[0]}.VarFile.XXXXXXXXXX\""
     {
         printf '### %s\n' \
             "" \
@@ -78,8 +78,6 @@ test_env_get_line() {
     rm -f "${VarFile}" ||
         warn "Failed to remove temporary file.\nFailing command: ${C["FailingCommand"]}rm -f \"${VarFile}\""
 
-    # Return a "pass" for now.
-    # There is an error to be fixed in "Test=  Va# lue# Not a Comment"
     [[ -n ${ForcePass-} ]] && return 0
     return ${result}
 }

--- a/.scripts/env_get_literal.sh
+++ b/.scripts/env_get_literal.sh
@@ -57,7 +57,7 @@ test_env_get_literal() {
         Var_16 "Var_16=  Va# lue # Comment" "  Va# lue # Comment"
     )
     VarFile=$(mktemp -t "${APPLICATION_NAME}.${FUNCNAME[0]}.VarFile.XXXXXXXXXX") ||
-        fatal "Failed to create temporary file '${C["File"]}.env${NC}' file.\nFailing command: ${C["FailingCommand"]}mktemp -t \"${APPLICATION_NAME}.${FUNCNAME[0]}.VarFile.XXXXXXXXXX\""
+        fatal "Failed to create temporary file.\nFailing command: ${C["FailingCommand"]}mktemp -t \"${APPLICATION_NAME}.${FUNCNAME[0]}.VarFile.XXXXXXXXXX\""
     {
         printf '### %s\n' \
             "" \
@@ -82,8 +82,6 @@ test_env_get_literal() {
     rm -f "${VarFile}" ||
         warn "Failed to remove temporary file.\nFailing command: ${C["FailingCommand"]}rm -f \"${VarFile}\""
 
-    # Return a "pass" for now.
-    # There is an error to be fixed in "Test=  Va# lue# Not a Comment"
     [[ -n ${ForcePass-} ]] && return 0
     return ${result}
 }


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Refine env_get* test scripts by clarifying ForcePass usage, standardizing temporary file error messages, and removing outdated comments

Enhancements:
- Add explanatory comments on ForcePass and known error case in test_env_get
- Unify mktemp fatal error messages across env_get.sh, env_get_line.sh, and env_get_literal.sh by removing specific file references

Tests:
- Remove redundant inline comments about ForcePass behavior and pre-existing test errors in all test_env_get functions