### PR TITLE
Update watchtower to use nickfedor container

### DIFF
--- a/compose/.apps/watchtower/watchtower.aarch64.yml
+++ b/compose/.apps/watchtower/watchtower.aarch64.yml
@@ -1,3 +1,3 @@
 services:
   watchtower<__instance>:
-    image: ghcr.io/containrrr/watchtower:${WATCHTOWER<__INSTANCE>__TAG?}
+    image: nickfedor/watchtower:${WATCHTOWER<__INSTANCE>__TAG?}

--- a/compose/.apps/watchtower/watchtower.x86_64.yml
+++ b/compose/.apps/watchtower/watchtower.x86_64.yml
@@ -1,3 +1,3 @@
 services:
   watchtower<__instance>:
-    image: ghcr.io/containrrr/watchtower:${WATCHTOWER<__INSTANCE>__TAG?}
+    image: nickfedor/watchtower:${WATCHTOWER<__INSTANCE>__TAG?}


### PR DESCRIPTION
# Pull request

**Purpose**
The containrrr/watchtower image has been abandoned for several years. There are several forked images but nickfedor/watchtower seems to be the most actively maintained one. 

**Approach**
This is a straight image swap from ghcr.io/containrrr/watchtower to nickfedor/watchtower. There appears to be no difference between environment flags compared to the original. 

Note - this is my first PR so apologies if I've gotten something wrong. 

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [x] Use github checklists. When solved, check the box and explain the answer.

**Learning**
There appear to be 2 main forks of watchtower, [nickfedor/watchtower](https://github.com/nicholas-fedor/watchtower) and [beatkind/watchtower](https://github.com/beatkind/watchtower). Beatkind have recently [announced their intention](https://github.com/beatkind/watchtower/issues/142) to pause maintenance and merge with the nickfedor image, leaving one that is actively maintained. 

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Enhancements:
- Swap the watchtower container image to the actively maintained nickfedor/watchtower fork