### PR TITLE
Escape `\n` instead of converting to newlines in stack trace

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -255,9 +255,8 @@ fatal() {
             local StackCmdIndent
             StackCmdIndent="$(printf "  %${FrameNumberLength}s${indent}    " "")"
             local StackCmdFormat="%s\n"
-            # Replaced \n with a literal newline
-            local NL=$'\n'
-            cmdString="${cmdString//\\n/$NL}"
+            # Escape \n so it will print \n instead of a newline
+            cmdString="${cmdString//\\n/\\\\\\\\n}"
             # Indent each line of the string
             cmdString="$(pr -t -o ${#StackCmdIndent} <<< "${cmdString}")"
             # shellcheck disable=SC2059 # Don't use variables in the printf format string.


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Bug Fixes:
- Ensure stack trace command strings display literal `\n` characters rather than rendering them as line breaks.