### PR TITLE
Use angle quotes instead of single quotes in the arguments in stack trace

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -242,17 +242,19 @@ fatal() {
         )
         if [[ -n ${cmd-} ]]; then
             local FrameCmdPrefix=""
-            local FrameArgPrefix="${C["TraceFrameLines"]}│${C["TraceCmdArgs"]}"
+            local FrameArgPrefix="${C["TraceFrameLines"]}│"
             local cmdString="${C["TraceCmd"]}${cmd}${NC}"
             local -a cmdArray=()
             cmdArray+=("${FrameCmdPrefix}${cmdString}")
             if [[ CmdArgCount -ne 0 ]]; then
                 local -i j
                 for ((j = CurrentArg + CmdArgCount - 1; j >= CurrentArg; j--)); do
-                    local cmdArgString="${BASH_ARGV[$j]//\\/\\\\\\\\}"
-                    cmdArgString="${NC}'${C["TraceCmdArgs"]}$(strip_ansi_colors "${cmdArgString}")${NC}'"
+                    local cmdArgString="${BASH_ARGV[$j]}"
+                    cmdArgString="$(strip_ansi_colors "${cmdArgString}")"
+                    cmdArgString="${cmdArgString//\\/\\\\\\\\}"
+                    cmdArgString="${NC}«${C["TraceCmdArgs"]}${cmdArgString}${NC}»"
                     while read -r cmdLine; do
-                        cmdArray+=("${FrameArgPrefix}${cmdLine}")
+                        cmdArray+=("${FrameArgPrefix}${C["TraceCmdArgs"]}${cmdLine}")
                     done <<< "${cmdArgString}"
                 done
             fi


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Enhancements:
- Change stack trace argument formatting to use angle quotes and consistent argument prefixes when displaying command-line arguments in error traces.