### PR TITLE
Remove extraneous character in bash version check

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -15,7 +15,7 @@ verlt() { ! verlte "${2}" "${1}"; }
 
 # Check for supported bash version
 declare REQUIRED_BASH_VERSION="4"
-if verlt "${BASH_VERSION}" "${REQUIRED_BASH_VERSION}"l; then
+if verlt "${BASH_VERSION}" "${REQUIRED_BASH_VERSION}"; then
     echo "Unsupported bash version."
     echo "${APPLICATION_NAME} requres at least bash version ${REQUIRED_BASH_VERSION}, installed version is ${BASH_VERSION}."
     exit 1


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Bug Fixes:
- Remove extraneous 'l' character from the bash version comparison to ensure proper version checking