### PR TITLE
Remove testing "fatal" notice from `menu_main.sh`

### DIFF
--- a/.scripts/menu_main.sh
+++ b/.scripts/menu_main.sh
@@ -7,9 +7,6 @@ menu_main() {
         return
     fi
 
-    fatal \
-        "Failed to create temporary update '${C["File"]}.env${NC}' file.\n" \
-        "Failing command: ${C["FailingCommand"]}mktemp -t \"${APPLICATION_NAME}.${FUNCNAME[0]}.MKTEMP_ENV_UPDATED.XXXXXXXXXX\""
     local Title="Main Menu"
     local Option_Configure="Configuration"
     local Option_InstallDependencies="Install Dependencies"


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Bug Fixes:
- Prevent the main menu script from failing with a hard fatal error when temporary env file creation messaging is triggered.