### PR TITLE
Correct the alignment of the frame number in stack trace

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -228,8 +228,7 @@ fatal() {
     local -i thisFuncLine=$((LINENO - 1))
     local -a Stack=()
     local StackSize=${#FUNCNAME[@]}
-    local -i FrameNumberLength
-    FrameNumberLength=$((${#StackSize} / 10))
+    local -i FrameNumberLength=${#StackSize}
     local NoFile="<nofile>"
     local NoFunction="<nofunction>"
 
@@ -251,8 +250,8 @@ fatal() {
             )"
         )
         if [[ -n ${cmd-} ]]; then
-            local FrameCmdPrefix="${C["TraceFrameLines"]}│"
-            local FrameArgPrefix="${C["TraceFrameLines"]}│"
+            local FrameCmdPrefix="${C["TraceFrameLines"]}│${NC}"
+            local FrameArgPrefix="${C["TraceFrameLines"]}│${NC}"
             local cmdString="${C["TraceCmd"]}${cmd}${NC}"
             local -a cmdArray=()
             cmdArray+=("${FrameCmdPrefix}${cmdString}")
@@ -269,7 +268,7 @@ fatal() {
                 done
             fi
             local StackCmdIndent
-            StackCmdIndent="$(printf "  %${FrameNumberLength}s${indent}    " "")"
+            StackCmdIndent="$(printf "  %${FrameNumberLength}s${indent}   " "")"
             local cmdLines
             cmdLines="$(
                 pr -t -o ${#StackCmdIndent} <<< "$(


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Adjust stack trace formatting to improve frame number alignment and command/argument line rendering.

Bug Fixes:
- Fix incorrect frame number width calculation in stack traces so alignment matches the stack size.
- Ensure stack trace command and argument prefixes correctly reset colors to avoid style leakage between lines.
- Tighten indentation for stack trace command blocks to improve visual alignment with frame headers.