### PR TITLE
Move the stack trace to before the fatal error

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -125,6 +125,7 @@ declare -Agr C=( # Pre-defined colors
     ["Error"]="${F[R]}"
     ["Fatal"]="${B[R]}${F[W]}"
 
+    ["FatalFooter"]="${NC}"
     ["TraceHeading"]="${F[R]}"
     ["TraceFooter"]="${F[R]}"
     ["TraceFrameNumber"]="${F[R]}"
@@ -216,7 +217,7 @@ fatal_notrace() {
 }
 fatal() {
     local -i thisFuncLine=$((LINENO - 1))
-    local -a Stack=("${C["TraceHeading"]}Stack trace:${NC}\n")
+    local -a Stack=()
     local StackSize=${#FUNCNAME[@]}
     local -i FrameNumberLength
     FrameNumberLength=$((${#StackSize} / 10))
@@ -280,12 +281,15 @@ fatal() {
     done
 
     fatal_notrace \
+        "${C["TraceHeading"]}### BEGIN STACK TRACE ###\n" \
+        "${Stack[@]}" \
+        "${C["TraceFooter"]}### END STACK TRACE ###\n" \
+        "\n" \
         "$@" \
         "\n" \
         "\n" \
-        "${Stack[@]}" \
-        "\n" \
-        "${C["TraceFooter"]}Please let the dev know of this error.${NC}"
+        "${C["FatalFooter"]}Please let the dev know of this error.\n" \
+        "${C["FatalFooter"]}It has been recorded in '${C["File"]}${SCRIPTPATH}/dockstarter.log${C["FatalFooter"]}'.\n"
 }
 
 [[ -f "${SCRIPTPATH}/.includes/global_variables.sh" ]] && source "${SCRIPTPATH}/.includes/global_variables.sh"


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Improve fatal error handling output and ensure failures to create temporary update files are surfaced with a stack trace.

Bug Fixes:
- Handle failures to create the temporary updated .env file by invoking the fatal error handler with a descriptive message and failing command.

Enhancements:
- Reformat fatal error output to show a clearly delimited stack trace before the fatal message.
- Adjust fatal error footer text and coloring, and include information about where the error has been logged.