### PR TITLE
Add argument lists to the stack trace in fatal notices

### DIFF
--- a/.includes/misc_functions.sh
+++ b/.includes/misc_functions.sh
@@ -41,12 +41,33 @@ quote_elements_with_spaces() {
     local Result=''
     # Quote any arguments with spaces in them
     for element in "$@"; do
-        if [[ ${element} == *" "* ]]; then
-            # If the element contains spaces, quote it
+        if [[ -z ${element} || ${element} == *" "* ]]; then
+            # If the element is an empty string or contains spaces, quote it
             Result+="\"${element}\" "
         else
             # Otherwise, add it as is
             Result+="${element} "
+        fi
+    done
+    # Remove any trailing space
+    Result="${Result% }"
+    printf '%s\n' "${Result}"
+}
+
+custom_quote_elements_with_spaces() {
+    local Quote=${1}
+    local Color=${2}
+    shift 2
+
+    local Result=''
+    # Quote any arguments with spaces in them
+    for element in "$@"; do
+        if [[ -z ${element} || ${element} == *" "* ]]; then
+            # If the element is an empty string or contains spaces, quote it
+            Result+="${Quote}${Color}${element}${NC}${Quote}${NC} "
+        else
+            # Otherwise, add it as is
+            Result+="${Color}${element}${NC} "
         fi
     done
     # Remove any trailing space


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Enhance fatal error handling to include detailed stack traces with function arguments and improve argument quoting utilities.

Enhancements:
- Revamp the fatal() handler to build a richer, colorized stack trace that includes function calls, source locations, and their argument lists.
- Extend argument quoting utilities to correctly handle empty strings and support colorized, custom-quoted output for stack trace display.