### PR TITLE
reate color vars for unit test "pass" and "fail" highlighting

### DIFF
--- a/.includes/test_functions.sh
+++ b/.includes/test_functions.sh
@@ -98,7 +98,7 @@ run_unit_tests_pipe() {
         else
             local FailLine
             FailLine="$(
-                printf "${C["UnitTestFail"]-}>${NC-}| [${C["UnitTestFail"]-}%s${NC-}]${InputPad} | [${C["UnitTestFail"]-}%s${NC-}]${ExpectedValuePad} | [${C["UnitTestFail"]-}%s${NC-}]${ReturnedValuePad} |${C["UnitTestFail"]-}<${NC-}" \
+                printf "${C["UnitTestFailArrow"]-}>${NC-}| [${C["UnitTestFail"]-}%s${NC-}]${InputPad} | [${C["UnitTestFail"]-}%s${NC-}]${ExpectedValuePad} | [${C["UnitTestFail"]-}%s${NC-}]${ReturnedValuePad} |${C["UnitTestFailArrow"]-}<${NC-}" \
                     "${Input}" "${ExpectedValue}" "${ReturnedValue}"
             )"
             error "${FailLine}"

--- a/.includes/test_functions.sh
+++ b/.includes/test_functions.sh
@@ -91,14 +91,14 @@ run_unit_tests_pipe() {
         if [[ ${ReturnedValue} == "${ExpectedValue}" ]]; then
             local SuccessLine
             SuccessLine="$(
-                printf " | [${InputColor}%s${NC-}]${InputPad} | [${ExpectedColor}%s${NC-}]${ExpectedValuePad} | [${C["Notice"]-}%s${NC-}]${ReturnedValuePad} | " \
+                printf " | [${InputColor}%s${NC-}]${InputPad} | [${ExpectedColor}%s${NC-}]${ExpectedValuePad} | [${C["UnitTestPass"]-}%s${NC-}]${ReturnedValuePad} | " \
                     "${Input}" "${ExpectedValue}" "${ReturnedValue}"
             )"
             notice "${SuccessLine}"
         else
             local FailLine
             FailLine="$(
-                printf "${C["Error"]-}>${NC-}| [${C["Error"]-}%s${NC-}]${InputPad} | [${C["Error"]-}%s${NC-}]${ExpectedValuePad} | [${C["Error"]-}%s${NC-}]${ReturnedValuePad} |${C["Error"]-}<${NC-}" \
+                printf "${C["UnitTestFail"]-}>${NC-}| [${C["UnitTestFail"]-}%s${NC-}]${InputPad} | [${C["UnitTestFail"]-}%s${NC-}]${ExpectedValuePad} | [${C["UnitTestFail"]-}%s${NC-}]${ReturnedValuePad} |${C["UnitTestFail"]-}<${NC-}" \
                     "${Input}" "${ExpectedValue}" "${ReturnedValue}"
             )"
             error "${FailLine}"

--- a/main.sh
+++ b/main.sh
@@ -107,7 +107,7 @@ declare -Agr C=( # Pre-defined colors
     ["Fatal"]="${B[R]}${F[W]}"
 
     ["UnitTestPass"]="${F[G]}"
-    ["UnitTestFail"]="${F[K]}${B[R]}"
+    ["UnitTestFail"]="${F[R]}"
     ["UnitTestFailArrow"]="${F[R]}"
 
     ["App"]="${F[C]}"

--- a/main.sh
+++ b/main.sh
@@ -108,6 +108,7 @@ declare -Agr C=( # Pre-defined colors
 
     ["UnitTestPass"]="${F[G]}"
     ["UnitTestFail"]="${F[K]}${B[R]}"
+    ["UnitTestFailArrow"]="${F[R]}"
 
     ["App"]="${F[C]}"
     ["Branch"]="${F[C]}"

--- a/main.sh
+++ b/main.sh
@@ -106,6 +106,9 @@ declare -Agr C=( # Pre-defined colors
     ["Error"]="${F[R]}"
     ["Fatal"]="${B[R]}${F[W]}"
 
+    ["UnitTestPass"]="${F[G]}"
+    ["UnitTestFail"]="${F[R]}"
+
     ["App"]="${F[C]}"
     ["Branch"]="${F[C]}"
     ["FailingCommand"]="${F[R]}"

--- a/main.sh
+++ b/main.sh
@@ -107,7 +107,7 @@ declare -Agr C=( # Pre-defined colors
     ["Fatal"]="${B[R]}${F[W]}"
 
     ["UnitTestPass"]="${F[G]}"
-    ["UnitTestFail"]="${F[R]}"
+    ["UnitTestFail"]="${F[K]}${B[R]}"
 
     ["App"]="${F[C]}"
     ["Branch"]="${F[C]}"


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Add specific color variables for unit test pass and fail highlighting and apply them in test output formatting

Enhancements:
- Introduce new color variables UnitTestPass, UnitTestFail, and UnitTestFailArrow
- Update run_unit_tests_pipe to use dedicated pass/fail colors instead of generic Notice/Error colors