### PR TITLE
Add an "Exit" button to dialog boxes in the menu

### DIFF
--- a/.scripts/menu_config.sh
+++ b/.scripts/menu_config.sh
@@ -46,8 +46,10 @@ menu_config() {
         local -a ConfigChoiceDialog=(
             --output-fd 1
             --title "${DC["Title"]-}${Title}"
+            --extra-button
             --ok-label "Select"
-            --cancel-label "Back"
+            --extra-label "Back"
+            --cancel-label "Exit"
             --menu "What would you like to do?" 0 0 0
             "${ConfigOpts[@]}"
         )
@@ -56,7 +58,7 @@ menu_config() {
         ConfigChoice=$(_dialog_ --default-item "${LastConfigChoice}" "${ConfigChoiceDialog[@]}") || ConfigDialogButtonPressed=$?
         LastConfigChoice=${ConfigChoice}
         case ${DIALOG_BUTTONS[ConfigDialogButtonPressed]-} in
-            OK)
+            OK) # Select
                 case "${ConfigChoice}" in
                     "${Option_FullSetup}")
                         run_script 'menu_config_vars' || true
@@ -99,7 +101,8 @@ menu_config() {
                                 run_script_dialog "${DC["TitleSuccess"]-}Docker Compose" "Stopping and removing all containers, networks, volumes, and images.\n${DC["CommandLine"]-} ${APPLICATION_COMMAND} --compose down" "" \
                                     'docker_compose' "down"
                                 ;;
-                            CANCEL | ESC) ;; # Cancel
+                            CANCEL | ESC) # Cancel
+                                ;;
                             *)
                                 if [[ -n ${DIALOG_BUTTONS[YesNoDialogButtonPressed]-} ]]; then
                                     fatal "Unexpected dialog button '${DIALOG_BUTTONS[YesNoDialogButtonPressed]}' pressed in menu_config."
@@ -117,8 +120,11 @@ menu_config() {
                         ;;
                 esac
                 ;;
-            CANCEL | ESC)
+            EXTRA | ESC) # Back
                 return
+                ;;
+            CANCEL) # Exit
+                run_script 'menu_exit'
                 ;;
             *)
                 if [[ -n ${DIALOG_BUTTONS[ConfigDialogButtonPressed]-} ]]; then

--- a/.scripts/menu_config_apps.sh
+++ b/.scripts/menu_config_apps.sh
@@ -68,8 +68,10 @@ menu_config_apps() {
         local -a AppChoiceDialog=(
             "${AppChoiceParams[@]}"
             --title "${DC["Title"]-}${Title}"
+            --extra-button
             --ok-label "Select"
-            --cancel-label "Done"
+            --extra-label "Back"
+            --cancel-label "Exit"
             --menu "${MenuText}"
             "${WindowRows}" "${WindowCols}"
             "${WindowListRows}"
@@ -80,15 +82,18 @@ menu_config_apps() {
         AppChoice=$(_dialog_ --default-item "${LastAppChoice}" "${AppChoiceDialog[@]}") || AppChoiceButtonPressed=$?
         LastAppChoice=${AppChoice}
         case ${DIALOG_BUTTONS[AppChoiceButtonPressed]-} in
-            OK)
+            OK) # Select
                 if [[ ${AppChoice} == "${AddAplicationText}" ]]; then
                     run_script 'menu_add_app'
                 else
                     run_script 'menu_config_vars' "${AppChoice}"
                 fi
                 ;;
-            CANCEL | ESC)
+            EXTRA | ESC) # Back
                 return
+                ;;
+            CANCEL) # Exit
+                run_script 'menu_exit'
                 ;;
             *)
                 if [[ -n ${DIALOG_BUTTONS[AppChoiceButtonPressed]-} ]]; then

--- a/.scripts/menu_config_vars.sh
+++ b/.scripts/menu_config_vars.sh
@@ -161,7 +161,7 @@ menu_config_vars() {
                 --extra-button
                 --ok-label "Select"
                 --extra-label "Remove"
-                --cancel-label "Done"
+                --cancel-label "Back"
                 --title "${DC["Title"]-}${Title}"
                 --default-item "${LastLineChoice}"
                 --menu "${DialogHeading}" "$((LINES - DC["WindowRowsAdjust"]))" "$((COLUMNS - DC["WindowColsAdjust"]))" -1
@@ -228,7 +228,7 @@ menu_config_vars() {
                         fi
                     fi
                     ;;
-                CANCEL | ESC) # Done
+                CANCEL | ESC) # Back
                     return
                     ;;
                 *)

--- a/.scripts/menu_exit.sh
+++ b/.scripts/menu_exit.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+menu_exit() {
+    if run_script 'question_prompt' Y "Do you want to exit ${APPLICATION_NAME}?" "Exit ${APPLICATION_NAME}" "${ASSUMEYES:+Y}"; then
+        clear
+        info "Exiting ${APPLICATION_NAME}."
+        exit 0
+    fi
+    return 0
+}
+
+test_menu_exit() {
+    # run_script 'menu_exit'
+    warn "CI does not test menu_exit."
+}

--- a/.scripts/menu_main.sh
+++ b/.scripts/menu_main.sh
@@ -56,7 +56,7 @@ menu_main() {
             CANCEL | ESC)
                 clear
                 info "Exiting ${APPLICATION_NAME}."
-                return
+                exit 0
                 ;;
             *)
                 if [[ -n ${DIALOG_BUTTONS[MainDialogButtonPressed]-} ]]; then

--- a/.scripts/menu_options.sh
+++ b/.scripts/menu_options.sh
@@ -22,8 +22,10 @@ menu_options() {
         local -a ChoiceDialog=(
             --output-fd 1
             --title "${DC["Title"]-}${Title}"
+            --extra-button
             --ok-label "Select"
-            --cancel-label "Back"
+            --extra-label "Back"
+            --cancel-label "Exit"
             --menu "What would you like to do?" 0 0 0
             "${Opts[@]}"
         )
@@ -32,7 +34,7 @@ menu_options() {
         Choice=$(_dialog_ --default-item "${LastChoice}" "${ChoiceDialog[@]}") || DialogButtonPressed=$?
         LastChoice=${Choice}
         case ${DIALOG_BUTTONS[DialogButtonPressed]-} in
-            OK)
+            OK) # Select
                 case "${Choice}" in
                     "${Option_Theme}")
                         run_script 'menu_options_theme' || true
@@ -48,10 +50,11 @@ menu_options() {
                         ;;
                 esac
                 ;;
-            CANCEL | ESC)
-                clear
-                info "Exiting ${APPLICATION_NAME}."
+            EXTRA | ESC) # Back
                 return
+                ;;
+            CANCEL) # Exit
+                run_script 'menu_exit'
                 ;;
             *)
                 if [[ -n ${DIALOG_BUTTONS[DialogButtonPressed]-} ]]; then


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Add explicit exit handling to menu dialogs and centralize exit behavior in a shared script.

New Features:
- Introduce a dedicated menu_exit script that prompts for confirmation before exiting the application.
- Add explicit Exit buttons to configuration, options, and app configuration dialogs, separate from the Back navigation control.

Enhancements:
- Adjust menu dialogs to use the extra button as Back while repurposing the Cancel button for exiting, improving consistency of menu navigation labels.