### PR TITLE
Replace `pr` with `expand` and `indent`

### DIFF
--- a/includes/cmdline.sh
+++ b/includes/cmdline.sh
@@ -1153,9 +1153,7 @@ cmdline_error_text() {
 		pr -e -t -o "${Indent}" <<< "${CommandLine}" | sed 's/[[:space:]]\+$//'
 	)"
 	Message=${Message//\\n/$'\n'}
-	Message="$(
-		pr -e -t -o "${Indent}" <<< "${Message}" | sed 's/[[:space:]]\+$//'
-	)"
+	Message="$(expand <<< "${Message}" | indent_string_pipe "${Indent}" | sed 's/[[:space:]]\+$//')"
 
 	local UsageText
 	if [[ -z ${Command} ]]; then
@@ -1163,7 +1161,7 @@ cmdline_error_text() {
 	else
 		local CommandUsage
 		CommandUsage="$(usage_raw "${Command}" NoHeading)"
-		UsageText="Usage is:\n$(pr -e -t -o "${Indent}" <<< "${CommandUsage}")"
+		UsageText="Usage is:\n$(expand <<< "${CommandUsage}" | indent_string_pipe "${Indent}")"
 	fi
 
 	local PointerLine


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Enhancements:
- Standardize indentation of error messages and usage output by using `expand` combined with `indent_string_pipe` instead of `pr`.