### PR TITLE
Add unit tests to `app_is_builtin`

### DIFF
--- a/.scripts/app_is_builtin.sh
+++ b/.scripts/app_is_builtin.sh
@@ -11,9 +11,30 @@ app_is_builtin() {
 }
 
 test_app_is_builtin() {
-    run_script 'app_is_builtin' WATCHTOWER
-    notice "'app_is_builtin' WATCHTOWER returned $?"
-    run_script 'app_is_builtin' APPTHATDOESNOTEXIST
-    notice "'app_is_builtin' APPTHATDOESNOTEXIST returned $?"
-    warn "CI does not test app_is_builtin."
+    local ForcePass='' # Force the tests to pass even on failure if set to a non-empty value
+    local -i result=0
+    local -a Test=(
+        WATCHTOWER YES
+        SAMBA YES
+        RADARR YES
+        nzbget YES
+        NZBGet YES
+        NZBGET YES
+        NONEXISTENTAPP NO
+        WATCHTOWER__INSTANCE YES
+        SAMBA__INSTANCE YES
+        RADARR__INSTANCE YES
+        NZBGET__INSTANCE YES
+        NONEXISTENTAPP__INSTANCE NO
+    )
+    run_unit_tests_pipe "App" "App" "${ForcePass}" < <(
+        for ((i = 0; i < ${#Test[@]}; i += 2)); do
+            printf '%s\n' \
+                "${Test[i]}" \
+                "${Test[i + 1]}" \
+                "$(run_script 'app_is_builtin' "${Test[i]}" && echo "YES" || echo "NO")"
+        done
+    )
+    result=$?
+    return ${result}
 }


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Add comprehensive unit tests for the app_is_builtin function using run_unit_tests_pipe to validate expected YES/NO results

Tests:
- Add structured test matrix covering built-in apps, case variations, instance suffixes, and non-existent apps
- Replace ad-hoc test calls and warning with automated pass/fail reporting via run_unit_tests_pipe