### PR TITLE
Add an `invalid_dialog_button` helper function to return error messages

### DIFF
--- a/.includes/dialog_functions.sh
+++ b/.includes/dialog_functions.sh
@@ -258,3 +258,12 @@ dialog_success() {
     fi
     dialog_message "${DC["TitleSuccess"]-}${Title}" "${Message}" "${TimeOut}"
 }
+
+invalid_dialog_button() {
+    local -l NoticeType=${1:-notice}
+    local -i DialogButtonNumber=${2}
+    local DialogButton="${DIALOG_BUTTONS[DialogButtonNumber]-#${DialogButtonNumber}}"
+    ${NoticeType} \
+        "Error in '${C["File"]}${BASH_SOURCE[1]}${NC}', function '${C["RunningCommand"]}${FUNCNAME[1]}${NC}', line '${C["RunningCommand"]}${BASH_LINENO[0]}${NC}'.\n" \
+        "Unexpected dialog button '${F[C]}${DialogButton}${NC}' pressed."
+}

--- a/.scripts/menu_add_app.sh
+++ b/.scripts/menu_add_app.sh
@@ -119,11 +119,8 @@ menu_add_app() {
                         CANCEL | ESC) # Back
                             ;;
                         *)
-                            if [[ -n ${DIALOG_BUTTONS[YesNoDialogButtonPressed]-} ]]; then
-                                fatal "Unexpected dialog button '${F[C]}${DIALOG_BUTTONS[YesNoDialogButtonPressed]}${NC}' pressed in '${C["RunningCommand"]-}${FUNCNAME[0]}${NC}'."
-                            else
-                                fatal "Unexpected dialog button value '${F[C]}${YesNoDialogButtonPressed}${NC}' pressed in '${C["RunningCommand"]-}${FUNCNAME[0]}${NC}'."
-                            fi
+                            invalid_dialog_button \
+                                fatal ${YesNoDialogButtonPressed}
                             ;;
                     esac
                 fi
@@ -132,11 +129,8 @@ menu_add_app() {
                 return
                 ;;
             *)
-                if [[ -n ${DIALOG_BUTTONS[InputValueDialogButtonPressed]-} ]]; then
-                    fatal "Unexpected dialog button '${F[C]}${DIALOG_BUTTONS[InputValueDialogButtonPressed]}${NC}' pressed in '${C["RunningCommand"]-}${FUNCNAME[0]}${NC}'."
-                else
-                    fatal "Unexpected dialog button value '${F[C]}${InputValueDialogButtonPressed}${NC}' pressed in '${C["RunningCommand"]-}${FUNCNAME[0]}${NC}'."
-                fi
+                invalid_dialog_button \
+                    fatal ${InputValueDialogButtonPressed}
                 ;;
         esac
     done

--- a/.scripts/menu_add_var.sh
+++ b/.scripts/menu_add_var.sh
@@ -371,11 +371,8 @@ menu_add_var() {
                         return
                         ;;
                     *)
-                        if [[ -n ${DIALOG_BUTTONS[InputValueDialogButtonPressed]-} ]]; then
-                            fatal "Unexpected dialog button '${F[C]}${DIALOG_BUTTONS[InputValueDialogButtonPressed]}${NC}' pressed in '${C["RunningCommand"]-}${FUNCNAME[0]}${NC}'."
-                        else
-                            fatal "Unexpected dialog button value '${F[C]}${InputValueDialogButtonPressed}${NC}' pressed in '${C["RunningCommand"]-}${FUNCNAME[0]}${NC}'."
-                        fi
+                        invalid_dialog_button \
+                            fatal ${InputValueDialogButtonPressed}
                         ;;
                 esac
             done

--- a/.scripts/menu_app_select.sh
+++ b/.scripts/menu_app_select.sh
@@ -246,11 +246,8 @@ menu_app_select() {
             return 1
             ;;
         *)
-            if [[ -n ${DIALOG_BUTTONS[SelectedAppsDialogButtonPressed]-} ]]; then
-                fatal "Unexpected dialog button '${F[C]}${DIALOG_BUTTONS[SelectedAppsDialogButtonPressed]}${NC}' pressed in '${C["RunningCommand"]-}${FUNCNAME[0]}${NC}'."
-            else
-                fatal "Unexpected dialog button value '${SelectedAppsDialogButtonPressed}' pressed in '${C["RunningCommand"]-}${FUNCNAME[0]}${NC}'."
-            fi
+            invalid_dialog_button \
+                fatal ${SelectedAppsDialogButtonPressed}
             ;;
     esac
 }

--- a/.scripts/menu_config.sh
+++ b/.scripts/menu_config.sh
@@ -104,11 +104,8 @@ menu_config() {
                             CANCEL | ESC) # Cancel
                                 ;;
                             *)
-                                if [[ -n ${DIALOG_BUTTONS[YesNoDialogButtonPressed]-} ]]; then
-                                    fatal "Unexpected dialog button '${F[C]}${DIALOG_BUTTONS[YesNoDialogButtonPressed]}' pressed in '${C["RunningCommand"]-}${FUNCNAME[0]}${NC}'."
-                                else
-                                    fatal "Unexpected dialog button value '${YesNoDialogButtonPressed}' pressed in '${C["RunningCommand"]-}${FUNCNAME[0]}${NC}'."
-                                fi
+                                invalid_dialog_button \
+                                    fatal ${YesNoDialogButtonPressed}
                                 ;;
                         esac
                         ;;
@@ -127,11 +124,8 @@ menu_config() {
                 run_script 'menu_exit'
                 ;;
             *)
-                if [[ -n ${DIALOG_BUTTONS[ConfigDialogButtonPressed]-} ]]; then
-                    fatal "Unexpected dialog button '${F[C]}${DIALOG_BUTTONS[ConfigDialogButtonPressed]}' pressed in '${C["RunningCommand"]-}${FUNCNAME[0]}${NC}'."
-                else
-                    fatal "Unexpected dialog button value '${ConfigDialogButtonPressed}' pressed in '${C["RunningCommand"]-}${FUNCNAME[0]}${NC}'."
-                fi
+                invalid_dialog_button \
+                    fatal ${ConfigDialogButtonPressed}
                 ;;
         esac
     done

--- a/.scripts/menu_config_apps.sh
+++ b/.scripts/menu_config_apps.sh
@@ -96,11 +96,8 @@ menu_config_apps() {
                 run_script 'menu_exit'
                 ;;
             *)
-                if [[ -n ${DIALOG_BUTTONS[AppChoiceButtonPressed]-} ]]; then
-                    fatal "Unexpected dialog button '${F[C]}${DIALOG_BUTTONS[AppChoiceButtonPressed]}${NC}' pressed in '${C["RunningCommand"]-}${FUNCNAME[0]}${NC}'."
-                else
-                    fatal "Unexpected dialog button value '${AppChoiceButtonPressed}' pressed in '${C["RunningCommand"]-}${FUNCNAME[0]}${NC}'."
-                fi
+                invalid_dialog_button \
+                    fatal ${AppChoiceButtonPressed}
                 ;;
         esac
     done

--- a/.scripts/menu_config_vars.sh
+++ b/.scripts/menu_config_vars.sh
@@ -232,11 +232,8 @@ menu_config_vars() {
                     return
                     ;;
                 *)
-                    if [[ -n ${DIALOG_BUTTONS[LineDialogButtonPressed]-} ]]; then
-                        fatal "Unexpected dialog button '${F[C]}${DIALOG_BUTTONS[LineDialogButtonPressed]}${NC}' pressed in '${C["RunningCommand"]-}${FUNCNAME[0]}${NC}'."
-                    else
-                        fatal "Unexpected dialog button value '${LineDialogButtonPressed}' pressed in '${C["RunningCommand"]-}${FUNCNAME[0]}${NC}'."
-                    fi
+                    invalid_dialog_button \
+                        fatal ${LineDialogButtonPressed}
                     ;;
             esac
         done

--- a/.scripts/menu_main.sh
+++ b/.scripts/menu_main.sh
@@ -59,11 +59,8 @@ menu_main() {
                 exit 0
                 ;;
             *)
-                if [[ -n ${DIALOG_BUTTONS[MainDialogButtonPressed]-} ]]; then
-                    fatal "Unexpected dialog button '${F[C]}${DIALOG_BUTTONS[MainDialogButtonPressed]}${NC}' pressed in '${C["RunningCommand"]-}${FUNCNAME[0]}${NC}'."
-                else
-                    fatal "Unexpected dialog button value '${MainDialogButtonPressed}' pressed in '${C["RunningCommand"]-}${FUNCNAME[0]}${NC}'."
-                fi
+                invalid_dialog_button \
+                    fatal ${MainDialogButtonPressed}
                 ;;
         esac
     done

--- a/.scripts/menu_options.sh
+++ b/.scripts/menu_options.sh
@@ -57,11 +57,8 @@ menu_options() {
                 run_script 'menu_exit'
                 ;;
             *)
-                if [[ -n ${DIALOG_BUTTONS[DialogButtonPressed]-} ]]; then
-                    fatal "Unexpected dialog button '${F[C]}${DIALOG_BUTTONS[DialogButtonPressed]}${NC}' pressed in '${C["RunningCommand"]-}${FUNCNAME[0]}${NC}'."
-                else
-                    fatal "Unexpected dialog button value '${F[C]}${DialogButtonPressed}' pressed in '${C["RunningCommand"]-}${FUNCNAME[0]}${NC}'."
-                fi
+                invalid_dialog_button \
+                    fatal ${DialogButtonPressed}
                 ;;
         esac
     done

--- a/.scripts/menu_options_display.sh
+++ b/.scripts/menu_options_display.sh
@@ -81,11 +81,8 @@ menu_options_display() {
                 return
                 ;;
             *)
-                if [[ -n ${DIALOG_BUTTONS[DialogButtonPressed]-} ]]; then
-                    fatal "Unexpected dialog button '${F[C]}${DIALOG_BUTTONS[DialogButtonPressed]}${NC}' pressed in '${C["RunningCommand"]-}${FUNCNAME[0]}${NC}'."
-                else
-                    fatal "Unexpected dialog button value '${F[C]}${DialogButtonPressed}' pressed in '${C["RunningCommand"]-}${FUNCNAME[0]}${NC}'."
-                fi
+                invalid_dialog_button \
+                    fatal ${DialogButtonPressed}
                 ;;
         esac
     done

--- a/.scripts/menu_options_package_manager.sh
+++ b/.scripts/menu_options_package_manager.sh
@@ -75,11 +75,8 @@ menu_options_package_manager() {
                 return
                 ;;
             *)
-                if [[ -n ${DIALOG_BUTTONS[DialogButtonPressed]-} ]]; then
-                    fatal "Unexpected dialog button '${F[C]}${DIALOG_BUTTONS[DialogButtonPressed]}${NC}' pressed in '${C["RunningCommand"]-}${FUNCNAME[0]}${NC}'."
-                else
-                    fatal "Unexpected dialog button value '${F[C]}${DialogButtonPressed}' pressed in '${C["RunningCommand"]-}${FUNCNAME[0]}${NC}'."
-                fi
+                invalid_dialog_button \
+                    fatal ${DialogButtonPressed}
                 ;;
         esac
     done

--- a/.scripts/menu_options_theme.sh
+++ b/.scripts/menu_options_theme.sh
@@ -61,11 +61,8 @@ menu_options_theme() {
                 return
                 ;;
             *)
-                if [[ -n ${DIALOG_BUTTONS[DialogButtonPressed]-} ]]; then
-                    fatal "Unexpected dialog button '${F[C]}${DIALOG_BUTTONS[DialogButtonPressed]}${NC}' pressed in '${C["RunningCommand"]-}${FUNCNAME[0]}${NC}'."
-                else
-                    fatal "Unexpected dialog button value '${F[C]}${DialogButtonPressed}' pressed in '${C["RunningCommand"]-}${FUNCNAME[0]}${NC}'."
-                fi
+                invalid_dialog_button \
+                    fatal ${DialogButtonPressed}
                 ;;
         esac
     done

--- a/.scripts/menu_value_prompt.sh
+++ b/.scripts/menu_value_prompt.sh
@@ -538,11 +538,8 @@ menu_value_prompt() {
                 fi
                 ;;
             *)
-                if [[ -n ${DIALOG_BUTTONS[SelectValueDialogButtonPressed]-} ]]; then
-                    fatal "Unexpected dialog button '${F[C]}${DIALOG_BUTTONS[SelectValueDialogButtonPressed]}${NC}' pressed in '${C["RunningCommand"]-}${FUNCNAME[0]}${NC}'."
-                else
-                    fatal "Unexpected dialog button value '${F[C]}${SelectValueDialogButtonPressed}${NC}' pressed in '${C["RunningCommand"]-}${FUNCNAME[0]}${NC}'."
-                fi
+                invalid_dialog_button \
+                    fatal ${SelectValueDialogButtonPressed}
                 ;;
         esac
     done

--- a/.scripts/question_prompt.sh
+++ b/.scripts/question_prompt.sh
@@ -70,11 +70,8 @@ question_prompt() {
                     break
                     ;;
                 *)
-                    if [[ -n ${DIALOG_BUTTONS[YesNoDialogButtonPressed]-} ]]; then
-                        fatal "Unexpected dialog button '${F[C]}${DIALOG_BUTTONS[YesNoDialogButtonPressed]}${NC}' pressed in '${C["RunningCommand"]-}${FUNCNAME[0]}${NC}'."
-                    else
-                        fatal "Unexpected dialog button value '${YesNoDialogButtonPressed}' pressed in '${C["RunningCommand"]-}${FUNCNAME[0]}${NC}'."
-                    fi
+                    invalid_dialog_button \
+                        fatal ${YesNoDialogButtonPressed}
                     ;;
             esac
         done


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Introduce a shared helper for handling unexpected dialog button presses and update menu scripts to use it for consistent error reporting.

Enhancements:
- Add an invalid_dialog_button helper function that standardizes error messages for unexpected dialog button presses across dialogs.
- Refactor multiple menu and prompt scripts to delegate unexpected button handling to the new helper for more consistent and maintainable error handling logic.