### PR TITLE
Move the `.dialogrc` and `.dialogoptions` files to the temp folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,6 @@
 # Cache directory - created in .scripts/install_docker.sh and .scripts/install_yq.sh
 /.cache
 
-# Dialog configuration file - created by .scripts/menu.sh for dialog interface settings
-/.dialogrc
-
-# Dialog options file
-/.dialogoptions
-
 # Temporary folder
 /.temp/
 

--- a/.includes/dialog_functions.sh
+++ b/.includes/dialog_functions.sh
@@ -8,8 +8,8 @@ DIALOG=$(command -v dialog) || true
 declare -Agx DC
 
 declare -rgx DIALOGRC_NAME='.dialogrc'
-declare -rgx DIALOGRC="${SCRIPTPATH}/${DIALOGRC_NAME}"
-declare -rgx DIALOG_OPTIONS_FILE="${SCRIPTPATH}/.dialogoptions"
+declare -rgx DIALOGRC="${TEMP_FOLDER}/${DIALOGRC_NAME}"
+declare -rgx DIALOG_OPTIONS_FILE="${TEMP_FOLDER}/.dialogoptions"
 
 declare -rigx DIALOGTIMEOUT=3
 declare -rigx DIALOG_OK=0


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Enhancements:
- Use TEMP_FOLDER for .dialogrc and .dialogoptions paths instead of the script path