### PR TITLE
Allow optional arguments during fresh install.

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -245,9 +245,15 @@ check_sudo() {
 clone_repo() {
     warn "Attempting to clone ${APPLICATION_NAME} repo to '${C["Folder"]-}${DETECTED_HOMEDIR}/.docker${NC-}' location."
     git clone -b "${TARGET_BRANCH}" "${APPLICATION_REPO}" "${DETECTED_HOMEDIR}/.docker" ||
-        fatal "Failed to clone ${APPLICATION_NAME} repo.\nFailing command: ${C["FailingCommand"]-}git clone -b \"${TARGET_BRANCH}\" \"${APPLICATION_REPO}\" \"${DETECTED_HOMEDIR}/.docker\""
-    notice "Performing first run install."
-    exec bash "${DETECTED_HOMEDIR}/.docker/main.sh" "-yvi"
+        fatal \
+            "Failed to clone ${APPLICATION_NAME} repo.\n" \
+            "Failing command: ${C["FailingCommand"]-}git clone -b \"${TARGET_BRANCH}\" \"${APPLICATION_REPO}\" \"${DETECTED_HOMEDIR}/.docker\""
+    if [[ ${#ARGS[@]} -eq 0 ]]; then
+        notice "Performing first run install."
+        exec bash "${DETECTED_HOMEDIR}/.docker/main.sh" "-yvi"
+    else
+        exec bash "${DETECTED_HOMEDIR}/.docker/main.sh" "${ARGS[@]}"
+    fi
 }
 
 # Cleanup Function


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Allow optional command-line arguments to be passed during a fresh install, falling back to the default '-yvi' flags when no arguments are given.

New Features:
- Forward user-provided arguments to the install script on first run

Enhancements:
- Split and indent the fatal clone error message for improved readability