### PR TITLE
Warn if the `ForcePass` variable is set for a test even if no error occurred.

### DIFF
--- a/.includes/test_functions.sh
+++ b/.includes/test_functions.sh
@@ -106,9 +106,12 @@ run_unit_tests_pipe() {
         fi
     done
     notice "${TableLine}"
-    if [[ -n ${ForcePass} && ${result} != 0 ]]; then
-        warn "The '${C["Var"]-}ForcePass${NC-}' variable is set, passing test even though an error occured."
-        return 0
+    if [[ -n ${ForcePass} ]]; then
+        warn "The '${C["Var"]-}ForcePass${NC-}' variable is set."
+        if [[ ${result} != 0 ]]; then
+            error "Passing test even though an error occurred."
+            return 0
+        fi
     fi
     return ${result}
 }


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Update test runner to always warn when the ForcePass variable is set and to emit a separate error message when a failing test is force-passed

Enhancements:
- Always warn when ForcePass is set regardless of test outcome
- Log a distinct error message and force-pass the test only when it actually fails