### PR TITLE
Fixes for Ubuntu 25.10

### DIFF
--- a/.includes/pm_variables.sh
+++ b/.includes/pm_variables.sh
@@ -103,8 +103,10 @@ declare -Argx PM_ZYPPER_DEP_PACKAGE=(
 )
 
 declare -argx PM__PACKAGE_BLACKLIST=(
-    "busybox-.*"
+    ".*busybox.*"
+    ".*toybox.*"
     "9base"
+    "coreutils-from-gnu"
     "coreutils-single"
     "curl-minimal"
     "gitlab-shell"


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Update package blacklist patterns to improve compatibility with Ubuntu 25.10

Enhancements:
- Broaden the regex for busybox blacklist to match any busybox variant
- Add toybox and coreutils-from-gnu to the package blacklist