### PR TITLE
Replace `pr -e` with `expand`

### DIFF
--- a/.includes/cmdline.sh
+++ b/.includes/cmdline.sh
@@ -1079,11 +1079,11 @@ cmdline_error_text() {
     local -i Indent=3
 
     CommandLine="$(
-        pr -e -t -o "${Indent}" <<< "${CommandLine}" | sed 's/[[:space:]]\+$//'
+        pr -t -o "${Indent}" <<< "${CommandLine}" | expand | sed 's/[[:space:]]\+$//'
     )"
     Message=${Message//\\n/$'\n'}
     Message="$(
-        pr -e -t -o "${Indent}" <<< "${Message}" | sed 's/[[:space:]]\+$//'
+        pr -t -o "${Indent}" <<< "${Message}" | expand | sed 's/[[:space:]]\+$//'
     )"
 
     local UsageText
@@ -1092,7 +1092,7 @@ cmdline_error_text() {
     else
         local CommandUsage
         CommandUsage="$(usage "${Command}" NoHeading)"
-        UsageText="Usage is:\n$(pr -e -t -o "${Indent}" <<< "${CommandUsage}")"
+        UsageText="Usage is:\n$(pr -t -o "${Indent}" <<< "${CommandUsage}" | expand)"
     fi
     cat << EOF
 Error in command line:

--- a/.scripts/menu_app_select.sh
+++ b/.scripts/menu_app_select.sh
@@ -78,7 +78,8 @@ menu_app_select() {
             readarray -t AddedAppsTable < <(
                 printf "%s\n" "${AddedAppsTable[@]}" |
                     column -c "$((TextCols - ${#Indent}))" |
-                    pr -e -t -o "${#Indent}"
+                    pr -t -o "${#Indent}" |
+                    expand
             )
         fi
         update_gauge 1
@@ -380,7 +381,8 @@ init_gauge_text() {
             FormattedAppNames="$(
                 printf "%s\n" "${AppNamesArray[@]}" |
                     fmt -w "$((TextCols - AppsColumnStart))" |
-                    pr -e -t -o "${AppsColumnStart}"
+                    pr -t -o "${AppsColumnStart}" |
+                    expand
             )"
 
             # Get the color codes to add to the app names


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Enhancements:
- Replace all uses of pr -e with pr -t piped to expand for consistent tab expansion