### PR TITLE
Do a `reset -Q` instead of `clear` in `menu_main`

### DIFF
--- a/.scripts/menu_main.sh
+++ b/.scripts/menu_main.sh
@@ -54,7 +54,7 @@ menu_main() {
                 esac
                 ;;
             CANCEL | ESC)
-                clear
+                reset -Q || clear
                 info "Exiting ${APPLICATION_NAME}."
                 exit 0
                 ;;


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Enhancements:
- Use `reset -Q` with a fallback to `clear` when exiting from the main menu on cancel or escape to better restore the terminal state.