### PR TITLE
Use `tput` to populate `LINES` and `COLUMNS` variables

### DIFF
--- a/.includes/dialog_functions.sh
+++ b/.includes/dialog_functions.sh
@@ -137,6 +137,8 @@ dialog_pipe() {
     fi
     Title="$(strip_ansi_colors "${Title}")"
     SubTitle="$(strip_ansi_colors "${SubTitle}")"
+    COLUMNS=$(tput cols)
+    LINES=$(tput lines)
     _dialog_ \
         --title "${DC["Title"]-}${Title}" \
         --timeout "${TimeOut}" \
@@ -199,6 +201,8 @@ dialog_info() {
     if [[ -z ${DC["_defined_"]-} ]]; then
         run_script 'config_theme'
     fi
+    COLUMNS=$(tput cols)
+    LINES=$(tput lines)
     _dialog_ \
         --title "${Title}" \
         --infobox "${Message}" \
@@ -214,6 +218,8 @@ dialog_message() {
     if [[ -z ${DC["_defined_"]-} ]]; then
         run_script 'config_theme'
     fi
+    COLUMNS=$(tput cols)
+    LINES=$(tput lines)
     _dialog_ \
         --title "${Title}" \
         --timeout "${TimeOut}" \

--- a/.scripts/menu_add_app.sh
+++ b/.scripts/menu_add_app.sh
@@ -11,6 +11,8 @@ menu_add_app() {
     local AppName=""
     #local BaseAppName InstanceName
     while true; do
+        COLUMNS=$(tput cols)
+        LINES=$(tput lines)
         local AppNameHeading="${AppName}"
         if ! run_script 'appname_is_valid' "${AppName}"; then
             AppNameHeading="${AppNameNone}"

--- a/.scripts/menu_add_var.sh
+++ b/.scripts/menu_add_var.sh
@@ -92,6 +92,8 @@ menu_add_var() {
             AddAllHelpLine="This will add all stock variables listed below."
             local -A OptionValue=()
             while true; do
+                COLUMNS=$(tput cols)
+                LINES=$(tput lines)
                 VarNameHeading="${VarName:-${VarNameNone}}"
                 Heading="$(run_script 'menu_heading' ":${AppName}" "${VarNameHeading}")"
                 local -a TemplateValueOptions ClearValueOptions EnabledValueOptions AddAllValueOptions StockValueOptions
@@ -180,6 +182,8 @@ menu_add_var() {
                     --no-hot-list
                     --title "${DC["Title"]-}${Title}"
                 )
+                COLUMNS=$(tput cols)
+                LINES=$(tput lines)
                 local -i MenuTextLines
                 MenuTextLines="$(_dialog_ "${SelectValueDialogParams[@]}" --print-text-size "${SelectValueMenuText}" "$((LINES - DC["WindowRowsAdjust"]))" "$((COLUMNS - DC["WindowColsAdjust"]))" | cut -d ' ' -f 1)"
                 local -i SelectValueDialogButtonPressed=0
@@ -289,6 +293,8 @@ menu_add_var() {
                 AppNameHeading="${AppName}:"
             fi
             while true; do
+                COLUMNS=$(tput cols)
+                LINES=$(tput lines)
                 VarNameHeading="${VarName:-${VarNameNone}}"
                 local InputValueText
                 Heading="$(run_script 'menu_heading' "${AppNameHeading}" "")"

--- a/.scripts/menu_app_select.sh
+++ b/.scripts/menu_app_select.sh
@@ -68,6 +68,8 @@ menu_app_select() {
             AddedAppsRegex="${AddedApps[*]}"
             IFS="${old_IFS}"
 
+            COLUMNS=$(tput cols)
+            LINES=$(tput lines)
             printf "\nCurrently installed applications:\n\n"
             local -i TextCols
             TextCols=$((COLUMNS - DC["WindowColsAdjust"] - DC["TextColsAdjust"]))
@@ -143,6 +145,8 @@ menu_app_select() {
     if [[ ${CI-} == true ]]; then
         SelectedAppsDialogButtonPressed=${DIALOG_CANCEL}
     else
+        COLUMNS=$(tput cols)
+        LINES=$(tput lines)
         local SelectAppsDialogText="Choose which apps you would like to install:\n Use ${DC["KeyCap"]-}[up]${DC["NC"]-}, ${DC["KeyCap"]-}[down]${DC["NC"]-}, and ${DC["KeyCap"]-}[space]${DC["NC"]-} to select apps, and ${DC["KeyCap"]-}[tab]${DC["NC"]-} to switch to the buttons at the bottom."
         local SelectedAppsDialogParams=(
             --title "${DC["Title"]-}${Title}"
@@ -261,6 +265,8 @@ show_gauge() {
         --backtitle "${BACKTITLE}"
     )
 
+    COLUMNS=$(tput cols)
+    LINES=$(tput lines)
     local -i ScreenRows=${LINES}
     local -i ScreenCols=${COLUMNS}
     local -i DialogCols
@@ -333,6 +339,8 @@ close_gauge() {
 }
 
 init_gauge_text() {
+    COLUMNS=$(tput cols)
+    LINES=$(tput lines)
     local IndentCols=3
     local SpaceCols=1
     local Indent Space

--- a/.scripts/menu_config.sh
+++ b/.scripts/menu_config.sh
@@ -42,6 +42,8 @@ menu_config() {
 
     local LastConfigChoice=""
     while true; do
+        COLUMNS=$(tput cols)
+        LINES=$(tput lines)
         local -a ConfigChoiceDialog=(
             --output-fd 1
             --title "${DC["Title"]-}${Title}"

--- a/.scripts/menu_config_apps.sh
+++ b/.scripts/menu_config_apps.sh
@@ -19,6 +19,8 @@ menu_config_apps() {
         #ScreenSize="$(_dialog_ --output-fd 1 --print-maxsize)"
         #ScreenRows="$(echo "${ScreenSize}" | cut -d ' ' -f 2 | cut -d ',' -f 1)"
         #ScreenCols="$(echo "${ScreenSize}" | cut -d ' ' -f 3)"
+        COLUMNS=$(tput cols)
+        LINES=$(tput lines)
         ScreenRows="${LINES}"
         ScreenCols="${COLUMNS}"
         WindowRowsMax=$((ScreenRows - DC["WindowRowsAdjust"]))

--- a/.scripts/menu_config_vars.sh
+++ b/.scripts/menu_config_vars.sh
@@ -149,6 +149,8 @@ menu_config_vars() {
             LastLineChoice="$(printf "%0${PadSize}d" "${TotalLines}")"
         fi
         while true; do
+            COLUMNS=$(tput cols)
+            LINES=$(tput lines)
             local DialogHeading
             DialogHeading="$(run_script 'menu_heading' "${APPNAME-}")"
             local -a LineDialog=(

--- a/.scripts/menu_dialog_example.sh
+++ b/.scripts/menu_dialog_example.sh
@@ -45,6 +45,8 @@ menu_dialog_example() {
 
     local Helpline="This is a sample help line with ${DC["Highlight"]-}highlighted${DC["NC"]-} text."
 
+    COLUMNS=$(tput cols)
+    LINES=$(tput lines)
     local -i MenuTextLines
     MenuTextLines="$(
         _dialog_ \

--- a/.scripts/menu_value_prompt.sh
+++ b/.scripts/menu_value_prompt.sh
@@ -302,6 +302,8 @@ menu_value_prompt() {
             --title "${DC["Title"]-}${Title}"
             --item-help
         )
+        COLUMNS=$(tput cols)
+        LINES=$(tput lines)
         local -i MenuTextLines
         MenuTextLines="$(_dialog_ "${SelectValueDialogParams[@]}" --print-text-size "${SelectValueMenuText}" "$((LINES - DC["WindowRowsAdjust"]))" "$((COLUMNS - DC["WindowColsAdjust"]))" | cut -d ' ' -f 1)"
         local -i SelectValueDialogButtonPressed=0

--- a/.scripts/question_prompt.sh
+++ b/.scripts/question_prompt.sh
@@ -44,6 +44,8 @@ question_prompt() {
             fi
             notice "${NoticeQuestion}" &> /dev/null
             notice "${YNPrompt}" &> /dev/null
+            COLUMNS=$(tput cols)
+            LINES=$(tput lines)
             # shellcheck disable=SC2206 # (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.
             local -a YesNoDialog=(
                 --output-fd 1


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Refresh terminal dimension variables before rendering dialogs and menus by using tput to set COLUMNS and LINES in multiple scripts.

Enhancements:
- Dynamically populate COLUMNS and LINES using tput cols/lines before computing dialog dimensions in menu_app_select.sh
- Add COLUMNS and LINES updates via tput in dialog_functions.sh to ensure accurate sizing for all _dialog_ calls
- Insert tput-based COLUMNS and LINES assignments in menu_add_var.sh, menu_add_app.sh, menu_config.sh, menu_config_apps.sh, menu_config_vars.sh, menu_dialog_example.sh, menu_value_prompt.sh, and question_prompt.sh