### PR TITLE
Add the missing `--theme-list` and `--theme-table` command-line options

### DIFF
--- a/.includes/cmdline.sh
+++ b/.includes/cmdline.sh
@@ -65,6 +65,7 @@ parse_arguments() {
                 -p | --prune) ;&
                 -R | --reset) ;&
                 -S | --select) ;&
+                --theme-list | --theme-table) ;&
                 --theme-shadows | --theme-no-shadows) ;&
                 --theme-scrollbar | --theme-no-scrollbar) ;&
                 --theme-lines | --theme-no-lines) ;&


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

New Features:
- Support for --theme-list and --theme-table CLI options