### PR TITLE
Add volume configuration for Flame app

### DIFF
--- a/compose/.apps/flame/flame.yml
+++ b/compose/.apps/flame/flame.yml
@@ -6,3 +6,4 @@ services:
     volumes:
       - /etc/localtime:/etc/localtime:ro
       - ${FLAME<__INSTANCE>__VOLUME_DOCKER_SOCKET?}:/var/run/docker.sock
+      - ${DOCKER_VOLUME_CONFIG?}/flame<__instance>:/app/data


### PR DESCRIPTION
adding persistent storage

## Summary by Sourcery

New Features:
- Add host volume mapping for Flame app data directory (\"/app/data\") via DOCKER_VOLUME_CONFIG