### PR TITLE
Disable the `ds -M apps` option.  It is currently broken.

### DIFF
--- a/.includes/cmdline.sh
+++ b/.includes/cmdline.sh
@@ -105,7 +105,7 @@ parse_arguments() {
                         case "${MenuCommand,,}" in
                             main) ;&
                             config) ;&
-                            config-apps | apps) ;&
+                            #config-apps | apps) ;&
                             config-app-select | app-select | select) ;&
                             config-global | global) ;&
                             options) ;&

--- a/.includes/usage.sh
+++ b/.includes/usage.sh
@@ -373,14 +373,14 @@ EOF
             Found=1
             #${C["UsageCommand"]-}-M --menu${NC-} < config-global | global >${NC-}
             #    Load the Global Configutation page in the menu.
+            #${C["UsageCommand"]-}-M --menu${NC-} < ${C["UsageOption"]-}config-apps${NC-} | ${C["UsageOption"]-}apps${NC-} >${NC-}
+            #    Load the ${C["UsagePage"]-}Application Configuration${NC-} page in the menu.
             cat << EOF
 ${C["UsageCommand"]-}-M --menu${NC-}
     Start the menu system.
     This is the same as typing '${C["UsageCommand"]-}ds${NC-}'.
 ${C["UsageCommand"]-}-M --menu${NC-} < ${C["UsageOption"]-}main${NC-} | ${C["UsageOption"]-}config${NC-} | ${C["UsageOption"]-}options${NC-} >${NC-}
     Load the specified page in the menu.
-${C["UsageCommand"]-}-M --menu${NC-} < ${C["UsageOption"]-}config-apps${NC-} | ${C["UsageOption"]-}apps${NC-} >${NC-}
-    Load the ${C["UsagePage"]-}Application Configuration${NC-} page in the menu.
 ${C["UsageCommand"]-}-M --menu${NC-} < ${C["UsageOption"]-}options-display${NC-} | ${C["UsageOption"]-}display${NC-} >${NC-}
     Load the ${C["UsagePage"]-}Display Options${NC-} page in the menu.
 ${C["UsageCommand"]-}-M --menu${NC-} < ${C["UsageOption"]-}options-theme${NC-} | ${C["UsageOption"]-}theme${NC-} >${NC-}


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Disable the `ds -M apps` option by removing its menu entry from usage output and commenting out its argument handling in the parser to prevent its use until it is fixed

Bug Fixes:
- Prevent invocation of the currently broken `ds -M apps` option by disabling its support in code

Enhancements:
- Remove the `apps` submenu entry from the `ds -M --menu` usage documentation
- Comment out the `config-apps`/`apps` case in the argument parser to disable the broken option