### PR TITLE
Update `invalid_dialog_button` to take the button number as first argument

### DIFF
--- a/.includes/dialog_functions.sh
+++ b/.includes/dialog_functions.sh
@@ -260,8 +260,8 @@ dialog_success() {
 }
 
 invalid_dialog_button() {
-    local -l NoticeType=${1:-notice}
-    local -i DialogButtonNumber=${2}
+    local -i DialogButtonNumber=${1}
+    local -l NoticeType=${2:-fatal}
     local DialogButton="${DIALOG_BUTTONS[DialogButtonNumber]-#${DialogButtonNumber}}"
     ${NoticeType} "Unexpected dialog button '${F[C]}${DialogButton}${NC}' pressed."
 }

--- a/.scripts/menu_add_app.sh
+++ b/.scripts/menu_add_app.sh
@@ -119,8 +119,7 @@ menu_add_app() {
                         CANCEL | ESC) # Back
                             ;;
                         *)
-                            invalid_dialog_button \
-                                fatal ${YesNoDialogButtonPressed}
+                            invalid_dialog_button ${YesNoDialogButtonPressed}
                             ;;
                     esac
                 fi
@@ -129,8 +128,7 @@ menu_add_app() {
                 return
                 ;;
             *)
-                invalid_dialog_button \
-                    fatal ${InputValueDialogButtonPressed}
+                invalid_dialog_button ${InputValueDialogButtonPressed}
                 ;;
         esac
     done

--- a/.scripts/menu_add_var.sh
+++ b/.scripts/menu_add_var.sh
@@ -371,8 +371,7 @@ menu_add_var() {
                         return
                         ;;
                     *)
-                        invalid_dialog_button \
-                            fatal ${InputValueDialogButtonPressed}
+                        invalid_dialog_button ${InputValueDialogButtonPressed}
                         ;;
                 esac
             done

--- a/.scripts/menu_app_select.sh
+++ b/.scripts/menu_app_select.sh
@@ -246,8 +246,7 @@ menu_app_select() {
             return 1
             ;;
         *)
-            invalid_dialog_button \
-                fatal ${SelectedAppsDialogButtonPressed}
+            invalid_dialog_button ${SelectedAppsDialogButtonPressed}
             ;;
     esac
 }

--- a/.scripts/menu_config.sh
+++ b/.scripts/menu_config.sh
@@ -104,8 +104,7 @@ menu_config() {
                             CANCEL | ESC) # Cancel
                                 ;;
                             *)
-                                invalid_dialog_button \
-                                    fatal ${YesNoDialogButtonPressed}
+                                invalid_dialog_button ${YesNoDialogButtonPressed}
                                 ;;
                         esac
                         ;;
@@ -124,8 +123,7 @@ menu_config() {
                 run_script 'menu_exit'
                 ;;
             *)
-                invalid_dialog_button \
-                    fatal ${ConfigDialogButtonPressed}
+                invalid_dialog_button ${ConfigDialogButtonPressed}
                 ;;
         esac
     done

--- a/.scripts/menu_config_apps.sh
+++ b/.scripts/menu_config_apps.sh
@@ -96,8 +96,7 @@ menu_config_apps() {
                 run_script 'menu_exit'
                 ;;
             *)
-                invalid_dialog_button \
-                    fatal ${AppChoiceButtonPressed}
+                invalid_dialog_button ${AppChoiceButtonPressed}
                 ;;
         esac
     done

--- a/.scripts/menu_config_vars.sh
+++ b/.scripts/menu_config_vars.sh
@@ -232,8 +232,7 @@ menu_config_vars() {
                     return
                     ;;
                 *)
-                    invalid_dialog_button \
-                        fatal ${LineDialogButtonPressed}
+                    invalid_dialog_button ${LineDialogButtonPressed}
                     ;;
             esac
         done

--- a/.scripts/menu_main.sh
+++ b/.scripts/menu_main.sh
@@ -59,8 +59,7 @@ menu_main() {
                 exit 0
                 ;;
             *)
-                invalid_dialog_button \
-                    fatal ${MainDialogButtonPressed}
+                invalid_dialog_button ${MainDialogButtonPressed}
                 ;;
         esac
     done

--- a/.scripts/menu_options.sh
+++ b/.scripts/menu_options.sh
@@ -57,8 +57,7 @@ menu_options() {
                 run_script 'menu_exit'
                 ;;
             *)
-                invalid_dialog_button \
-                    fatal ${DialogButtonPressed}
+                invalid_dialog_button ${DialogButtonPressed}
                 ;;
         esac
     done

--- a/.scripts/menu_options_display.sh
+++ b/.scripts/menu_options_display.sh
@@ -81,8 +81,7 @@ menu_options_display() {
                 return
                 ;;
             *)
-                invalid_dialog_button \
-                    fatal ${DialogButtonPressed}
+                invalid_dialog_button ${DialogButtonPressed}
                 ;;
         esac
     done

--- a/.scripts/menu_options_package_manager.sh
+++ b/.scripts/menu_options_package_manager.sh
@@ -75,8 +75,7 @@ menu_options_package_manager() {
                 return
                 ;;
             *)
-                invalid_dialog_button \
-                    fatal ${DialogButtonPressed}
+                invalid_dialog_button ${DialogButtonPressed}
                 ;;
         esac
     done

--- a/.scripts/menu_options_theme.sh
+++ b/.scripts/menu_options_theme.sh
@@ -61,8 +61,7 @@ menu_options_theme() {
                 return
                 ;;
             *)
-                invalid_dialog_button \
-                    fatal ${DialogButtonPressed}
+                invalid_dialog_button ${DialogButtonPressed}
                 ;;
         esac
     done

--- a/.scripts/menu_value_prompt.sh
+++ b/.scripts/menu_value_prompt.sh
@@ -538,8 +538,7 @@ menu_value_prompt() {
                 fi
                 ;;
             *)
-                invalid_dialog_button \
-                    fatal ${SelectValueDialogButtonPressed}
+                invalid_dialog_button ${SelectValueDialogButtonPressed}
                 ;;
         esac
     done

--- a/.scripts/question_prompt.sh
+++ b/.scripts/question_prompt.sh
@@ -70,8 +70,7 @@ question_prompt() {
                     break
                     ;;
                 *)
-                    invalid_dialog_button \
-                        fatal ${YesNoDialogButtonPressed}
+                    invalid_dialog_button ${YesNoDialogButtonPressed}
                     ;;
             esac
         done


### PR DESCRIPTION
Updates `invalid_dialog_button` to take the button number as the first argument, and the notice type as the second argument. Change the default notice type from `notice` to `fatal`, and remove the explicit `fatal` arguments in the function calls.

# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Standardize dialog error handling by updating invalid_dialog_button usage and defaults across menu scripts.

Enhancements:
- Change invalid_dialog_button to accept the button number as the first argument and the notice type as an optional second argument with a default of fatal.
- Simplify all menu scripts to call invalid_dialog_button with only the button number, relying on the new default notice type.