### PR TITLE
Set up variables for the application log file, and a future fatal log file.

### DIFF
--- a/.scripts/menu_main.sh
+++ b/.scripts/menu_main.sh
@@ -7,6 +7,9 @@ menu_main() {
         return
     fi
 
+    fatal \
+        "Failed to create temporary update '${C["File"]}.env${NC}' file.\n" \
+        "Failing command: ${C["FailingCommand"]}mktemp -t \"${APPLICATION_NAME}.${FUNCNAME[0]}.MKTEMP_ENV_UPDATED.XXXXXXXXXX\""
     local Title="Main Menu"
     local Option_Configure="Configuration"
     local Option_InstallDependencies="Install Dependencies"

--- a/main.sh
+++ b/main.sh
@@ -80,6 +80,9 @@ SCRIPTNAME="${SCRIPTPATH}/$(basename "$(get_scriptname)")"
 readonly SCRIPTNAME
 export SCRIPTNAME
 
+declare -rgx APPLICATION_LOG="${SCRIPTPATH}/${APPLICATION_NAME,,}.log"
+declare -rgx FATAL_LOG="${SCRIPTPATH}/fatal.log"
+
 # Terminal Colors
 declare -Agr B=( # Background
     [B]=$(tput setab 4 2> /dev/null || echo -e "\e[44m") # Blue
@@ -126,7 +129,7 @@ declare -Agr C=( # Pre-defined colors
     ["Fatal"]="${B[R]}${F[W]}"
 
     ["FatalFooter"]="${NC}"
-    ["TraceHeading"]="${F[R]}"
+    ["TraceHeader"]="${F[R]}"
     ["TraceFooter"]="${F[R]}"
     ["TraceFrameNumber"]="${F[R]}"
     ["TraceFrameLines"]="${F[R]}"
@@ -281,7 +284,7 @@ fatal() {
     done
 
     fatal_notrace \
-        "${C["TraceHeading"]}### BEGIN STACK TRACE ###\n" \
+        "${C["TraceHeader"]}### BEGIN STACK TRACE ###\n" \
         "${Stack[@]}" \
         "${C["TraceFooter"]}### END STACK TRACE ###\n" \
         "\n" \
@@ -289,7 +292,7 @@ fatal() {
         "\n" \
         "\n" \
         "${C["FatalFooter"]}Please let the dev know of this error.\n" \
-        "${C["FatalFooter"]}It has been recorded in '${C["File"]}${SCRIPTPATH}/dockstarter.log${C["FatalFooter"]}'.\n"
+        "${C["FatalFooter"]}It has been recorded in '${C["File"]}${APPLICATION_LOG}${C["FatalFooter"]}'.\n"
 }
 
 [[ -f "${SCRIPTPATH}/.includes/global_variables.sh" ]] && source "${SCRIPTPATH}/.includes/global_variables.sh"
@@ -358,11 +361,11 @@ cleanup() {
     local -ri EXIT_CODE=$?
     trap - ERR EXIT SIGABRT SIGALRM SIGHUP SIGINT SIGQUIT SIGTERM
 
-    sudo sh -c "cat ${MKTEMP_LOG:-/dev/null} >> ${SCRIPTPATH}/dockstarter.log" || true
+    sudo sh -c "cat ${MKTEMP_LOG:-/dev/null} >> ${APPLICATION_LOG}" || true
     if [[ -n ${MKTEMP_LOG-} && -f ${MKTEMP_LOG} ]]; then
         sudo rm -f "${MKTEMP_LOG}" &> /dev/null || true
     fi
-    sudo sh -c "echo \"$(tail -1000 "${SCRIPTPATH}/dockstarter.log")\" > ${SCRIPTPATH}/dockstarter.log" || true
+    sudo sh -c "echo \"$(tail -1000 "${APPLICATION_LOG}")\" > ${APPLICATION_LOG}" || true
     if [[ -n ${TEMP_FOLDER-} && -d ${TEMP_FOLDER} ]]; then
         sudo rm -rf "${TEMP_FOLDER?}" &> /dev/null || true
     fi


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Define reusable log file variables and use them across fatal error handling and cleanup while improving error reporting for temporary update file creation.

New Features:
- Introduce APPLICATION_LOG and FATAL_LOG environment variables to centralize application and fatal log file paths.

Enhancements:
- Replace hard-coded application log paths with the APPLICATION_LOG variable in fatal messaging and cleanup routines.
- Rename the trace color key from TraceHeading to TraceHeader for consistent terminology.
- Add a fatal error invocation when creating the temporary updated .env file fails in the main menu script.