### PR TITLE
Change colors slightly in stack trace

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -200,13 +200,11 @@ notice() { timestamped_log true "${C["Notice"]-}[NOTICE]${NC-}" "$@"; }
 warn() { timestamped_log true "${C["Warn"]-}[WARN  ]${NC-}" "$@"; }
 error() { timestamped_log true "${C["Error"]-}[ERROR ]${NC-}" "$@"; }
 fatal_notrace() {
-    timestamped_log true \
-        "${C["Fatal"]-}[FATAL ]${NC}" \
-        "$@"
+    timestamped_log true "${C["Fatal"]-}[FATAL ]${NC}" "$@"
     exit 1
 }
 fatal() {
-    local -a stack=("${C["Fatal"]}Stack trace:${NC}\n")
+    local -a stack=("${C["Error"]}Stack trace:${NC}\n")
     local stack_size=${#FUNCNAME[@]}
     local -i i
     local indent="  "
@@ -218,18 +216,14 @@ fatal() {
         stack+=("${indent}└ ${C["File"]}$src${NC}:${C["RunningCommand"]}$line${NC} (${C["RunningCommand"]}$func${NC})\n")
         indent="${indent}    "
     done
-    #(IFS=$'\n'; echo "${stack[*]}")
 
-    #local ErrorLine="Error in '${C["File"]}${BASH_SOURCE[1]}${NC}', function '${C["RunningCommand"]}${FUNCNAME[1]}${NC}', line '${C["RunningCommand"]}${BASH_LINENO[0]}${NC}'."
-    timestamped_log true \
-        "${C["Fatal"]-}[FATAL ]${NC}" \
+    fatal_notrace \
         "$@" \
         "\n" \
         "\n" \
         "${stack[@]}" \
         "\n" \
-        "${C["Fatal"]}Please let the dev know of this error.${NC}"
-    exit 1
+        "${C["Error"]}Please let the dev know of this error.${NC}"
 }
 
 [[ -f "${SCRIPTPATH}/.includes/global_variables.sh" ]] && source "${SCRIPTPATH}/.includes/global_variables.sh"


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Adjust fatal error handling to tweak stack trace coloring and reuse the non-trace fatal logger.

Enhancements:
- Change stack trace and developer notification messages to use the error color scheme instead of the fatal color scheme for improved visual consistency.
- Refactor fatal error logging to delegate to the existing non-trace fatal helper, reducing duplication.