### PR TITLE
Use `up --pull always` for `ds -c update` instead of separate `pull` and `up` commands

### DIFF
--- a/scripts/docker_compose.sh
+++ b/scripts/docker_compose.sh
@@ -105,8 +105,7 @@ docker_compose() {
 				NoNotice="Not updating and starting containers for all enabled services."
 				YesNotice="Updating and starting containers for all enabled services."
 			fi
-			ComposeCommand[0]="pull --include-deps ${APPNAME-}"
-			ComposeCommand[1]="up -d --remove-orphans ${APPNAME-}"
+			ComposeCommand[0]="up -d --remove-orphans --pull always ${APPNAME-}"
 			;;
 		up)
 			if [[ -n ${AppName-} ]]; then
@@ -118,14 +117,13 @@ docker_compose() {
 				NoNotice="Not starting containers for all enabled services."
 				YesNotice="Starting containers for all enabled services."
 			fi
-			ComposeCommand[0]="up -d --remove-orphans ${APPNAME-}"
+			ComposeCommand[0]="up -d --remove-orphans --pull missing ${APPNAME-}"
 			;;
 		*)
 			Question="Update containers for all enabled services?"
 			NoNotice="Not updating containers for all enabled services."
 			YesNotice="Updating containers for all enabled services."
-			ComposeCommand[0]="pull --include-deps"
-			ComposeCommand[1]="up -d --remove-orphans"
+			ComposeCommand[0]="up -d --remove-orphans --pull always"
 			;;
 	esac
 


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Update docker compose helper to use a single `up` command with integrated image pulling behavior for update and default operations.

Enhancements:
- Change the update command to use `docker compose up` with `--pull always` instead of separate `pull` and `up` invocations.
- Adjust the standard `up` command to use `--pull missing` to fetch only missing images.