### PR TITLE
Fix creating symlink in Ubuntu 25.10

### DIFF
--- a/.scripts/symlink_ds.sh
+++ b/.scripts/symlink_ds.sh
@@ -26,7 +26,7 @@ symlink_ds() {
         if [[ ! -L ${SymlinkTarget} ]]; then
             info "Creating '${C["File"]}${SymlinkTarget}${NC}' symbolic link for ${APPLICATION_NAME}."
             mkdir -p "${Folder}" &> /dev/null || true
-            sudo ln -s -F "${SCRIPTNAME}" "${SymlinkTarget}" &> /dev/null || true
+            sudo ln -s "${SCRIPTNAME}" "${SymlinkTarget}" &> /dev/null || true
         fi
         if [[ -L ${SymlinkTarget} ]]; then
             FinalSymlinkFolder="${Folder}"


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Bug Fixes:
- Fix symlink creation on Ubuntu 25.10 by removing the -F flag from the ln command