### PR TITLE
Add a trace log to fatal errors

### DIFF
--- a/.includes/dialog_functions.sh
+++ b/.includes/dialog_functions.sh
@@ -263,7 +263,5 @@ invalid_dialog_button() {
     local -l NoticeType=${1:-notice}
     local -i DialogButtonNumber=${2}
     local DialogButton="${DIALOG_BUTTONS[DialogButtonNumber]-#${DialogButtonNumber}}"
-    ${NoticeType} \
-        "Error in '${C["File"]}${BASH_SOURCE[1]}${NC}', function '${C["RunningCommand"]}${FUNCNAME[1]}${NC}', line '${C["RunningCommand"]}${BASH_LINENO[0]}${NC}'.\n" \
-        "Unexpected dialog button '${F[C]}${DialogButton}${NC}' pressed."
+    ${NoticeType} "Unexpected dialog button '${F[C]}${DialogButton}${NC}' pressed."
 }


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Add enhanced fatal error logging with stack traces and simplify related dialog error handling.

New Features:
- Capture and log a bash stack trace when fatal errors occur to aid debugging.

Enhancements:
- Introduce a variant fatal_notrace helper for fatal errors without stack traces.
- Simplify dialog button error reporting to focus on the unexpected button pressed.
- Adjust main menu dialog handling to treat a specific invalid dialog button as a fatal error.