### PR TITLE
Use a "set_screen_size" helper function to set `LINES` and `COLUMNS` …

### DIFF
--- a/.includes/dialog_functions.sh
+++ b/.includes/dialog_functions.sh
@@ -33,6 +33,13 @@ declare -ragx DIALOG_BUTTONS=(
 
 declare -gx BACKTITLE=''
 
+declare -igx LINES COLUMNS
+
+set_screen_size() {
+    COLUMNS=$(tput cols)
+    LINES=$(tput lines)
+}
+
 _dialog_backtitle_() {
     local LeftHeading CenterHeading RightHeading
 
@@ -78,7 +85,7 @@ _dialog_backtitle_() {
     fi
 
     local -i HeadingLength
-    COLUMNS=$(tput cols)
+    set_screen_size
     HeadingLength=$((COLUMNS - 2))
 
     local CleanLeftHeading CleanCenterHeading CleanRightHeading
@@ -137,8 +144,7 @@ dialog_pipe() {
     fi
     Title="$(strip_ansi_colors "${Title}")"
     SubTitle="$(strip_ansi_colors "${SubTitle}")"
-    COLUMNS=$(tput cols)
-    LINES=$(tput lines)
+    set_screen_size
     _dialog_ \
         --title "${DC["Title"]-}${Title}" \
         --timeout "${TimeOut}" \
@@ -201,8 +207,7 @@ dialog_info() {
     if [[ -z ${DC["_defined_"]-} ]]; then
         run_script 'config_theme'
     fi
-    COLUMNS=$(tput cols)
-    LINES=$(tput lines)
+    set_screen_size
     _dialog_ \
         --title "${Title}" \
         --infobox "${Message}" \
@@ -218,8 +223,7 @@ dialog_message() {
     if [[ -z ${DC["_defined_"]-} ]]; then
         run_script 'config_theme'
     fi
-    COLUMNS=$(tput cols)
-    LINES=$(tput lines)
+    set_screen_size
     _dialog_ \
         --title "${Title}" \
         --timeout "${TimeOut}" \

--- a/.scripts/menu_add_app.sh
+++ b/.scripts/menu_add_app.sh
@@ -11,8 +11,7 @@ menu_add_app() {
     local AppName=""
     #local BaseAppName InstanceName
     while true; do
-        COLUMNS=$(tput cols)
-        LINES=$(tput lines)
+        set_screen_size
         local AppNameHeading="${AppName}"
         if ! run_script 'appname_is_valid' "${AppName}"; then
             AppNameHeading="${AppNameNone}"

--- a/.scripts/menu_add_var.sh
+++ b/.scripts/menu_add_var.sh
@@ -92,8 +92,7 @@ menu_add_var() {
             AddAllHelpLine="This will add all stock variables listed below."
             local -A OptionValue=()
             while true; do
-                COLUMNS=$(tput cols)
-                LINES=$(tput lines)
+                set_screen_size
                 VarNameHeading="${VarName:-${VarNameNone}}"
                 Heading="$(run_script 'menu_heading' ":${AppName}" "${VarNameHeading}")"
                 local -a TemplateValueOptions ClearValueOptions EnabledValueOptions AddAllValueOptions StockValueOptions
@@ -182,8 +181,7 @@ menu_add_var() {
                     --no-hot-list
                     --title "${DC["Title"]-}${Title}"
                 )
-                COLUMNS=$(tput cols)
-                LINES=$(tput lines)
+                set_screen_size
                 local -i MenuTextLines
                 MenuTextLines="$(_dialog_ "${SelectValueDialogParams[@]}" --print-text-size "${SelectValueMenuText}" "$((LINES - DC["WindowRowsAdjust"]))" "$((COLUMNS - DC["WindowColsAdjust"]))" | cut -d ' ' -f 1)"
                 local -i SelectValueDialogButtonPressed=0
@@ -293,8 +291,7 @@ menu_add_var() {
                 AppNameHeading="${AppName}:"
             fi
             while true; do
-                COLUMNS=$(tput cols)
-                LINES=$(tput lines)
+                set_screen_size
                 VarNameHeading="${VarName:-${VarNameNone}}"
                 local InputValueText
                 Heading="$(run_script 'menu_heading' "${AppNameHeading}" "")"

--- a/.scripts/menu_app_select.sh
+++ b/.scripts/menu_app_select.sh
@@ -68,8 +68,7 @@ menu_app_select() {
             AddedAppsRegex="${AddedApps[*]}"
             IFS="${old_IFS}"
 
-            COLUMNS=$(tput cols)
-            LINES=$(tput lines)
+            set_screen_size
             printf "\nCurrently installed applications:\n\n"
             local -i TextCols
             TextCols=$((COLUMNS - DC["WindowColsAdjust"] - DC["TextColsAdjust"]))
@@ -145,8 +144,7 @@ menu_app_select() {
     if [[ ${CI-} == true ]]; then
         SelectedAppsDialogButtonPressed=${DIALOG_CANCEL}
     else
-        COLUMNS=$(tput cols)
-        LINES=$(tput lines)
+        set_screen_size
         local SelectAppsDialogText="Choose which apps you would like to install:\n Use ${DC["KeyCap"]-}[up]${DC["NC"]-}, ${DC["KeyCap"]-}[down]${DC["NC"]-}, and ${DC["KeyCap"]-}[space]${DC["NC"]-} to select apps, and ${DC["KeyCap"]-}[tab]${DC["NC"]-} to switch to the buttons at the bottom."
         local SelectedAppsDialogParams=(
             --title "${DC["Title"]-}${Title}"
@@ -265,8 +263,7 @@ show_gauge() {
         --backtitle "${BACKTITLE}"
     )
 
-    COLUMNS=$(tput cols)
-    LINES=$(tput lines)
+    set_screen_size
     local -i ScreenRows=${LINES}
     local -i ScreenCols=${COLUMNS}
     local -i DialogCols
@@ -339,8 +336,7 @@ close_gauge() {
 }
 
 init_gauge_text() {
-    COLUMNS=$(tput cols)
-    LINES=$(tput lines)
+    set_screen_size
     local IndentCols=3
     local SpaceCols=1
     local Indent Space

--- a/.scripts/menu_config.sh
+++ b/.scripts/menu_config.sh
@@ -42,8 +42,7 @@ menu_config() {
 
     local LastConfigChoice=""
     while true; do
-        COLUMNS=$(tput cols)
-        LINES=$(tput lines)
+        set_screen_size
         local -a ConfigChoiceDialog=(
             --output-fd 1
             --title "${DC["Title"]-}${Title}"

--- a/.scripts/menu_config_apps.sh
+++ b/.scripts/menu_config_apps.sh
@@ -19,8 +19,7 @@ menu_config_apps() {
         #ScreenSize="$(_dialog_ --output-fd 1 --print-maxsize)"
         #ScreenRows="$(echo "${ScreenSize}" | cut -d ' ' -f 2 | cut -d ',' -f 1)"
         #ScreenCols="$(echo "${ScreenSize}" | cut -d ' ' -f 3)"
-        COLUMNS=$(tput cols)
-        LINES=$(tput lines)
+        set_screen_size
         ScreenRows="${LINES}"
         ScreenCols="${COLUMNS}"
         WindowRowsMax=$((ScreenRows - DC["WindowRowsAdjust"]))

--- a/.scripts/menu_config_vars.sh
+++ b/.scripts/menu_config_vars.sh
@@ -149,8 +149,7 @@ menu_config_vars() {
             LastLineChoice="$(printf "%0${PadSize}d" "${TotalLines}")"
         fi
         while true; do
-            COLUMNS=$(tput cols)
-            LINES=$(tput lines)
+            set_screen_size
             local DialogHeading
             DialogHeading="$(run_script 'menu_heading' "${APPNAME-}")"
             local -a LineDialog=(

--- a/.scripts/menu_dialog_example.sh
+++ b/.scripts/menu_dialog_example.sh
@@ -45,8 +45,7 @@ menu_dialog_example() {
 
     local Helpline="This is a sample help line with ${DC["Highlight"]-}highlighted${DC["NC"]-} text."
 
-    COLUMNS=$(tput cols)
-    LINES=$(tput lines)
+    set_screen_size
     local -i MenuTextLines
     MenuTextLines="$(
         _dialog_ \

--- a/.scripts/menu_value_prompt.sh
+++ b/.scripts/menu_value_prompt.sh
@@ -302,8 +302,7 @@ menu_value_prompt() {
             --title "${DC["Title"]-}${Title}"
             --item-help
         )
-        COLUMNS=$(tput cols)
-        LINES=$(tput lines)
+        set_screen_size
         local -i MenuTextLines
         MenuTextLines="$(_dialog_ "${SelectValueDialogParams[@]}" --print-text-size "${SelectValueMenuText}" "$((LINES - DC["WindowRowsAdjust"]))" "$((COLUMNS - DC["WindowColsAdjust"]))" | cut -d ' ' -f 1)"
         local -i SelectValueDialogButtonPressed=0

--- a/.scripts/question_prompt.sh
+++ b/.scripts/question_prompt.sh
@@ -44,8 +44,7 @@ question_prompt() {
             fi
             notice "${NoticeQuestion}" &> /dev/null
             notice "${YNPrompt}" &> /dev/null
-            COLUMNS=$(tput cols)
-            LINES=$(tput lines)
+            set_screen_size
             # shellcheck disable=SC2206 # (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.
             local -a YesNoDialog=(
                 --output-fd 1


### PR DESCRIPTION
…vars

# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Extract screen size setup into a reusable helper and update all dialog and menu scripts to use it instead of repeating tput commands

Enhancements:
- Introduce a set_screen_size helper in dialog_functions.sh to centralize computation of LINES and COLUMNS
- Replace direct tput cols/lines calls with set_screen_size across various menu and dialog scripts to DRY up screen sizing logic