### PR TITLE
Update logging routines

### DIFF
--- a/.includes/cmdline.sh
+++ b/.includes/cmdline.sh
@@ -663,10 +663,10 @@ run_command() {
             local UpperCase="${MenuCommandUpperCase["${MenuCommand}"]-}"
             if [[ -z ${DIALOG-} ]]; then
                 fatal_notrace \
-                    "The GUI requires the '${C["Program"]-}dialog${NC-}' command to be installed.\n" \
-                    "'${C["Program"]-}dialog${NC-}' command not found. Run '${C["UserCommand"]-}${APPLICATION_COMMAND} -i${NC-}' to install all dependencies.\n" \
-                    "\n" \
-                    "Unable to start GUI without the '${C["Program"]-}dialog${NC-}' command.\n"
+                    "The GUI requires the '${C["Program"]-}dialog${NC-}' command to be installed." \
+                    "'${C["Program"]-}dialog${NC-}' command not found. Run '${C["UserCommand"]-}${APPLICATION_COMMAND} -i${NC-}' to install all dependencies." \
+                    "" \
+                    "Unable to start GUI without the '${C["Program"]-}dialog${NC-}' command."
             fi
 
             if [[ ${#ParamsArray[@]} -gt 1 ]]; then
@@ -739,10 +739,10 @@ run_command() {
             if [[ ${RequireDialog-} ]]; then
                 if [[ -z ${DIALOG-} ]]; then
                     fatal_notrace \
-                        "The GUI requires the '${C["Program"]-}dialog${NC-}' command to be installed.\n" \
-                        "'${C["Program"]-}dialog${NC-}' command not found. Run '${C["UserCommand"]-}${APPLICATION_COMMAND} -i${NC-}' to install all dependencies.\n" \
-                        "\n" \
-                        "Unable to start GUI without the '${C["Program"]-}dialog${NC-}' command.\n"
+                        "The GUI requires the '${C["Program"]-}dialog${NC-}' command to be installed." \
+                        "'${C["Program"]-}dialog${NC-}' command not found. Run '${C["UserCommand"]-}${APPLICATION_COMMAND} -i${NC-}' to install all dependencies." \
+                        "" \
+                        "Unable to start GUI without the '${C["Program"]-}dialog${NC-}' command."
                 fi
                 declare -gx PROMPT="GUI"
                 run_script "${Script}" "${ParamsArray[@]-}"
@@ -776,10 +776,10 @@ run_command() {
             if [[ ${RequireDialog-} ]]; then
                 if [[ -z ${DIALOG-} ]]; then
                     fatal \
-                        "The GUI requires the '${C["Program"]-}dialog${NC-}' command to be installed.\n" \
-                        "'${C["Program"]-}dialog${NC-}' command not found. Run '${C["UserCommand"]-}${APPLICATION_COMMAND} -i${NC-}' to install all dependencies.\n" \
-                        "\n" \
-                        "Unable to start GUI without the '${C["Program"]-}dialog${NC-}' command.\n"
+                        "The GUI requires the '${C["Program"]-}dialog${NC-}' command to be installed." \
+                        "'${C["Program"]-}dialog${NC-}' command not found. Run '${C["UserCommand"]-}${APPLICATION_COMMAND} -i${NC-}' to install all dependencies." \
+                        "" \
+                        "Unable to start GUI without the '${C["Program"]-}dialog${NC-}' command."
                 fi
                 declare -gx PROMPT="GUI"
                 run_script "${Script}" ""
@@ -805,10 +805,10 @@ run_command() {
                     "No script is defined for command '${C["UserCommand"]-}${Command}${NC-}'."
             fi
             [[ -z ${DIALOG-} ]] && fatal_notrace \
-                "The GUI requires the '${C["Program"]-}dialog${NC-}' command to be installed.\n" \
-                "'${C["Program"]-}dialog${NC-}' command not found. Run '${C["UserCommand"]-}${APPLICATION_COMMAND} -i${NC-}' to install all dependencies.\n" \
-                "\n" \
-                "Unable to start GUI without the '${C["Program"]-}dialog${NC-}' command.\n"
+                "The GUI requires the '${C["Program"]-}dialog${NC-}' command to be installed." \
+                "'${C["Program"]-}dialog${NC-}' command not found. Run '${C["UserCommand"]-}${APPLICATION_COMMAND} -i${NC-}' to install all dependencies." \
+                "" \
+                "Unable to start GUI without the '${C["Program"]-}dialog${NC-}' command."
             declare -gx PROMPT="GUI"
             local AppName="${ParamsArray[0]-}"
             if [[ -z ${AppName} ]]; then
@@ -992,7 +992,7 @@ set_flags() {
                     warn \
                         "The '${C["UserCommand"]-}${APPLICATION_COMMAND} ${flag}${NC-}' option requires the '${C["Program"]-}dialog$}NC}' command to be installed." \
                         "'${C["Program"]-}dialog${NC-}' command not found. Run '${C["UserCommand"]-}${APPLICATION_COMMAND} -i${NC-}' to install all dependencies." \
-                        "\n" \
+                        "" \
                         "Coninuing without '${C["UserCommand"]-}${flag}${NC-}' option."
                 fi
                 ;;

--- a/.includes/ds_functions.sh
+++ b/.includes/ds_functions.sh
@@ -5,7 +5,7 @@ IFS=$'\n\t'
 ds_branch() {
     pushd "${SCRIPTPATH}" &> /dev/null ||
         fatal \
-            "Failed to change directory.\n" \
+            "Failed to change directory." \
             "Failing command: ${C["FailingCommand"]}pushd \"${SCRIPTPATH}\""
     git fetch --quiet &> /dev/null || true
     git symbolic-ref --short HEAD 2> /dev/null || true
@@ -20,7 +20,7 @@ ds_branch_exists() {
 
     pushd "${SCRIPTPATH}" &> /dev/null ||
         fatal \
-            "Failed to change directory.\n" \
+            "Failed to change directory." \
             "Failing command: ${C["FailingCommand"]}pushd \"${SCRIPTPATH}\""
     local -i result=0
     git ls-remote --exit-code --heads origin "${CheckBranch}" &> /dev/null || result=$?
@@ -42,7 +42,7 @@ ds_version() {
 
     pushd "${SCRIPTPATH}" &> /dev/null ||
         fatal \
-            "Failed to change directory.\n" \
+            "Failed to change directory." \
             "Failing command: ${C["FailingCommand"]}pushd \"${SCRIPTPATH}\""
     if [[ -z ${CheckBranch-} ]] || ds_branch_exists "${Branch}"; then
         # Get the current tag. If no tag, use the commit instead.
@@ -61,7 +61,7 @@ ds_version() {
 ds_update_available() {
     pushd "${SCRIPTPATH}" &> /dev/null ||
         fatal \
-            "Failed to change directory.\n" \
+            "Failed to change directory." \
             "Failing command: ${C["FailingCommand"]}pushd \"${SCRIPTPATH}\""
     git fetch --quiet &> /dev/null
     local -i result=0

--- a/.includes/pm_variables.sh
+++ b/.includes/pm_variables.sh
@@ -197,8 +197,8 @@ pm_check_dependencies() {
                     printf \
                         "Dependency '${C["Program"]-}%s${NC-}' is not installed.\n" \
                         "${Dependencies[@]}"
-                )\n" \
-                    "Not all dependencies are installed.\n" \
+                )" \
+                    "Not all dependencies are installed." \
                     "Either install them manually, or run '${C["UserCommand"]-}${APPLICATION_COMMAND} -i${NC-}' to install dependencies."
                 ;;
         esac

--- a/.includes/run_script.sh
+++ b/.includes/run_script.sh
@@ -25,7 +25,7 @@ check_script() {
 
     pm_check_dependencies error "${_dependencies_list[@]}" ||
         fatal \
-            "Fatal error in '${C["RunningCommand"]-}${script_name}${NC-}'.\n"
+            "Fatal error in '${C["RunningCommand"]-}${script_name}${NC-}'."
 }
 
 # Script Runner Function

--- a/.includes/test_functions.sh
+++ b/.includes/test_functions.sh
@@ -78,8 +78,8 @@ run_unit_tests_pipe() {
     )"
     notice \
         "${TableLine}" \
-        "${Heading}\n" \
-        "${TableLine}\n"
+        "${Heading}" \
+        "${TableLine}"
     local -i i
     for ((i = 0; i < ${#Test[@]}; i += 3)); do
         local Input="${Test[i]-}"

--- a/.scripts/app_env_file.sh
+++ b/.scripts/app_env_file.sh
@@ -20,7 +20,7 @@ app_env_file() {
         notice "Renaming '${C["File"]}${OldAppEnvFile}${NC}' to '${C["File"]}${AppEnvFile}${NC}'"
         mv "${OldAppEnvFile}" "${AppEnvFile}" ||
             fatal \
-                "Failed to rename file.\n" \
+                "Failed to rename file." \
                 "Failing command: ${C["FailingCommand"]}mv \"${OldAppEnvFile}\" \"${AppEnvFile}\""
         local SearchString="${APP_ENV_FOLDER_NAME}/${OldAppEnvFilename}"
         if [[ -f ${COMPOSE_OVERRIDE} ]] && ${GREP} -q -F "${SearchString}" "${COMPOSE_OVERRIDE}"; then
@@ -32,7 +32,7 @@ app_env_file() {
             SearchString="${SearchString//./[.]}"
             ${SED} -i "s|${SearchString}|${ReplaceString}|g" "${COMPOSE_OVERRIDE}" ||
                 fatal \
-                    "Failed to edit override file.\n" \
+                    "Failed to edit override file." \
                     "Failing command: ${C["FailingCommand"]}${SED} -i \"s|${SearchString}|${ReplaceString}|g\" \"${COMPOSE_OVERRIDE}\""
         fi
     fi

--- a/.scripts/app_instance_file.sh
+++ b/.scripts/app_instance_file.sh
@@ -19,7 +19,7 @@ app_instance_file() {
     if [[ ! -d ${INSTANCES_FOLDER} ]]; then
         mkdir -p "${INSTANCES_FOLDER}" ||
             fatal \
-                "Failed to create folder '${C["Folder"]}${INSTANCES_FOLDER}${NC}'.\n" \
+                "Failed to create folder '${C["Folder"]}${INSTANCES_FOLDER}${NC}'." \
                 "Failing command: mkdir -p \"${INSTANCES_FOLDER}\""
         run_script 'set_permissions' "${INSTANCES_FOLDER}"
     fi
@@ -44,7 +44,7 @@ app_instance_file() {
                 run_script 'set_permissions' "${Folder}"
                 rm -rf "${Folder}" &> /dev/null ||
                     error \
-                        "Failed to remove directory.\n" \
+                        "Failed to remove directory." \
                         "Failing command: ${C["FailingCommand"]}rm -rf \"${Folder}\""
             fi
         done
@@ -58,7 +58,7 @@ app_instance_file() {
                 run_script 'set_permissions' "${File}"
                 rm -f "${File}" &> /dev/null ||
                     error \
-                        "Failed to remove file.\n" \
+                        "Failed to remove file." \
                         "Failing command: ${C["FailingCommand"]}rm -f \"${File}\""
             fi
         done
@@ -76,7 +76,7 @@ app_instance_file() {
         # Create the folder to place the instance file in
         mkdir -p "${InstanceFolder}" ||
             fatal \
-                "Failed to create folder '${C["Folder"]}${InstanceFolder}${NC}'.\n" \
+                "Failed to create folder '${C["Folder"]}${InstanceFolder}${NC}'." \
                 "Failing command: ${C["FailingCommand"]}mkdir -p \"${InstanceFolder}\""
         run_script 'set_permissions' "${InstanceFolder}"
     fi
@@ -98,7 +98,7 @@ app_instance_file() {
         # Create the folder to place the copy of the template file in
         mkdir -p "${InstanceTemplateFolder}" ||
             fatal \
-                "Failed to create folder '${C["Folder"]}${InstanceTemplateFolder}${NC}'.\n" \
+                "Failed to create folder '${C["Folder"]}${InstanceTemplateFolder}${NC}'." \
                 "Failing command: ${C["FailingCommand"]}mkdir -p \"${InstanceTemplateFolder}\""
         run_script 'set_permissions' "${InstanceTemplateFolder}"
     fi
@@ -106,7 +106,7 @@ app_instance_file() {
     # Copy the original template file
     cp "${TemplateFile}" "${InstanceTemplateFile}" ||
         fatal \
-            "Failed to copy file.\n" \
+            "Failed to copy file." \
             "Failing command: ${C["FailingCommand"]}cp \"${TemplateFile}\" \"${InstanceTemplateFile}\""
     run_script 'set_permissions' "${InstanceTemplateFile}"
 }

--- a/.scripts/app_instance_folder.sh
+++ b/.scripts/app_instance_folder.sh
@@ -26,7 +26,7 @@ app_instance_folder() {
         if [[ ! -d ${InstanceFolder} ]]; then
             mkdir -p "${InstanceFolder}" ||
                 fatal \
-                    "Failed to create folder '${C["Folder"]}${InstanceFolder}${NC}'.\n" \
+                    "Failed to create folder '${C["Folder"]}${InstanceFolder}${NC}'." \
                     "Failing command: ${C["FailingCommand"]}mkdir -p \"${InstanceFolder}\""
             run_script 'set_permissions' "${InstanceFolder}"
         fi

--- a/.scripts/appfolders_create.sh
+++ b/.scripts/appfolders_create.sh
@@ -38,7 +38,7 @@ appfolders_create() {
                     notice "Creating folder '${C["Folder"]}${FOLDER}${NC}'"
                     mkdir -p "${FOLDER}" ||
                         warn \
-                            "Could not create folder '${C["Folder"]}${FOLDER}${NC}'\n" \
+                            "Could not create folder '${C["Folder"]}${FOLDER}${NC}'" \
                             "Failing command: ${C["FailingCommand"]}mkdir -p  \"${FOLDER}\""
                     if [[ -d ${FOLDER} ]]; then
                         run_script 'set_permissions' "${FOLDER}"

--- a/.scripts/appvars_purge.sh
+++ b/.scripts/appvars_purge.sh
@@ -86,21 +86,21 @@ appvars_purge() {
             if [[ -n ${GlobalVarsToRemove[*]-} ]]; then
                 # Remove variables from global .env file
                 notice \
-                    "Removing variables from ${C["File"]}${COMPOSE_ENV}${NC}:\n" \
+                    "Removing variables from ${C["File"]}${COMPOSE_ENV}${NC}:" \
                     "$(printf "${Indent}${C[Var]}%s${NC}\n" "${GlobalLinesToRemove[@]}")"
                 ${SED} -i -E "/^\s*(${GlobalVarsRegex})\s*=/d" "${COMPOSE_ENV}" ||
                     fatal \
-                        "Failed to purge '${C["App"]}${AppName}${NC}' variables.\n" \
+                        "Failed to purge '${C["App"]}${AppName}${NC}' variables." \
                         "Failing command: ${C["FailingCommand"]}${SED} -i -E \"/^\\\*(${GlobalVarsRegex})\\\*/d\" \"${COMPOSE_ENV}\""
             fi
             if [[ -n ${AppEnvVarsToRemove[*]-} ]]; then
                 # Remove variables from .env.app.appname file
                 notice \
-                    "Removing variables from ${C["File"]}${AppEnvFile}${NC}:\n" \
+                    "Removing variables from ${C["File"]}${AppEnvFile}${NC}:" \
                     "$(printf "${Indent}${C[Var]}%s${NC}\n" "${AppEnvLinesToRemove[@]-}")"
                 ${SED} -i -E "/^\s*(${AppEnvVarsRegex})\s*=/d" "${AppEnvFile}" ||
                     fatal \
-                        "Failed to purge '${C["App"]}${AppName}${NC}' variables.\n" \
+                        "Failed to purge '${C["App"]}${AppName}${NC}' variables." \
                         "Failing command: ${C["FailingCommand"]}${SED} -i -E \"/^\\\*(${AppEnvVarsRegex})\\\*/d\" \"${AppEnvFile}\""
             fi
         else

--- a/.scripts/appvars_rename.sh
+++ b/.scripts/appvars_rename.sh
@@ -13,19 +13,19 @@ appvars_rename() {
         notice "Migrating from '${C["App"]}${FROMAPP^^}${NC}' to '${C["App"]}${TOAPP^^}${NC}'."
         docker stop "${FROMAPP,,}" ||
             warn \
-                "Failed to stop '${C["App"]}${FROMAPP,,}${NC}' container.\n" \
+                "Failed to stop '${C["App"]}${FROMAPP,,}${NC}' container." \
                 "Failing command: ${C["FailingCommand"]}docker stop ${FROMAPP,,}"
         notice "Moving config folder."
         local DOCKER_VOLUME_CONFIG
         DOCKER_VOLUME_CONFIG="$(run_script 'env_get' DOCKER_VOLUME_CONFIG)"
         mv "${DOCKER_VOLUME_CONFIG}/${FROMAPP,,}" "${DOCKER_VOLUME_CONFIG}/${TOAPP,,}" ||
             warn \
-                "Failed to move folder.\n" \
+                "Failed to move folder." \
                 "Failing command: ${C["FailingCommand"]}mv \"${DOCKER_VOLUME_CONFIG}/${FROMAPP,,}\" \"${DOCKER_VOLUME_CONFIG}/${TOAPP,,}\""
         notice "Migrating vars."
         ${SED} -i "s/^\s*${FROMAPP^^}__/${TOAPP^^}__/" "${COMPOSE_ENV}" ||
             fatal \
-                "Failed to migrate vars from '${C["App"]}${FROMAPP^^}__${NC}' to '${C["App"]}${TOAPP^^}__${NC}'\n" \
+                "Failed to migrate vars from '${C["App"]}${FROMAPP^^}__${NC}' to '${C["App"]}${TOAPP^^}__${NC}'" \
                 "Failing command: ${C["FailingCommand"]}${SED} -i \"s/^\\s*${FROMAPP^^}__/${TOAPP^^}__/\" \"${COMPOSE_ENV}\""
         run_script 'appvars_create' "${TOAPP^^}"
         notice "Completed migrating from '${C["App"]}${FROMAPP^^}${NC}' to '${C["App"]}${TOAPP^^}${NC}'. Run '${C["UserCommand"]}${APPLICATION_COMMAND} -c${NC}' to create the new container."

--- a/.scripts/config_create.sh
+++ b/.scripts/config_create.sh
@@ -11,7 +11,7 @@ config_create() {
             notice "Renaming '${C["File"]-}${OldIniFile}${NC-}' to '${C["File"]-}${APPLICATION_INI_FILE}${NC-}'."
             mv "${OldIniFile}" "${APPLICATION_INI_FILE}" ||
                 fatal \
-                    "Failed to rename old config file.\n" \
+                    "Failed to rename old config file." \
                     "Failing command: ${C["FailingCommand"]}mv \"${OldIniFile}\" \"${APPLICATION_INI_FILE}\""
 
         else
@@ -20,7 +20,7 @@ config_create() {
             notice "Copying '${C["File"]-}${DefaultIniFile}${NC-}' to '${C["File"]-}${APPLICATION_INI_FILE}${NC-}'."
             cp "${DefaultIniFile}" "${APPLICATION_INI_FILE}" ||
                 fatal \
-                    "Failed to copy default config file.\n" \
+                    "Failed to copy default config file." \
                     "Failing command: ${C["FailingCommand"]}cp \"${DefaultIniFile}\" \"${APPLICATION_INI_FILE}\""
 
         fi

--- a/.scripts/config_package_manager.sh
+++ b/.scripts/config_package_manager.sh
@@ -26,11 +26,11 @@ config_package_manager() {
         if [[ -n ${PackageManager} ]]; then
             if ! run_script 'package_manager_is_valid' "${PackageManager}"; then
                 error \
-                    "Selected package manager '${C["UserCommand"]}${PackageManager}${NC}' unknown.\n" \
-                    "\n" \
-                    "Known package managers are:\n" \
-                    "\n" \
-                    "$(run_script 'package_manager_table')\n"
+                    "Selected package manager '${C["UserCommand"]}${PackageManager}${NC}' unknown." \
+                    "" \
+                    "Known package managers are:" \
+                    "" \
+                    "$(run_script 'package_manager_table')"
                 return 1
             fi
             run_script 'config_set' PackageManager "${PackageManager}"
@@ -42,11 +42,11 @@ config_package_manager() {
 
         if [[ -n ${PackageManager} ]] && ! run_script 'package_manager_exists' "${PackageManager}"; then
             warn \
-                "Selected package manager '${C["UserCommand"]}${PackageManager}${NC}' not detected.\n" \
-                "\n" \
-                "Detected package managers are:\n" \
-                "\n" \
-                "$(run_script 'package_manager_existing_table')\n"
+                "Selected package manager '${C["UserCommand"]}${PackageManager}${NC}' not detected." \
+                "" \
+                "Detected package managers are:" \
+                "" \
+                "$(run_script 'package_manager_existing_table')"
         fi
     fi
 

--- a/.scripts/config_set.sh
+++ b/.scripts/config_set.sh
@@ -26,7 +26,7 @@ config_set() {
     ${SED} -i "/^\s*${SET_VAR}\s*=/d" "${VAR_FILE}" || true
     echo "${SET_VAR}=${NEW_VAL}" >> "${VAR_FILE}" ||
         fatal \
-            "Failed to set ${C["Var"]}${SET_VAR}=${NEW_VAL}${NC}\n" \
+            "Failed to set ${C["Var"]}${SET_VAR}=${NEW_VAL}${NC}" \
             "Failing command: ${C["FailingCommand"]} \"echo ${SET_VAR}=${NEW_VAL}\" >> \"${VAR_FILE}\""
 }
 

--- a/.scripts/config_theme.sh
+++ b/.scripts/config_theme.sh
@@ -151,7 +151,7 @@ config_theme() {
 
     echo "${DialogOptions}" > "${DIALOG_OPTIONS_FILE}" ||
         fatal \
-            "Failed to save dialog options file.\n" \
+            "Failed to save dialog options file." \
             "Failing command: ${C["FailingCommand"]}echo \"${DialogOptions}\" > \"${DIALOG_OPTIONS_FILE}\""
     run_script 'set_permissions' "${DIALOG_OPTIONS_FILE}"
 

--- a/.scripts/docker_compose.sh
+++ b/.scripts/docker_compose.sh
@@ -125,7 +125,7 @@ docker_compose() {
                         eval "${Command}" || result=$?
                         if [[ ${result} != 0 ]]; then
                             error \
-                                "Failed to run compose.\n" \
+                                "Failed to run compose." \
                                 "Failing command: ${C["FailingCommand"]}${Command}"
                             break
                         fi
@@ -146,7 +146,7 @@ docker_compose() {
                     eval "${Command}" || result=$?
                     if [[ ${result} != 0 ]]; then
                         error \
-                            "Failed to run compose.\n" \
+                            "Failed to run compose." \
                             "Failing command: ${C["FailingCommand"]}${Command}"
                         break
                     fi
@@ -171,7 +171,7 @@ test_docker_compose() {
     run_script 'yml_merge'
     eval "docker compose --project-directory ${COMPOSE_FOLDER}/ config" ||
         fatal \
-            "Failed to display compose config.\n" \
+            "Failed to display compose config." \
             "Failing command: ${C["FailingCommand"]}docker compose --project-directory ${COMPOSE_FOLDER}/ config"
     run_script 'docker_compose'
 }

--- a/.scripts/docker_prune.sh
+++ b/.scripts/docker_prune.sh
@@ -16,7 +16,7 @@ docker_prune() {
                 notice "Running: ${C["RunningCommand"]}${Command}${NC}"
                 eval "${Command}" ||
                     error \
-                        "Failed to remove unused docker resources.\n" \
+                        "Failed to remove unused docker resources." \
                         "Failing command: ${C["FailingCommand"]}${Command}"
             } |& dialog_pipe "${DC["TitleSuccess"]-}${Title}" "${YesNotice}${DC["NC"]-}\n${DC["CommandLine"]-} ${Command}"
         else
@@ -24,7 +24,7 @@ docker_prune() {
             notice "Running: ${C["RunningCommand"]}${Command}${NC}"
             eval "${Command}" ||
                 error \
-                    "Failed to remove unused docker resources.\n" \
+                    "Failed to remove unused docker resources." \
                     "Failing command: ${C["FailingCommand"]}${Command}"
         fi
     else

--- a/.scripts/enable_docker_service.sh
+++ b/.scripts/enable_docker_service.sh
@@ -18,12 +18,12 @@ enable_docker_service() {
         info "Enabling docker service."
         eval "sudo ${DOCKER_SERVICE_ENABLE}" &> /dev/null ||
             fatal \
-                "Failed to enable docker service.\n" \
+                "Failed to enable docker service." \
                 "Failing command: ${C["FailingCommand"]}${DOCKER_SERVICE_ENABLE}"
         info "Starting docker service."
         eval "sudo ${DOCKER_SERVICE_START}" &> /dev/null ||
             fatal \
-                "Failed to start docker service.\n" \
+                "Failed to start docker service." \
                 "Failing command: ${C["FailingCommand"]}${DOCKER_SERVICE_START}"
     fi
 }

--- a/.scripts/env_backup.sh
+++ b/.scripts/env_backup.sh
@@ -38,30 +38,30 @@ env_backup() {
     info "Copying '${C["File"]}.env${NC}' file to '${C["Folder"]}${BACKUP_FOLDER}/.env${NC}'"
     mkdir -p "${BACKUP_FOLDER}" ||
         fatal \
-            "Failed to make directory.\n" \
+            "Failed to make directory." \
             "Failing command: ${C["FailingCommand"]}mkdir -p \"${BACKUP_FOLDER}\""
     cp "${COMPOSE_ENV}" "${BACKUP_FOLDER}/" ||
         fatal \
-            "Failed to copy backup.\n" \
+            "Failed to copy backup." \
             "Failing command: ${C["FailingCommand"]}cp \"${COMPOSE_ENV}\"/.env.app.* \"${BACKUP_FOLDER}/\""
     if [[ -n $(${FIND} "${COMPOSE_FOLDER}" -type f -maxdepth 1 -name ".env.app.*" 2> /dev/null) ]]; then
         cp "${COMPOSE_FOLDER}"/.env.app.* "${BACKUP_FOLDER}/" ||
             fatal \
-                "Failed to copy backup.\n" \
+                "Failed to copy backup." \
                 "Failing command: ${C["FailingCommand"]}cp \"${COMPOSE_FOLDER}\"/.env.app.* \"${BACKUP_FOLDER}/\""
     fi
     if [[ -d ${APP_ENV_FOLDER} ]]; then
         info "Copying appplication env folder to '${C["Folder"]}${BACKUP_FOLDER}/${APP_ENV_FOLDER_NAME}${NC}'"
         cp -r "${APP_ENV_FOLDER}" "${BACKUP_FOLDER}/" ||
             fatal \
-                "Failed to copy backup.\n" \
+                "Failed to copy backup." \
                 "Failing command: ${C["FailingCommand"]}cp -r \"${APP_ENV_FOLDER}\" \"${BACKUP_FOLDER}/\""
     fi
     if [[ -f ${COMPOSE_OVERRIDE} ]]; then
         info "Copying override file to '${C["Folder"]}${BACKUP_FOLDER}/${COMPOSE_OVERRIDE_NAME}${NC}'"
         cp "${COMPOSE_OVERRIDE}" "${BACKUP_FOLDER}/" ||
             fatal \
-                "Failed to copy backup.\n" \
+                "Failed to copy backup." \
                 "Failing command: ${C["FailingCommand"]}cp \"${COMPOSE_OVERRIDE}\" \"${BACKUP_FOLDER}/\""
     fi
 
@@ -78,7 +78,7 @@ env_backup() {
         info "Removing old backup location."
         rm -rf "${DOCKER_VOLUME_CONFIG}/.env.backups" ||
             fatal \
-                "Failed to remove directory.\n" \
+                "Failed to remove directory." \
                 "Failing command: ${C["FailingCommand"]}rm -rf \"${DOCKER_VOLUME_CONFIG}/.env.backups\""
     fi
 }

--- a/.scripts/env_copy.sh
+++ b/.scripts/env_copy.sh
@@ -48,7 +48,7 @@ env_copy() {
     fi
     printf '\n%s\n' "${NEW_VAR_LINE}" >> "${TO_VAR_FILE}" ||
         fatal \
-            "Failed to add '${C["Var"]}${NEW_VAR_LINE}${NC}' in '${C["File"]}${TO_VAR_FILE}${NC}'\n" \
+            "Failed to add '${C["Var"]}${NEW_VAR_LINE}${NC}' in '${C["File"]}${TO_VAR_FILE}${NC}'" \
             "Failing command: ${C["FailingCommand"]}printf '\n%s\n' \"${NEW_VAR_LINE}\" >> \"${TO_VAR_FILE}\""
 }
 

--- a/.scripts/env_create.sh
+++ b/.scripts/env_create.sh
@@ -28,7 +28,7 @@ env_create() {
         warn "${F[C]}${COMPOSE_ENV}${NC} not found. Copying example template."
         cp "${COMPOSE_ENV_DEFAULT_FILE}" "${COMPOSE_ENV}" ||
             fatal \
-                "Failed to copy file.\n" \
+                "Failed to copy file." \
                 "Failing command: ${C["FailingCommand"]}cp \"${COMPOSE_ENV_DEFAULT_FILE}\" \"${COMPOSE_ENV}\""
         run_script 'set_permissions' "${COMPOSE_ENV}"
         run_script 'env_sanitize'

--- a/.scripts/env_delete.sh
+++ b/.scripts/env_delete.sh
@@ -31,7 +31,7 @@ env_delete() {
     notice "   ${C["Var"]}${DELETE_VAR}${NC}"
     ${SED} -i "/^\s*${DELETE_VAR}\s*=/d" "${VAR_FILE}" ||
         fatal \
-            "Failed to remove var '${C["Var"]}${DELETE_VAR}${NC}' in '${C["File"]}${VAR_FILE}${NC}'\n" \
+            "Failed to remove var '${C["Var"]}${DELETE_VAR}${NC}' in '${C["File"]}${VAR_FILE}${NC}'" \
             "Failing command: ${C["FailingCommand"]}${SED} -i \"/^\\s*${DELETE_VAR}\\s*=/d\" \"${VAR_FILE}\""
 }
 

--- a/.scripts/env_get.sh
+++ b/.scripts/env_get.sh
@@ -62,7 +62,7 @@ test_env_get() {
     )
     VarFile=$(mktemp -t "${APPLICATION_NAME}.${FUNCNAME[0]}.VarFile.XXXXXXXXXX") ||
         fatal \
-            "Failed to create temporary file.\n" \
+            "Failed to create temporary file." \
             "Failing command: ${C["FailingCommand"]}mktemp -t \"${APPLICATION_NAME}.${FUNCNAME[0]}.VarFile.XXXXXXXXXX\""
     {
         printf '### %s\n' \
@@ -87,7 +87,7 @@ test_env_get() {
 
     rm -f "${VarFile}" ||
         warn \
-            "Failed to remove temporary file.\n" \
+            "Failed to remove temporary file." \
             "Failing command: ${C["FailingCommand"]}rm -f \"${VarFile}\""
 
     return ${result}

--- a/.scripts/env_get_line.sh
+++ b/.scripts/env_get_line.sh
@@ -58,7 +58,7 @@ test_env_get_line() {
     )
     VarFile=$(mktemp -t "${APPLICATION_NAME}.${FUNCNAME[0]}.VarFile.XXXXXXXXXX") ||
         fatal \
-            "Failed to create temporary file.\n" \
+            "Failed to create temporary file." \
             "Failing command: ${C["FailingCommand"]}mktemp -t \"${APPLICATION_NAME}.${FUNCNAME[0]}.VarFile.XXXXXXXXXX\""
     {
         printf '### %s\n' \
@@ -83,7 +83,7 @@ test_env_get_line() {
 
     rm -f "${VarFile}" ||
         warn \
-            "Failed to remove temporary file.\n" \
+            "Failed to remove temporary file." \
             "Failing command: ${C["FailingCommand"]}rm -f \"${VarFile}\""
 
     return ${result}

--- a/.scripts/env_get_literal.sh
+++ b/.scripts/env_get_literal.sh
@@ -58,7 +58,7 @@ test_env_get_literal() {
     )
     VarFile=$(mktemp -t "${APPLICATION_NAME}.${FUNCNAME[0]}.VarFile.XXXXXXXXXX") ||
         fatal \
-            "Failed to create temporary file.\n" \
+            "Failed to create temporary file." \
             "Failing command: ${C["FailingCommand"]}mktemp -t \"${APPLICATION_NAME}.${FUNCNAME[0]}.VarFile.XXXXXXXXXX\""
     {
         printf '### %s\n' \
@@ -83,7 +83,7 @@ test_env_get_literal() {
 
     rm -f "${VarFile}" ||
         warn \
-            "Failed to remove temporary file.\n" \
+            "Failed to remove temporary file." \
             "Failing command: ${C["FailingCommand"]}rm -f \"${VarFile}\""
 
     return ${result}

--- a/.scripts/env_merge_newonly.sh
+++ b/.scripts/env_merge_newonly.sh
@@ -33,7 +33,7 @@ env_merge_newonly() {
                 run_script 'env_get_line_regex' "${VarsToAddRegex}" "${MergeFromFile}"
             )
             notice \
-                "Adding variables to ${C["File"]}${MergeToFile}${NC}:\n" \
+                "Adding variables to ${C["File"]}${MergeToFile}${NC}:" \
                 "$(printf "   ${C[Var]}%s${NC}\n" "${MergeLines[@]}")"
             {
                 printf '\n'

--- a/.scripts/env_rename.sh
+++ b/.scripts/env_rename.sh
@@ -48,11 +48,11 @@ env_rename() {
     fi
     printf '\n%s\n' "${NEW_VAR_LINE}" >> "${TO_VAR_FILE}" ||
         fatal \
-            "Failed to add '${C["Var"]}${NEW_VAR_LINE}${NC}' in '${C["File"]}${TO_VAR_FILE}${NC}'\n" \
+            "Failed to add '${C["Var"]}${NEW_VAR_LINE}${NC}' in '${C["File"]}${TO_VAR_FILE}${NC}'" \
             "Failing command: ${C["FailingCommand"]}printf '\n%s\n' \"${NEW_VAR_LINE}\" >> \"${TO_VAR_FILE}\""
     ${SED} -i "/^\s*${FROM_VAR}\s*=/d" "${FROM_VAR_FILE}" ||
         fatal \
-            "Failed to remove var '${C["Var"]}${FROM_VAR}${NC}' in '${C["File"]}${FROM_VAR_FILE}${NC}'\n" \
+            "Failed to remove var '${C["Var"]}${FROM_VAR}${NC}' in '${C["File"]}${FROM_VAR_FILE}${NC}'" \
             "Failing command: ${C["FailingCommand"]}${SED} -i \"/^\\s*${FROM_VAR}\\s*=/d\" \"${FROM_VAR_FILE}\""
 }
 

--- a/.scripts/env_set.sh
+++ b/.scripts/env_set.sh
@@ -38,7 +38,7 @@ env_set() {
     ${SED} -i "/^\s*${SET_VAR}\s*=/d" "${VAR_FILE}" || true
     echo "${SET_VAR}=${NEW_VAL}" >> "${VAR_FILE}" ||
         fatal \
-            "Failed to set ${C["Var"]}${SET_VAR}=${NEW_VAL}${NC}\n" \
+            "Failed to set ${C["Var"]}${SET_VAR}=${NEW_VAL}${NC}" \
             "Failing command: ${C["FailingCommand"]} echo \"${SET_VAR}=${NEW_VAL}\" >> \"${VAR_FILE}\""
 }
 

--- a/.scripts/env_set_literal.sh
+++ b/.scripts/env_set_literal.sh
@@ -34,7 +34,7 @@ env_set_literal() {
     ${SED} -i "/^\s*${SET_VAR}\s*=/d" "${VAR_FILE}" || true
     echo "${SET_VAR}=${NEW_VAL}" >> "${VAR_FILE}" ||
         fatal \
-            "Failed to set ${C["Var"]}${SET_VAR}=${NEW_VAL}${NC}\n" \
+            "Failed to set ${C["Var"]}${SET_VAR}=${NEW_VAL}${NC}" \
             "Failing command: ${C["FailingCommand"]} echo \"${SET_VAR}=${NEW_VAL}\" >> \"${VAR_FILE}\""
 }
 

--- a/.scripts/env_update.sh
+++ b/.scripts/env_update.sh
@@ -22,7 +22,7 @@ env_update() {
             notice "Deleting '${C["File"]}${AppEnvFile}${NC}'."
             rm -f "${AppEnvFile}" ||
                 warn \
-                    "Failed to remove '${C["File"]}${AppEnvFile}${NC}'.\n" \
+                    "Failed to remove '${C["File"]}${AppEnvFile}${NC}'." \
                     "Failing command: ${C["FailingCommand"]}rm -f \"${AppEnvFile}\""
         fi
     done
@@ -59,24 +59,24 @@ env_update() {
         fi
         rm -f "${ENV_LINES_FILE}" ||
             warn \
-                "Failed to remove temporary '${C["File"]}.env${NC}' update file.\n" \
+                "Failed to remove temporary '${C["File"]}.env${NC}' update file." \
                 "Failing command: ${C["FailingCommand"]}rm -f \"${ENV_LINES_FILE}\""
 
         local MKTEMP_ENV_UPDATED
         MKTEMP_ENV_UPDATED=$(mktemp -t "${APPLICATION_NAME}.${FUNCNAME[0]}.MKTEMP_ENV_UPDATED.XXXXXXXXXX") ||
             fatal \
-                "Failed to create temporary update '${C["File"]}.env${NC}' file.\n" \
+                "Failed to create temporary update '${C["File"]}.env${NC}' file." \
                 "Failing command: ${C["FailingCommand"]}mktemp -t \"${APPLICATION_NAME}.${FUNCNAME[0]}.MKTEMP_ENV_UPDATED.XXXXXXXXXX\""
         printf '%s\n' "${UPDATED_ENV_LINES[@]}" > "${MKTEMP_ENV_UPDATED}" ||
             fatal \
                 "Failed to write temporary '${C["File"]}.env${NC}' update file."
         cp -f "${MKTEMP_ENV_UPDATED}" "${COMPOSE_ENV}" ||
             fatal \
-                "Failed to copy file.\n" \
+                "Failed to copy file." \
                 "Failing command: ${C["FailingCommand"]}cp -f \"${MKTEMP_ENV_UPDATED}\" \"${COMPOSE_ENV}\""
         rm -f "${MKTEMP_ENV_UPDATED}" ||
             warn \
-                "Failed to remove temporary ${C["File"]}.env${NC} update file.\n" \
+                "Failed to remove temporary ${C["File"]}.env${NC} update file." \
                 "Failing command: ${C["FailingCommand"]}rm -f \"${MKTEMP_ENV_UPDATED}\""
         run_script 'set_permissions' "${COMPOSE_ENV}"
         #run_script 'unset_needs_env_update' "${COMPOSE_ENV}"
@@ -106,18 +106,18 @@ env_update() {
                 local MKTEMP_APP_ENV_UPDATED
                 MKTEMP_APP_ENV_UPDATED=$(mktemp -t "${APPLICATION_NAME}.${FUNCNAME[0]}.MKTEMP_APP_ENV_UPDATED.XXXXXXXXXX") ||
                     fatal \
-                        "Failed to create temporary update '${C["File"]}.env.app.${appname}${NC}' file.\n" \
+                        "Failed to create temporary update '${C["File"]}.env.app.${appname}${NC}' file." \
                         "Failing command: ${C["FailingCommand"]}mktemp -t \"${APPLICATION_NAME}.${FUNCNAME[0]}.MKTEMP_APP_ENV_UPDATED.XXXXXXXXXX\"${NC}"
                 printf '%s\n' "${UPDATED_APP_ENV_LINES[@]}" > "${MKTEMP_APP_ENV_UPDATED}" ||
                     fatal \
                         "Failed to write temporary '${C["File"]}.env.app.${appname}${NC}' update file."
                 cp -f "${MKTEMP_APP_ENV_UPDATED}" "${APP_ENV_FILE}" ||
                     fatal \
-                        "Failed to copy file.\n" \
+                        "Failed to copy file." \
                         "Failing command: ${C["FailingCommand"]}cp -f \"${MKTEMP_APP_ENV_UPDATED}\" \"${APP_ENV_FILE}\""
                 rm -f "${MKTEMP_APP_ENV_UPDATED}" ||
                     warn \
-                        "Failed to remove temporary '${C["File"]}.env.app.${appname}${NC}' update file.\n" \
+                        "Failed to remove temporary '${C["File"]}.env.app.${appname}${NC}' update file." \
                         "Failing command: ${C["FailingCommand"]}rm -f \"${MKTEMP_APP_ENV_UPDATED}\""
                 run_script 'set_permissions' "${APP_ENV_FILE}"
                 #run_script 'unset_needs_env_update' "${APP_ENV_FILE}"

--- a/.scripts/get_docker.sh
+++ b/.scripts/get_docker.sh
@@ -27,7 +27,7 @@ command_get_docker() {
     #shellcheck disable=SC2034 # (warning): MKTEMP_GET_DOCKER appears unused. Verify use (or export if used externally).
     MKTEMP_GET_DOCKER=$(mktemp -t "${APPLICATION_NAME}.${FUNCNAME[0]}.MKTEMP_GET_DOCKER.XXXXXXXXXX") ||
         fatal \
-            "Failed to create temporary docker install script.\n" \
+            "Failed to create temporary docker install script." \
             "Failing command: ${C["FailingCommand"]}mktemp -t \"${APPLICATION_NAME}.${FUNCNAME[0]}.MKTEMP_GET_DOCKER.XXXXXXXXXX\""
     info "Downloading docker install script."
     #shellcheck disable=SC2016 # (info): Expressions don't expand in single quotes, use double quotes for that.
@@ -35,7 +35,7 @@ command_get_docker() {
     notice "Running: ${C["RunningCommand"]}${COMMAND}${NC}"
     eval "${COMMAND}" ||
         fatal \
-            "Failed to get docker install script.\n" \
+            "Failed to get docker install script." \
             "Failing command: ${C["FailingCommand"]}${COMMAND}"
     info "Running docker install script."
     #shellcheck disable=SC2016 # (info): Expressions don't expand in single quotes, use double quotes for that.
@@ -43,7 +43,7 @@ command_get_docker() {
     notice "Running: ${C["RunningCommand"]}${COMMAND}${NC}"
     eval "${COMMAND}" ||
         fatal \
-            "Failed to install docker.\n" \
+            "Failed to install docker." \
             "Failing command: ${C["FailingCommand"]}${COMMAND}"
     #shellcheck disable=SC2016 # (info): Expressions don't expand in single quotes, use double quotes for that.
     COMMAND='rm -f "${MKTEMP_GET_DOCKER}"'
@@ -56,10 +56,10 @@ test_get_docker() {
     run_script 'get_docker'
     docker --version ||
         fatal \
-            "Failed to determine docker version.\n" \
+            "Failed to determine docker version." \
             "Failing command: ${C["FailingCommand"]}docker --version"
     docker compose version ||
         fatal \
-            "Failed to determine docker compose version.\n" \
+            "Failed to determine docker compose version." \
             "Failing command: ${C["FailingCommand"]}docker compose version"
 }

--- a/.scripts/menu_config_vars.sh
+++ b/.scripts/menu_config_vars.sh
@@ -21,13 +21,13 @@ menu_config_vars() {
         if [[ -n ${CurrentGlobalEnvFile-} ]]; then
             rm -f "${CurrentGlobalEnvFile}" ||
                 warn \
-                    "Failed to remove temporary '${C["File"]}.env${NC}' file.\n" \
+                    "Failed to remove temporary '${C["File"]}.env${NC}' file." \
                     "Failing command: ${C["FailingCommand"]}rm -f \"${CurrentGlobalEnvFile}\""
         fi
         if [[ -n ${CurrentAppEnvFile-} ]]; then
             rm -f "${CurrentAppEnvFile}" ||
                 warn \
-                    "Failed to remove temporary '${C["File"]}.env.app.${appname}${NC}' file.\n" \
+                    "Failed to remove temporary '${C["File"]}.env.app.${appname}${NC}' file." \
                     "Failing command: ${C["FailingCommand"]}rm -f \"${CurrentAppEnvFile}\""
         fi
         local DefaultGlobalEnvFile=''
@@ -240,13 +240,13 @@ menu_config_vars() {
     if [[ -n ${CurrentGlobalEnvFile-} ]]; then
         rm -f "${CurrentGlobalEnvFile}" ||
             warn \
-                "Failed to remove temporary '${C["File"]}.env${NC}' file.\n" \
+                "Failed to remove temporary '${C["File"]}.env${NC}' file." \
                 "Failing command: ${C["FailingCommand"]}rm -f \"${CurrentGlobalEnvFile}\""
     fi
     if [[ -n ${CurrentAppEnvFile-} ]]; then
         rm -f "${CurrentAppEnvFile}" ||
             warn \
-                "Failed to remove temporary '${C["File"]}.env.app.${appname}${NC}' file.\n" \
+                "Failed to remove temporary '${C["File"]}.env.app.${appname}${NC}' file." \
                 "Failing command: ${C["FailingCommand"]}rm -f \"${CurrentAppEnvFile}\""
     fi
 }

--- a/.scripts/override_backup.sh
+++ b/.scripts/override_backup.sh
@@ -19,11 +19,11 @@ override_backup() {
         info "Copying '${C["File"]}docker-compose.override.yml${NC}' file to '${C["File"]}${DOCKER_VOLUME_CONFIG}/.compose.backups/docker-compose.override.yml.${BACKUPTIME}${NC}'"
         mkdir -p "${DOCKER_VOLUME_CONFIG}/.compose.backups" ||
             fatal \
-                "Failed to make directory.\n" \
+                "Failed to make directory." \
                 "Failing command: ${C["FailingCommand"]}mkdir -p \"${DOCKER_VOLUME_CONFIG}/.compose.backups\""
         cp "${COMPOSE_FOLDER}/docker-compose.override.yml" "${DOCKER_VOLUME_CONFIG}/.compose.backups/docker-compose.override.yml.${BACKUPTIME}" ||
             fatal \
-                "Failed to copy file.\n" \
+                "Failed to copy file." \
                 "Failing command: ${C["FailingCommand"]}cp \"${COMPOSE_FOLDER}/docker-compose.override.yml\" \"${DOCKER_VOLUME_CONFIG}/.compose.backups/docker-compose.override.yml.${BACKUPTIME}\""
         run_script 'set_permissions' "${DOCKER_VOLUME_CONFIG}/.compose.backups"
         info "Removing old '${C["File"]}docker-compose.override.yml${NC}' backups."

--- a/.scripts/override_var_rename.sh
+++ b/.scripts/override_var_rename.sh
@@ -20,7 +20,7 @@ override_var_rename() {
         # Replace $FromVar or ${FromVar followed by a word break to $ToVar or ${ToVar
         ${SED} -i -E "s/([$]\{?)${FromVar}\b/\1${ToVar}/g" "${COMPOSE_OVERRIDE}" ||
             fatal \
-                "Failed to rename variable in override file.\n" \
+                "Failed to rename variable in override file." \
                 "Failing command: ${C["FailingCommand"]} ${SED} -i -E \"s/([$]\\{?)${FromVar}\\\\b/\\\\1${ToVar}/g\" \"${COMPOSE_OVERRIDE}\""
 
     fi

--- a/.scripts/package_manager_init.sh
+++ b/.scripts/package_manager_init.sh
@@ -18,21 +18,21 @@ package_manager_init() {
         if ! run_script 'package_manager_is_valid' "${PreferredPackageManager}"; then
             NoticeType="warn"
             ${NoticeType} \
-                "Selected package manager '${C["UserCommand"]}${PreferredPackageManager}${NC}' unknown.\n" \
-                "\n" \
-                "Known package managers are:\n" \
-                "\n" \
-                "$(run_script 'package_manager_table')\n" \
+                "Selected package manager '${C["UserCommand"]}${PreferredPackageManager}${NC}' unknown." \
+                "" \
+                "Known package managers are:" \
+                "" \
+                "$(run_script 'package_manager_table')" \
                 " "
         elif ! run_script 'package_manager_exists' "${PreferredPackageManager}"; then
             NoticeType="warn"
             ${NoticeType} \
-                "Selected package manager '${C["UserCommand"]}${PreferredPackageManager}${NC}' not detected.\n" \
-                "\n" \
-                "Detected package managers are:\n" \
-                "\n" \
-                "$(run_script 'package_manager_existing_table')\n" \
-                " "
+                "Selected package manager '${C["UserCommand"]}${PreferredPackageManager}${NC}' not detected." \
+                "" \
+                "Detected package managers are:" \
+                "" \
+                "$(run_script 'package_manager_existing_table')" \
+                ""
         else
             PM="${PreferredPackageManager}"
         fi
@@ -49,11 +49,11 @@ package_manager_init() {
     if [[ -z ${PM-} ]]; then
         fatal \
             "Unable to detect a compatible package manager." \
-            "\n" \
-            "Known package managers are:\n" \
-            "\n" \
-            "$(run_script 'package_manager_table')\n" \
-            " "
+            "" \
+            "Known package managers are:" \
+            "" \
+            "$(run_script 'package_manager_table')" \
+            ""
     fi
 
     local NoticeText

--- a/.scripts/package_manager_run.sh
+++ b/.scripts/package_manager_run.sh
@@ -18,7 +18,7 @@ package_manager_run() {
                     "'${C["Program"]}docker${NC}' is not available. Please install '${C["Program"]}docker${NC}' and try again."
             docker compose version &> /dev/null ||
                 fatal \
-                    "Please see ${C["URL"]}https://docs.docker.com/compose/install/linux/${NC} to install '${C["Program"]}docker compose${NC}'\n" \
+                    "Please see ${C["URL"]}https://docs.docker.com/compose/install/linux/${NC} to install '${C["Program"]}docker compose${NC}'" \
                     "'${C["Program"]}docker compose${NC}' is not available. Please install '${C["Program"]}docker compose${NC}' and try again."
             ;;
     esac

--- a/.scripts/pm_apk_install.sh
+++ b/.scripts/pm_apk_install.sh
@@ -30,7 +30,7 @@ pm_apk_install() {
     notice "Running: ${C["RunningCommand"]}${Command}${NC}"
     eval "${REDIRECT}${Command}" ||
         fatal \
-            "Failed to install dependencies from apk.\n" \
+            "Failed to install dependencies from apk." \
             "Failing command: ${C["FailingCommand"]}${Command}"
 }
 

--- a/.scripts/pm_apk_install_docker.sh
+++ b/.scripts/pm_apk_install_docker.sh
@@ -14,7 +14,7 @@ pm_apk_install_docker() {
     fi
     eval "${REDIRECT}${COMMAND}" ||
         fatal \
-            "Failed to install docker and docker-compose using apk.\n" \
+            "Failed to install docker and docker-compose using apk." \
             "Failing command: ${C["FailingCommand"]}${COMMAND}"
 }
 

--- a/.scripts/pm_apk_upgrade.sh
+++ b/.scripts/pm_apk_upgrade.sh
@@ -15,7 +15,7 @@ pm_apk_upgrade() {
         fi
         eval "${REDIRECT}${COMMAND}" ||
             fatal \
-                "Failed to upgrade packages from apk.\n" \
+                "Failed to upgrade packages from apk." \
                 "Failing command: ${C["FailingCommand"]}${COMMAND}"
     fi
 }

--- a/.scripts/pm_apt_clean.sh
+++ b/.scripts/pm_apt_clean.sh
@@ -14,7 +14,7 @@ pm_apt_clean() {
     notice "Running: ${C["RunningCommand"]}${Command}${NC}"
     eval "${REDIRECT}${Command}" ||
         warn \
-            "Failed to remove unused packages from apt.\n" \
+            "Failed to remove unused packages from apt." \
             "Failing command: ${C["FailingCommand"]}${Command}"
 
     info "Cleaning up package cache."
@@ -22,7 +22,7 @@ pm_apt_clean() {
     notice "Running: ${C["RunningCommand"]}${Command}${NC}"
     eval "${REDIRECT}${Command}" ||
         warn \
-            "Failed to cleanup cache from apt.\n" \
+            "Failed to cleanup cache from apt." \
             "Failing command: ${C["FailingCommand"]}${Command}"
 }
 

--- a/.scripts/pm_apt_install.sh
+++ b/.scripts/pm_apt_install.sh
@@ -17,7 +17,7 @@ pm_apt_install() {
         notice "Running: ${C["RunningCommand"]}${Command}${NC}"
         eval "${REDIRECT}${Command}" ||
             fatal \
-                "Failed to install '${C["Program"]}apt-file${NC}' from apt.\n" \
+                "Failed to install '${C["Program"]}apt-file${NC}' from apt." \
                 "Failing command: ${C["FailingCommand"]}${Command}"
     fi
     notice "Updating package information."
@@ -25,7 +25,7 @@ pm_apt_install() {
     notice "Running: ${C["RunningCommand"]}${Command}${NC}"
     eval "${REDIRECT}${Command}" ||
         fatal \
-            "Failed to get updates from apt.\n" \
+            "Failed to get updates from apt." \
             "Failing command: ${C["FailingCommand"]}${Command}"
 
     notice "Determining packages to install."
@@ -48,7 +48,7 @@ pm_apt_install() {
     notice "Running: ${C["RunningCommand"]}${Command}${NC}"
     eval "${REDIRECT}${Command}" ||
         fatal \
-            "Failed to install dependencies from apt.\n" \
+            "Failed to install dependencies from apt." \
             "Failing command: ${C["FailingCommand"]}${Command}"
 }
 

--- a/.scripts/pm_apt_repos.sh
+++ b/.scripts/pm_apt_repos.sh
@@ -25,7 +25,7 @@ pm_apt_repos() {
         notice "Running: ${C["RunningCommand"]}${COMMAND}${NC}"
         eval "${REDIRECT}${COMMAND}" ||
             fatal \
-                "Failed to get updates from apt.\n" \
+                "Failed to get updates from apt." \
                 "Failing command: ${C["FailingCommand"]}${COMMAND}"
 
         COMMAND="sudo apt-get -y install apt-transport-https"
@@ -33,7 +33,7 @@ pm_apt_repos() {
         notice "Running: ${C["RunningCommand"]}${COMMAND}${NC}"
         eval "${REDIRECT}${COMMAND}" ||
             fatal \
-                "Failed to install apt-transport-https from apt.\n" \
+                "Failed to install apt-transport-https from apt." \
                 "Failing command: ${C["FailingCommand"]}${COMMAND}"
     fi
     local MINIMUM_LIBSECCOMP2="2.4.4"
@@ -44,11 +44,11 @@ pm_apt_repos() {
         info "Installing buster-backports repo for libseccomp2."
         sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 04EE7237B7D453EC 648ACFD622F3D138 ||
             error \
-                "Failed to get apt key for buster-backports repo.\n" \
+                "Failed to get apt key for buster-backports repo." \
                 "Failing command: ${C["FailingCommand"]}sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 04EE7237B7D453EC 648ACFD622F3D138"
         echo "deb http://deb.debian.org/debian buster-backports main" | sudo tee -a /etc/apt/sources.list.d/buster-backports.list ||
             error \
-                "Failed to add buster-backports repo to sources.\n" \
+                "Failed to add buster-backports repo to sources." \
                 "Failing command: ${C["FailingCommand"]}echo \"deb http://deb.debian.org/debian buster-backports main\" | sudo tee -a /etc/apt/sources.list.d/buster-backports.list"
     fi
     COMMAND="sudo apt-get -y update"
@@ -56,7 +56,7 @@ pm_apt_repos() {
     notice "Running: ${C["RunningCommand"]}${COMMAND}${NC}"
     eval "${REDIRECT}${COMMAND}" ||
         fatal \
-            "Failed to get updates from apt.\n" \
+            "Failed to get updates from apt." \
             "Failing command: ${C["FailingCommand"]}${COMMAND}"
     if vergt "${MINIMUM_LIBSECCOMP2}" "${INSTALLED_LIBSECCOMP2:-0}"; then
         COMMAND="sudo apt-get -y install -t buster-backports libseccomp2"
@@ -64,7 +64,7 @@ pm_apt_repos() {
         notice "Running: ${C["RunningCommand"]}${COMMAND}${NC}"
         eval "${REDIRECT}${COMMAND}" ||
             fatal \
-                "Failed to install libseccomp2 from buster-backports repo.\n" \
+                "Failed to install libseccomp2 from buster-backports repo." \
                 "Failing command: ${C["FailingCommand"]}${COMMAND}"
     fi
 }

--- a/.scripts/pm_apt_upgrade.sh
+++ b/.scripts/pm_apt_upgrade.sh
@@ -17,7 +17,7 @@ pm_apt_upgrade() {
     notice "Running: ${C["RunningCommand"]}${COMMAND}${NC}"
     eval "${REDIRECT}${COMMAND}" ||
         fatal \
-            "Failed to upgrade packages from apt.\n" \
+            "Failed to upgrade packages from apt." \
             "Failing command: ${C["FailingCommand"]}${COMMAND}"
 }
 

--- a/.scripts/pm_brew_clean.sh
+++ b/.scripts/pm_brew_clean.sh
@@ -14,7 +14,7 @@ pm_brew_clean() {
     notice "Running: ${C["RunningCommand"]}${Command}${NC}"
     eval "${REDIRECT}${Command}" ||
         warn \
-            "Failed to remove unused packages from brew.\n" \
+            "Failed to remove unused packages from brew." \
             "Failing command: ${C["FailingCommand"]}${Command}"
 
     info "Cleaning up package cache."
@@ -22,7 +22,7 @@ pm_brew_clean() {
     notice "Running: ${C["RunningCommand"]}${Command}${NC}"
     eval "${REDIRECT}${Command}" ||
         warn \
-            "Failed to cleanup cache from brew.\n" \
+            "Failed to cleanup cache from brew." \
             "Failing command: ${C["FailingCommand"]}${Command}"
 }
 

--- a/.scripts/pm_brew_install.sh
+++ b/.scripts/pm_brew_install.sh
@@ -30,7 +30,7 @@ pm_brew_install() {
     notice "Running: ${C["RunningCommand"]}${Command}${NC}"
     eval "${REDIRECT}${Command}" ||
         fatal \
-            "Failed to install dependencies from brew.\n" \
+            "Failed to install dependencies from brew." \
             "Failing command: ${C["FailingCommand"]}${Command}"
 }
 

--- a/.scripts/pm_brew_repos.sh
+++ b/.scripts/pm_brew_repos.sh
@@ -13,7 +13,7 @@ pm_brew_repos() {
     notice "Running: ${C["RunningCommand"]}${Command}${NC}"
     eval "${REDIRECT}${Command}" ||
         fatal \
-            "Failed to get updates from brew.\n" \
+            "Failed to get updates from brew." \
             "Failing command: ${C["FailingCommand"]}${Command}"
 }
 

--- a/.scripts/pm_brew_upgrade.sh
+++ b/.scripts/pm_brew_upgrade.sh
@@ -13,7 +13,7 @@ pm_brew_upgrade() {
         notice "Running: ${C["RunningCommand"]}${Command}${NC}"
         eval "${REDIRECT}${Command}" ||
             fatal \
-                "Failed to upgrade packages from brew.\n" \
+                "Failed to upgrade packages from brew." \
                 "Failing command: ${C["FailingCommand"]}${Command}"
     done
 }

--- a/.scripts/pm_dnf_clean.sh
+++ b/.scripts/pm_dnf_clean.sh
@@ -6,13 +6,13 @@ pm_dnf_clean() {
     info "Removing unused packages."
     sudo dnf -y autoremove &> /dev/null ||
         warn \
-            "Failed to remove unused packages from dnf.\n" \
+            "Failed to remove unused packages from dnf." \
             "Failing command: ${C["FailingCommand"]}sudo dnf -y autoremove"
 
     info "Cleaning up package cache."
     sudo dnf -y clean all &> /dev/null ||
         warn \
-            "Failed to cleanup cache from dnf.\n" \
+            "Failed to cleanup cache from dnf." \
             "Failing command: ${C["FailingCommand"]}sudo dnf -y clean all"
 }
 

--- a/.scripts/pm_dnf_install.sh
+++ b/.scripts/pm_dnf_install.sh
@@ -32,7 +32,7 @@ pm_dnf_install() {
     notice "Running: ${C["RunningCommand"]}${Command}${NC}"
     eval "${REDIRECT}${Command}" ||
         fatal \
-            "Failed to install dependencies from dnf.\n" \
+            "Failed to install dependencies from dnf." \
             "Failing command: ${C["FailingCommand"]}${Command}"
 }
 

--- a/.scripts/pm_dnf_upgrade.sh
+++ b/.scripts/pm_dnf_upgrade.sh
@@ -15,7 +15,7 @@ pm_dnf_upgrade() {
         fi
         eval "${REDIRECT}${COMMAND}" ||
             fatal \
-                "Failed to upgrade packages from dnf.\n" \
+                "Failed to upgrade packages from dnf." \
                 "Failing command: ${C["FailingCommand"]}${COMMAND}"
     fi
 }

--- a/.scripts/pm_nala_clean.sh
+++ b/.scripts/pm_nala_clean.sh
@@ -14,7 +14,7 @@ pm_nala_clean() {
     notice "Running: ${C["RunningCommand"]}${Command}${NC}"
     eval "${REDIRECT}${Command}" ||
         warn \
-            "Failed to remove unused packages from nala.\n" \
+            "Failed to remove unused packages from nala." \
             "Failing command: ${C["FailingCommand"]}${Command}"
 
     info "Cleaning up package cache."
@@ -22,7 +22,7 @@ pm_nala_clean() {
     notice "Running: ${C["RunningCommand"]}${Command}${NC}"
     eval "${REDIRECT}${Command}" ||
         warn \
-            "Failed to cleanup cache from nala.\n" \
+            "Failed to cleanup cache from nala." \
             "Failing command: ${C["FailingCommand"]}${Command}"
 }
 

--- a/.scripts/pm_nala_install.sh
+++ b/.scripts/pm_nala_install.sh
@@ -17,7 +17,7 @@ pm_nala_install() {
         notice "Running: ${C["RunningCommand"]}${Command}${NC}"
         eval "${REDIRECT}${Command}" ||
             fatal \
-                "Failed to install '${C["Program"]}apt-file${NC}' from nala.\n" \
+                "Failed to install '${C["Program"]}apt-file${NC}' from nala." \
                 "Failing command: ${C["FailingCommand"]}${Command}"
     fi
     notice "Updating package information."
@@ -25,7 +25,7 @@ pm_nala_install() {
     notice "Running: ${C["RunningCommand"]}${Command}${NC}"
     eval "${REDIRECT}${Command}" ||
         fatal \
-            "Failed to get updates from apt-file.\n" \
+            "Failed to get updates from apt-file." \
             "Failing command: ${C["FailingCommand"]}${Command}"
 
     notice "Determining packages to install."
@@ -48,7 +48,7 @@ pm_nala_install() {
     notice "Running: ${C["RunningCommand"]}${Command}${NC}"
     eval "${REDIRECT}${Command}" ||
         fatal \
-            "Failed to install dependencies from nala.\n" \
+            "Failed to install dependencies from nala." \
             "Failing command: ${C["FailingCommand"]}${Command}"
 }
 

--- a/.scripts/pm_nala_repos.sh
+++ b/.scripts/pm_nala_repos.sh
@@ -25,7 +25,7 @@ pm_nala_repos() {
         notice "Running: ${C["RunningCommand"]}${COMMAND}${NC}"
         eval "${REDIRECT}${COMMAND}" ||
             fatal \
-                "Failed to get updates from nala.\n" \
+                "Failed to get updates from nala." \
                 "Failing command: ${C["FailingCommand"]}${COMMAND}"
 
         COMMAND="sudo nala install --no-update -y apt-transport-https"
@@ -33,7 +33,7 @@ pm_nala_repos() {
         notice "Running: ${C["RunningCommand"]}${COMMAND}${NC}"
         eval "${REDIRECT}${COMMAND}" ||
             fatal \
-                "Failed to install apt-transport-https from nala.\n" \
+                "Failed to install apt-transport-https from nala." \
                 "Failing command: ${C["FailingCommand"]}${COMMAND}"
     fi
     local MINIMUM_LIBSECCOMP2="2.4.4"
@@ -44,11 +44,11 @@ pm_nala_repos() {
         info "Installing buster-backports repo for libseccomp2."
         sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 04EE7237B7D453EC 648ACFD622F3D138 ||
             error \
-                "Failed to get apt key for buster-backports repo.\n" \
+                "Failed to get apt key for buster-backports repo." \
                 "Failing command: ${C["FailingCommand"]}sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 04EE7237B7D453EC 648ACFD622F3D138"
         echo "deb http://deb.debian.org/debian buster-backports main" | sudo tee -a /etc/apt/sources.list.d/buster-backports.list ||
             error \
-                "Failed to add buster-backports repo to sources.\n" \
+                "Failed to add buster-backports repo to sources." \
                 "Failing command: ${C["FailingCommand"]}echo \"deb http://deb.debian.org/debian buster-backports main\" | sudo tee -a /etc/apt/sources.list.d/buster-backports.list"
     fi
     info "Updating repositories."
@@ -56,7 +56,7 @@ pm_nala_repos() {
     notice "Running: ${C["RunningCommand"]}${COMMAND}${NC}"
     eval "${REDIRECT}${COMMAND}" ||
         fatal \
-            "Failed to get updates from nala.\n" \
+            "Failed to get updates from nala." \
             "Failing command: ${C["FailingCommand"]}${COMMAND}"
     if vergt "${MINIMUM_LIBSECCOMP2}" "${INSTALLED_LIBSECCOMP2:-0}"; then
         info "Installing libseccomp2 from buster-backports repo."
@@ -64,7 +64,7 @@ pm_nala_repos() {
         notice "Running: ${C["RunningCommand"]}${COMMAND}${NC}"
         eval "${REDIRECT}${COMMAND}" ||
             fatal \
-                "Failed to install libseccomp2 from buster-backports repo.\n" \
+                "Failed to install libseccomp2 from buster-backports repo." \
                 "Failing command: ${C["FailingCommand"]}${COMMAND}"
     fi
 }

--- a/.scripts/pm_nala_upgrade.sh
+++ b/.scripts/pm_nala_upgrade.sh
@@ -17,7 +17,7 @@ pm_nala_upgrade() {
     notice "Running: ${C["RunningCommand"]}${COMMAND}${NC}"
     eval "${REDIRECT}${COMMAND}" ||
         fatal \
-            "Failed to upgrade packages from nala.\n" \
+            "Failed to upgrade packages from nala." \
             "Failing command: ${C["FailingCommand"]}${COMMAND}"
 }
 

--- a/.scripts/pm_pacman_clean.sh
+++ b/.scripts/pm_pacman_clean.sh
@@ -6,7 +6,7 @@ pm_pacman_clean() {
     info "Cleaning up package cache."
     sudo pacman -Sc --noconfirm &> /dev/null ||
         info \
-            "Failed to cleanup pacman cache.\n" \
+            "Failed to cleanup pacman cache." \
             "Failing command: ${C["FailingCommand"]}sudo pacman -Sc --noconfirm"
 }
 

--- a/.scripts/pm_pacman_install.sh
+++ b/.scripts/pm_pacman_install.sh
@@ -32,7 +32,7 @@ pm_pacman_install() {
     notice "Running: ${C["RunningCommand"]}${Command}${NC}"
     eval "${REDIRECT}${Command}" ||
         fatal \
-            "Failed to install dependencies from pacman.\n" \
+            "Failed to install dependencies from pacman." \
             "Failing command: ${C["FailingCommand"]}${Command}"
 }
 
@@ -46,7 +46,7 @@ detect_packages() {
         notice "Running: ${C["RunningCommand"]}${Command}${NC}"
         eval "${REDIRECT}${Command}" ||
             fatal \
-                "Failed to install '${C["Program"]}pkgfile${NC}' from pacman.\n" \
+                "Failed to install '${C["Program"]}pkgfile${NC}' from pacman." \
                 "Failing command: ${C["FailingCommand"]}${Command}"
     fi
     notice "Updating package information."
@@ -54,7 +54,7 @@ detect_packages() {
     notice "Running: ${C["RunningCommand"]}${Command}${NC}"
     eval "${REDIRECT}${Command}" ||
         fatal \
-            "Failed to get updates from pkgfile.\n" \
+            "Failed to get updates from pkgfile." \
             "Failing command: ${C["FailingCommand"]}${Command}"
 
     local RegEx_Package_Blacklist
@@ -71,7 +71,7 @@ detect_packages() {
         notice "Running: ${C["RunningCommand"]}${Command}${NC}"
         Package="$(eval "${Command}" 2> /dev/null)" ||
             fatal \
-                "Failed to find packages to install.\n" \
+                "Failed to find packages to install." \
                 "Failing command: ${C["FailingCommand"]}${Command}"
         Package="${Package##*/}"
         if [[ -n ${Package} && (-z ${RegEx_Package_Blacklist-} || ! ${Package} =~ ${RegEx_Package_Blacklist}) ]]; then

--- a/.scripts/pm_pacman_install_docker.sh
+++ b/.scripts/pm_pacman_install_docker.sh
@@ -14,7 +14,7 @@ pm_pacman_install_docker() {
     fi
     eval "${REDIRECT}${COMMAND}" ||
         fatal \
-            "Failed to install docker and docker-compose using pacman.\n" \
+            "Failed to install docker and docker-compose using pacman." \
             "Failing command: ${C["FailingCommand"]}${COMMAND}"
 }
 

--- a/.scripts/pm_pacman_upgrade.sh
+++ b/.scripts/pm_pacman_upgrade.sh
@@ -15,7 +15,7 @@ pm_pacman_upgrade() {
         fi
         eval "${REDIRECT}${COMMAND}" ||
             fatal \
-                "Failed to upgrade packages from pacman.\n" \
+                "Failed to upgrade packages from pacman." \
                 "Failing command: ${C["FailingCommand"]}${COMMAND}"
     fi
 }

--- a/.scripts/pm_yum_clean.sh
+++ b/.scripts/pm_yum_clean.sh
@@ -6,13 +6,13 @@ pm_yum_clean() {
     info "Removing unused packages."
     sudo yum -y autoremove &> /dev/null ||
         warn \
-            "Failed to remove unused packages from yum.\n" \
+            "Failed to remove unused packages from yum." \
             "Failing command: ${C["FailingCommand"]}sudo yum -y autoremove"
 
     info "Cleaning up package cache."
     sudo yum -y clean all &> /dev/null ||
         warn \
-            "Failed to cleanup cache from yum.\n" \
+            "Failed to cleanup cache from yum." \
             "Failing command: ${C["FailingCommand"]}sudo yum -y clean all"
 }
 

--- a/.scripts/pm_yum_install.sh
+++ b/.scripts/pm_yum_install.sh
@@ -32,7 +32,7 @@ pm_yum_install() {
     notice "Running: ${C["RunningCommand"]}${Command}${NC}"
     eval "${REDIRECT}${Command}" ||
         fatal \
-            "Failed to install dependencies from yum.\n" \
+            "Failed to install dependencies from yum." \
             "Failing command: ${C["FailingCommand"]}${Command}"
 }
 
@@ -45,7 +45,7 @@ detect_packages() {
         notice "Running: ${C["RunningCommand"]}${Command}${NC}"
         eval "${REDIRECT}${Command}" ||
             fatal \
-                "Failed to install '${C["Program"]}repoquery${NC}' from yum.\n" \
+                "Failed to install '${C["Program"]}repoquery${NC}' from yum." \
                 "Failing command: ${C["FailingCommand"]}${Command}"
     fi
 

--- a/.scripts/pm_yum_repos.sh
+++ b/.scripts/pm_yum_repos.sh
@@ -9,12 +9,12 @@ pm_yum_repos() {
     local MKTEMP_GET_IUS
     MKTEMP_GET_IUS=$(mktemp -t "${APPLICATION_NAME}.${FUNCNAME[0]}.MKTEMP_GET_IUS.XXXXXXXXXX") ||
         fatal \
-            "Failed to create temporary IUS repo install script.\n" \
+            "Failed to create temporary IUS repo install script." \
             "Failing command: ${C["FailingCommand"]}mktemp -t \"${APPLICATION_NAME}.${FUNCNAME[0]}.MKTEMP_GET_IUS.XXXXXXXXXX\""
     info "Downloading IUS install script."
     curl -fsSL setup.ius.io -o "${MKTEMP_GET_IUS}" &> /dev/null ||
         fatal \
-            "Failed to get IUS install script.\n" \
+            "Failed to get IUS install script." \
             "Failing command: ${C["FailingCommand"]}curl -fsSL setup.ius.io -o \"${MKTEMP_GET_IUS}\""
 
     info "Running IUS install script."
@@ -27,11 +27,11 @@ pm_yum_repos() {
     COMMAND="sudo bash ${MKTEMP_GET_IUS}"
     eval "${REDIRECT}${COMMAND}" ||
         warn \
-            "Failed to install IUS.\n" \
+            "Failed to install IUS." \
             "Failing command: ${C["FailingCommand"]}${COMMAND}"
     rm -f "${MKTEMP_GET_IUS}" ||
         warn \
-            "Failed to remove temporary IUS repo install script.\n" \
+            "Failed to remove temporary IUS repo install script." \
             "Failing command: ${C["FailingCommand"]}rm -f \"${MKTEMP_GET_IUS}\""
 }
 

--- a/.scripts/pm_yum_upgrade.sh
+++ b/.scripts/pm_yum_upgrade.sh
@@ -15,7 +15,7 @@ pm_yum_upgrade() {
         fi
         eval "${REDIRECT}${COMMAND}" ||
             fatal \
-                "Failed to upgrade packages from yum.\n" \
+                "Failed to upgrade packages from yum." \
                 "Failing command: ${C["FailingCommand"]}${COMMAND}"
     fi
 }

--- a/.scripts/pm_zypper_install.sh
+++ b/.scripts/pm_zypper_install.sh
@@ -32,7 +32,7 @@ pm_zypper_install() {
     notice "Running: ${C["RunningCommand"]}${Command}${NC}"
     eval "${REDIRECT}${Command}" ||
         fatal \
-            "Failed to install dependencies from zypper.\n" \
+            "Failed to install dependencies from zypper." \
             "Failing command: ${C["FailingCommand"]}${Command}"
 }
 

--- a/.scripts/pm_zypper_repos.sh
+++ b/.scripts/pm_zypper_repos.sh
@@ -15,7 +15,7 @@ pm_zypper_repos() {
     notice "Running: ${C["RunningCommand"]}${COMMAND}${NC}"
     eval "${REDIRECT}${COMMAND}" ||
         fatal \
-            "Failed to get updates from zypper.\n" \
+            "Failed to get updates from zypper." \
             "Failing command: ${C["FailingCommand"]}${COMMAND}"
 }
 

--- a/.scripts/pm_zypper_upgrade.sh
+++ b/.scripts/pm_zypper_upgrade.sh
@@ -15,7 +15,7 @@ pm_zypper_upgrade() {
         fi
         eval "${REDIRECT}${COMMAND}" ||
             fatal \
-                "Failed to upgrade packages from zypper.\n" \
+                "Failed to upgrade packages from zypper." \
                 "Failing command: ${C["FailingCommand"]}${COMMAND}"
     fi
 }

--- a/.scripts/request_reboot.sh
+++ b/.scripts/request_reboot.sh
@@ -6,10 +6,10 @@ request_reboot() {
     notice \
         "Your system may need to reboot for changes to take effect."
     warn \
-        "If this is your first run reboot is required.\n" \
+        "If this is your first run reboot is required." \
         "Failure to reboot on first run can cause errors with other operations."
     notice \
-        "Please run '${C["UserCommand"]}sudo reboot${NC}' manually.\n" \
+        "Please run '${C["UserCommand"]}sudo reboot${NC}' manually." \
         "If this is not your first run you may disregard this message."
 }
 

--- a/.scripts/require_docker.sh
+++ b/.scripts/require_docker.sh
@@ -12,10 +12,10 @@ test_require_docker() {
     run_script 'require_docker'
     docker --version ||
         fatal \
-            "Failed to determine docker version.\n" \
+            "Failed to determine docker version." \
             "Failing command: ${C["FailingCommand"]}docker --version"
     docker compose version ||
         fatal \
-            "Failed to determine docker compose version.\n" \
+            "Failed to determine docker compose version." \
             "Failing command: ${C["FailingCommand"]}docker compose version"
 }

--- a/.scripts/set_permissions.sh
+++ b/.scripts/set_permissions.sh
@@ -34,7 +34,7 @@ set_permissions() {
     info "Setting executable permission on '${C["File"]}${SCRIPTNAME}${NC}'"
     sudo chmod +x "${SCRIPTNAME}" &> /dev/null ||
         fatal \
-            "'${C["UserCommand"]}${APPLICATION_COMMAND}${NC}' must be executable.\n" \
+            "'${C["UserCommand"]}${APPLICATION_COMMAND}${NC}' must be executable." \
             "Failing command: ${C["FailingCommand"]}sudo chmod +x \"${SCRIPTNAME}\""
 }
 

--- a/.scripts/update_self.sh
+++ b/.scripts/update_self.sh
@@ -16,7 +16,7 @@ update_self() {
 
     pushd "${SCRIPTPATH}" &> /dev/null ||
         fatal \
-            "Failed to change directory.\n" \
+            "Failed to change directory." \
             "Failing command: ${C["FailingCommand"]}push \"${SCRIPTPATH}\""
 
     if [[ -z ${Branch-} ]]; then
@@ -91,7 +91,7 @@ commands_update_self() {
 
     pushd "${SCRIPTPATH}" &> /dev/null ||
         fatal \
-            "Failed to change directory.\n" \
+            "Failed to change directory." \
             "Failing command: ${C["FailingCommand"]}push \"${SCRIPTPATH}\""
     local QUIET=''
     if [[ -z ${VERBOSE-} ]]; then
@@ -100,7 +100,7 @@ commands_update_self() {
     notice "${Notice}"
     cd "${SCRIPTPATH}" ||
         fatal \
-            "Failed to change directory.\n" \
+            "Failed to change directory." \
             "Failing command: ${C["FailingCommand"]}cd \"${SCRIPTPATH}\""
     info "Setting file ownership on current repository files"
     sudo chown -R "$(id -u)":"$(id -g)" "${SCRIPTPATH}/.git" &> /dev/null || true
@@ -110,21 +110,21 @@ commands_update_self() {
     info "Fetching recent changes from git."
     eval git fetch ${QUIET-} --all --prune ||
         fatal \
-            "Failed to fetch recent changes from git.\n" \
+            "Failed to fetch recent changes from git." \
             "Failing command: ${C["FailingCommand"]}git fetch ${QUIET-} --all --prune"
     if [[ ${CI-} != true ]]; then
         eval git checkout ${QUIET-} --force "${Branch}" ||
             fatal \
-                "Failed to switch to github branch '${C["Branch"]}${Branch}${NC}'.\n" \
+                "Failed to switch to github branch '${C["Branch"]}${Branch}${NC}'." \
                 "Failing command: ${C["FailingCommand"]}git checkout ${QUIET-} --force \"${Branch}\""
         eval git reset ${QUIET-} --hard origin/"${Branch}" ||
             fatal \
-                "Failed to reset to branch '${C["Branch"]}origin/${Branch}${NC}'.\n" \
+                "Failed to reset to branch '${C["Branch"]}origin/${Branch}${NC}'." \
                 "Failing command: ${C["FailingCommand"]}git reset ${QUIET-} --hard origin/\"${Branch}\""
         info "Pulling recent changes from git."
         eval git pull ${QUIET-} ||
             fatal \
-                "Failed to pull recent changes from git.\n" \
+                "Failed to pull recent changes from git." \
                 "Failing command: ${C["FailingCommand"]}git pull ${QUIET-}"
     fi
     info "Cleaning up unnecessary files and optimizing the local repository."

--- a/.scripts/yml_merge.sh
+++ b/.scripts/yml_merge.sh
@@ -29,7 +29,7 @@ commands_yml_merge() {
             if [[ -f ${main_yml} ]]; then
                 if run_script 'app_is_deprecated' "${APPNAME}"; then
                     warn \
-                        "'${C["App"]}${AppName}${NC}' IS DEPRECATED!\n" \
+                        "'${C["App"]}${AppName}${NC}' IS DEPRECATED!" \
                         "Please run '${C["UserCommand"]}${APPLICATION_COMMAND} --status-disable ${AppName}${NC}' to disable it."
                 fi
                 local arch_yml
@@ -123,7 +123,7 @@ commands_yml_merge() {
     eval "docker compose --project-directory ${COMPOSE_FOLDER}/ config > ${COMPOSE_FOLDER}/docker-compose.yml" || result=$?
     if [[ ${result} != 0 ]]; then
         error \
-            "Failed to output compose config.\n" \
+            "Failed to output compose config." \
             "Failing command: ${C["FailingCommand"]}docker compose --project-directory ${COMPOSE_FOLDER}/ config > \"${COMPOSE_FOLDER}/docker-compose.yml\""
         return ${result}
     fi
@@ -137,7 +137,7 @@ test_yml_merge() {
     run_script 'yml_merge'
     eval "docker compose --project-directory ${COMPOSE_FOLDER}/ config" ||
         fatal \
-            "Failed to display compose config.\n" \
+            "Failed to display compose config." \
             "Failing command: ${C["FailingCommand"]}docker compose --project-directory ${COMPOSE_FOLDER}/ config"
     run_script 'appvars_purge' WATCHTOWER
 }


### PR DESCRIPTION
Update the logging routines to not require a `\n` at the end of each argument. Adjust all calls to the logging routines to remove the hard-coded `\n` chars.

Write out the `fatal` notices to a `fatal.log` in addition to appending to `dockstarter.log`

# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Refactor logging to centralize timestamping and output handling while introducing dedicated fatal error logging.

New Features:
- Write fatal error messages to a separate fatal.log file in addition to the main application log.

Enhancements:
- Simplify logging APIs so callers no longer embed trailing newlines in messages, relying on the logging routines to handle line termination.
- Adjust trace, debug, info, notice, warn, and error helpers to route through a single logging path using timestamped messages.
- Clean up and clarify many user- and error-facing messages, including stack traces and package manager notices, for more consistent formatting and wording.