### PR TITLE
Do a `reset -Q` instead of `clear` in `menu_exit`

### DIFF
--- a/.scripts/menu_exit.sh
+++ b/.scripts/menu_exit.sh
@@ -4,7 +4,7 @@ IFS=$'\n\t'
 
 menu_exit() {
     if run_script 'question_prompt' Y "Do you want to exit ${APPLICATION_NAME}?" "Exit ${APPLICATION_NAME}" "${ASSUMEYES:+Y}"; then
-        clear
+        reset -Q || clear
         info "Exiting ${APPLICATION_NAME}."
         exit 0
     fi


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Enhancements:
- Use a terminal reset command with quiet option in the exit flow to improve terminal state handling when leaving the application.