### PR TITLE
Add the missing `--config-pm` and `--config-pm-auto` usage text

### DIFF
--- a/.includes/usage.sh
+++ b/.includes/usage.sh
@@ -108,6 +108,15 @@ ${C["UsageCommand"]-}-c --compose${NC-} < ${C["UsageOption"]-}generate${NC-} | $
     Generates the '${C["UsageFile"]-}docker-compose.yml${NC-} file
 EOF
             ;;&
+        --config-pm | --config-pm-auto | "")
+            Found=1
+            cat << EOF
+${C["UsageCommand"]-}-T --config-pm${NC-} ${C["UsageOption"]-}<package manager>${NC-}
+    Select the specified package manager to install dependencies
+${C["UsageCommand"]-}-T --config-pm-auto${NC-}
+    Autodetect the package manager
+EOF
+            ;;&
         --config-pm-list | "")
             Found=1
             cat << EOF


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Enhancements:
- Add missing help text for --config-pm and --config-pm-auto flags in the usage output