### PR TITLE
Sanitize architecture value of "arm64" to "aarch64"

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -55,6 +55,9 @@ export DETECTED_HOMEDIR
 
 # System Information
 ARCH=$(uname -m)
+if [[ ${ARCH} == arm64 ]]; then
+    ARCH="aarch64"
+fi
 readonly ARCH
 export ARCH
 
@@ -312,7 +315,7 @@ fatal() {
 
 # Check for supported CPU architecture
 check_arch() {
-    if [[ ${ARCH} != "arm64" ]] && [[ ${ARCH} != "aarch64" ]] && [[ ${ARCH} != "x86_64" ]]; then
+    if [[ ${ARCH} != "aarch64" ]] && [[ ${ARCH} != "x86_64" ]]; then
         fatal_notrace \
             "Unsupported architeture." \
             "Supported architetures are 'aarch64' or 'x86_64', running architeture is '${ARCH}'."


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Normalize detected CPU architecture values and simplify architecture support checks.

Bug Fixes:
- Map detected 'arm64' architecture to 'aarch64' to align with supported architecture identifiers.
- Tighten the architecture validation logic to only allow normalized 'aarch64' and 'x86_64' values.