### PR TITLE
Colorize the dialog fatal error messages

### DIFF
--- a/.scripts/menu_add_app.sh
+++ b/.scripts/menu_add_app.sh
@@ -120,9 +120,9 @@ menu_add_app() {
                             ;;
                         *)
                             if [[ -n ${DIALOG_BUTTONS[YesNoDialogButtonPressed]-} ]]; then
-                                fatal "Unexpected dialog button '${F[C]}${DIALOG_BUTTONS[YesNoDialogButtonPressed]}${NC}' pressed in ${FUNCNAME[0]}."
+                                fatal "Unexpected dialog button '${F[C]}${DIALOG_BUTTONS[YesNoDialogButtonPressed]}${NC}' pressed in '${C["RunningCommand"]-}${FUNCNAME[0]}${NC}'."
                             else
-                                fatal "Unexpected dialog button value '${F[C]}${YesNoDialogButtonPressed}${NC}' pressed in ${FUNCNAME[0]}."
+                                fatal "Unexpected dialog button value '${F[C]}${YesNoDialogButtonPressed}${NC}' pressed in '${C["RunningCommand"]-}${FUNCNAME[0]}${NC}'."
                             fi
                             ;;
                     esac
@@ -133,9 +133,9 @@ menu_add_app() {
                 ;;
             *)
                 if [[ -n ${DIALOG_BUTTONS[InputValueDialogButtonPressed]-} ]]; then
-                    fatal "Unexpected dialog button '${F[C]}${DIALOG_BUTTONS[InputValueDialogButtonPressed]}${NC}' pressed in ${FUNCNAME[0]}."
+                    fatal "Unexpected dialog button '${F[C]}${DIALOG_BUTTONS[InputValueDialogButtonPressed]}${NC}' pressed in '${C["RunningCommand"]-}${FUNCNAME[0]}${NC}'."
                 else
-                    fatal "Unexpected dialog button value '${F[C]}${InputValueDialogButtonPressed}${NC}' pressed in ${FUNCNAME[0]}."
+                    fatal "Unexpected dialog button value '${F[C]}${InputValueDialogButtonPressed}${NC}' pressed in '${C["RunningCommand"]-}${FUNCNAME[0]}${NC}'."
                 fi
                 ;;
         esac

--- a/.scripts/menu_add_var.sh
+++ b/.scripts/menu_add_var.sh
@@ -372,9 +372,9 @@ menu_add_var() {
                         ;;
                     *)
                         if [[ -n ${DIALOG_BUTTONS[InputValueDialogButtonPressed]-} ]]; then
-                            fatal "Unexpected dialog button '${DIALOG_BUTTONS[InputValueDialogButtonPressed]}' pressed in ${FUNCNAME[0]}."
+                            fatal "Unexpected dialog button '${F[C]}${DIALOG_BUTTONS[InputValueDialogButtonPressed]}${NC}' pressed in '${C["RunningCommand"]-}${FUNCNAME[0]}${NC}'."
                         else
-                            fatal "Unexpected dialog button value '${InputValueDialogButtonPressed}' pressed in ${FUNCNAME[0]}."
+                            fatal "Unexpected dialog button value '${F[C]}${InputValueDialogButtonPressed}${NC}' pressed in '${C["RunningCommand"]-}${FUNCNAME[0]}${NC}'."
                         fi
                         ;;
                 esac

--- a/.scripts/menu_app_select.sh
+++ b/.scripts/menu_app_select.sh
@@ -247,9 +247,9 @@ menu_app_select() {
             ;;
         *)
             if [[ -n ${DIALOG_BUTTONS[SelectedAppsDialogButtonPressed]-} ]]; then
-                fatal "Unexpected dialog button '${DIALOG_BUTTONS[SelectedAppsDialogButtonPressed]}' pressed in ${FUNCNAME[0]}."
+                fatal "Unexpected dialog button '${F[C]}${DIALOG_BUTTONS[SelectedAppsDialogButtonPressed]}${NC}' pressed in '${C["RunningCommand"]-}${FUNCNAME[0]}${NC}'."
             else
-                fatal "Unexpected dialog button value '${SelectedAppsDialogButtonPressed}' pressed in ${FUNCNAME[0]}."
+                fatal "Unexpected dialog button value '${SelectedAppsDialogButtonPressed}' pressed in '${C["RunningCommand"]-}${FUNCNAME[0]}${NC}'."
             fi
             ;;
     esac

--- a/.scripts/menu_config.sh
+++ b/.scripts/menu_config.sh
@@ -105,9 +105,9 @@ menu_config() {
                                 ;;
                             *)
                                 if [[ -n ${DIALOG_BUTTONS[YesNoDialogButtonPressed]-} ]]; then
-                                    fatal "Unexpected dialog button '${DIALOG_BUTTONS[YesNoDialogButtonPressed]}' pressed in ${FUNCNAME[0]}."
+                                    fatal "Unexpected dialog button '${F[C]}${DIALOG_BUTTONS[YesNoDialogButtonPressed]}' pressed in '${C["RunningCommand"]-}${FUNCNAME[0]}${NC}'."
                                 else
-                                    fatal "Unexpected dialog button value '${YesNoDialogButtonPressed}' pressed in ${FUNCNAME[0]}."
+                                    fatal "Unexpected dialog button value '${YesNoDialogButtonPressed}' pressed in '${C["RunningCommand"]-}${FUNCNAME[0]}${NC}'."
                                 fi
                                 ;;
                         esac
@@ -128,9 +128,9 @@ menu_config() {
                 ;;
             *)
                 if [[ -n ${DIALOG_BUTTONS[ConfigDialogButtonPressed]-} ]]; then
-                    fatal "Unexpected dialog button '${DIALOG_BUTTONS[ConfigDialogButtonPressed]}' pressed in ${FUNCNAME[0]}."
+                    fatal "Unexpected dialog button '${F[C]}${DIALOG_BUTTONS[ConfigDialogButtonPressed]}' pressed in '${C["RunningCommand"]-}${FUNCNAME[0]}${NC}'."
                 else
-                    fatal "Unexpected dialog button value '${ConfigDialogButtonPressed}' pressed in ${FUNCNAME[0]}."
+                    fatal "Unexpected dialog button value '${ConfigDialogButtonPressed}' pressed in '${C["RunningCommand"]-}${FUNCNAME[0]}${NC}'."
                 fi
                 ;;
         esac

--- a/.scripts/menu_config_apps.sh
+++ b/.scripts/menu_config_apps.sh
@@ -97,9 +97,9 @@ menu_config_apps() {
                 ;;
             *)
                 if [[ -n ${DIALOG_BUTTONS[AppChoiceButtonPressed]-} ]]; then
-                    fatal "Unexpected dialog button '${DIALOG_BUTTONS[AppChoiceButtonPressed]}' pressed in ${FUNCNAME[0]}."
+                    fatal "Unexpected dialog button '${F[C]}${DIALOG_BUTTONS[AppChoiceButtonPressed]}${NC}' pressed in '${C["RunningCommand"]-}${FUNCNAME[0]}${NC}'."
                 else
-                    fatal "Unexpected dialog button value '${AppChoiceButtonPressed}' pressed in ${FUNCNAME[0]}."
+                    fatal "Unexpected dialog button value '${AppChoiceButtonPressed}' pressed in '${C["RunningCommand"]-}${FUNCNAME[0]}${NC}'."
                 fi
                 ;;
         esac

--- a/.scripts/menu_config_vars.sh
+++ b/.scripts/menu_config_vars.sh
@@ -233,9 +233,9 @@ menu_config_vars() {
                     ;;
                 *)
                     if [[ -n ${DIALOG_BUTTONS[LineDialogButtonPressed]-} ]]; then
-                        fatal "Unexpected dialog button '${DIALOG_BUTTONS[LineDialogButtonPressed]}' pressed in ${FUNCNAME[0]}."
+                        fatal "Unexpected dialog button '${F[C]}${DIALOG_BUTTONS[LineDialogButtonPressed]}${NC}' pressed in '${C["RunningCommand"]-}${FUNCNAME[0]}${NC}'."
                     else
-                        fatal "Unexpected dialog button value '${LineDialogButtonPressed}' pressed in ${FUNCNAME[0]}."
+                        fatal "Unexpected dialog button value '${LineDialogButtonPressed}' pressed in '${C["RunningCommand"]-}${FUNCNAME[0]}${NC}'."
                     fi
                     ;;
             esac

--- a/.scripts/menu_main.sh
+++ b/.scripts/menu_main.sh
@@ -60,9 +60,9 @@ menu_main() {
                 ;;
             *)
                 if [[ -n ${DIALOG_BUTTONS[MainDialogButtonPressed]-} ]]; then
-                    fatal "Unexpected dialog button '${DIALOG_BUTTONS[MainDialogButtonPressed]}' pressed in ${FUNCNAME[0]}."
+                    fatal "Unexpected dialog button '${F[C]}${DIALOG_BUTTONS[MainDialogButtonPressed]}${NC}' pressed in '${C["RunningCommand"]-}${FUNCNAME[0]}${NC}'."
                 else
-                    fatal "Unexpected dialog button value '${MainDialogButtonPressed}' pressed in ${FUNCNAME[0]}."
+                    fatal "Unexpected dialog button value '${MainDialogButtonPressed}' pressed in '${C["RunningCommand"]-}${FUNCNAME[0]}${NC}'."
                 fi
                 ;;
         esac

--- a/.scripts/menu_options.sh
+++ b/.scripts/menu_options.sh
@@ -58,9 +58,9 @@ menu_options() {
                 ;;
             *)
                 if [[ -n ${DIALOG_BUTTONS[DialogButtonPressed]-} ]]; then
-                    fatal "Unexpected dialog button '${DIALOG_BUTTONS[DialogButtonPressed]}' pressed in ${FUNCNAME[0]}."
+                    fatal "Unexpected dialog button '${F[C]}${DIALOG_BUTTONS[DialogButtonPressed]}${NC}' pressed in '${C["RunningCommand"]-}${FUNCNAME[0]}${NC}'."
                 else
-                    fatal "Unexpected dialog button value '${DialogButtonPressed}' pressed in ${FUNCNAME[0]}."
+                    fatal "Unexpected dialog button value '${F[C]}${DialogButtonPressed}' pressed in '${C["RunningCommand"]-}${FUNCNAME[0]}${NC}'."
                 fi
                 ;;
         esac

--- a/.scripts/menu_options_display.sh
+++ b/.scripts/menu_options_display.sh
@@ -82,9 +82,9 @@ menu_options_display() {
                 ;;
             *)
                 if [[ -n ${DIALOG_BUTTONS[DialogButtonPressed]-} ]]; then
-                    fatal "Unexpected dialog button '${DIALOG_BUTTONS[DialogButtonPressed]}' pressed in ${FUNCNAME[0]}."
+                    fatal "Unexpected dialog button '${F[C]}${DIALOG_BUTTONS[DialogButtonPressed]}${NC}' pressed in '${C["RunningCommand"]-}${FUNCNAME[0]}${NC}'."
                 else
-                    fatal "Unexpected dialog button value '${DialogButtonPressed}' pressed in ${FUNCNAME[0]}."
+                    fatal "Unexpected dialog button value '${F[C]}${DialogButtonPressed}' pressed in '${C["RunningCommand"]-}${FUNCNAME[0]}${NC}'."
                 fi
                 ;;
         esac

--- a/.scripts/menu_options_package_manager.sh
+++ b/.scripts/menu_options_package_manager.sh
@@ -76,9 +76,9 @@ menu_options_package_manager() {
                 ;;
             *)
                 if [[ -n ${DIALOG_BUTTONS[DialogButtonPressed]-} ]]; then
-                    fatal "Unexpected dialog button '${DIALOG_BUTTONS[DialogButtonPressed]}' pressed in ${FUNCNAME[0]}."
+                    fatal "Unexpected dialog button '${F[C]}${DIALOG_BUTTONS[DialogButtonPressed]}${NC}' pressed in '${C["RunningCommand"]-}${FUNCNAME[0]}${NC}'."
                 else
-                    fatal "Unexpected dialog button value '${DialogButtonPressed}' pressed in ${FUNCNAME[0]}."
+                    fatal "Unexpected dialog button value '${F[C]}${DialogButtonPressed}' pressed in '${C["RunningCommand"]-}${FUNCNAME[0]}${NC}'."
                 fi
                 ;;
         esac

--- a/.scripts/menu_options_theme.sh
+++ b/.scripts/menu_options_theme.sh
@@ -62,9 +62,9 @@ menu_options_theme() {
                 ;;
             *)
                 if [[ -n ${DIALOG_BUTTONS[DialogButtonPressed]-} ]]; then
-                    fatal "Unexpected dialog button '${DIALOG_BUTTONS[DialogButtonPressed]}' pressed in ${FUNCNAME[0]}."
+                    fatal "Unexpected dialog button '${F[C]}${DIALOG_BUTTONS[DialogButtonPressed]}${NC}' pressed in '${C["RunningCommand"]-}${FUNCNAME[0]}${NC}'."
                 else
-                    fatal "Unexpected dialog button value '${DialogButtonPressed}' pressed in ${FUNCNAME[0]}."
+                    fatal "Unexpected dialog button value '${F[C]}${DialogButtonPressed}' pressed in '${C["RunningCommand"]-}${FUNCNAME[0]}${NC}'."
                 fi
                 ;;
         esac

--- a/.scripts/menu_value_prompt.sh
+++ b/.scripts/menu_value_prompt.sh
@@ -539,9 +539,9 @@ menu_value_prompt() {
                 ;;
             *)
                 if [[ -n ${DIALOG_BUTTONS[SelectValueDialogButtonPressed]-} ]]; then
-                    fatal "Unexpected dialog button '${DIALOG_BUTTONS[SelectValueDialogButtonPressed]}' pressed in ${FUNCNAME[0]}."
+                    fatal "Unexpected dialog button '${F[C]}${DIALOG_BUTTONS[SelectValueDialogButtonPressed]}${NC}' pressed in '${C["RunningCommand"]-}${FUNCNAME[0]}${NC}'."
                 else
-                    fatal "Unexpected dialog button value' ${SelectValueDialogButtonPressed}' pressed in ${FUNCNAME[0]}."
+                    fatal "Unexpected dialog button value '${F[C]}${SelectValueDialogButtonPressed}${NC}' pressed in '${C["RunningCommand"]-}${FUNCNAME[0]}${NC}'."
                 fi
                 ;;
         esac

--- a/.scripts/question_prompt.sh
+++ b/.scripts/question_prompt.sh
@@ -71,9 +71,9 @@ question_prompt() {
                     ;;
                 *)
                     if [[ -n ${DIALOG_BUTTONS[YesNoDialogButtonPressed]-} ]]; then
-                        fatal "Unexpected dialog button '${DIALOG_BUTTONS[YesNoDialogButtonPressed]}' pressed in ${FUNCNAME[0]}."
+                        fatal "Unexpected dialog button '${F[C]}${DIALOG_BUTTONS[YesNoDialogButtonPressed]}${NC}' pressed in '${C["RunningCommand"]-}${FUNCNAME[0]}${NC}'."
                     else
-                        fatal "Unexpected dialog button value '${YesNoDialogButtonPressed}' pressed in ${FUNCNAME[0]}."
+                        fatal "Unexpected dialog button value '${YesNoDialogButtonPressed}' pressed in '${C["RunningCommand"]-}${FUNCNAME[0]}${NC}'."
                     fi
                     ;;
             esac


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Improve visibility and context of dialog-related fatal error messages across menu scripts.

Enhancements:
- Colorize dialog button values and labels in fatal error messages to make them stand out in terminal output.
- Include the current running command context alongside function names in dialog fatal errors to aid troubleshooting.