### PR TITLE
Fix migration from older config files

### DIFF
--- a/includes/global_variables.sh
+++ b/includes/global_variables.sh
@@ -57,22 +57,22 @@ for Folder in "${FolderList[@]}"; do
 done
 
 declare -rgx TIMESTAMPS_FOLDER="${APPLICATION_STATE_FOLDER}/${TIMESTAMPS_FOLDER_NAME}"
-if [[ -d ${SCRIPTPATH}/compose/${TIMESTAMPS_FOLDER_NAME} ]]; then
+if [[ -d ${SCRIPTPATH}/compose/.timestamps ]]; then
 	# Migrate old timestamps folder
 	if [[ ! -d ${TIMESTAMPS_FOLDER} ]]; then
-		mv "${SCRIPTPATH}/compose/${TIMESTAMPS_FOLDER_NAME}" "${TIMESTAMPS_FOLDER}" || true
+		mv "${SCRIPTPATH}/compose/.timestamps" "${TIMESTAMPS_FOLDER}" || true
 	else
-		rm -rf "${SCRIPTPATH}/compose/${TIMESTAMPS_FOLDER_NAME}" || true
+		rm -rf "${SCRIPTPATH}/compose/.timestamps" || true
 	fi
 fi
 
 declare -gx INSTANCES_FOLDER="${APPLICATION_STATE_FOLDER}/${INSTANCES_FOLDER_NAME}"
-if [[ -d ${SCRIPTPATH}/compose/${INSTANCES_FOLDER_NAME} ]]; then
+if [[ -d ${SCRIPTPATH}/compose/.instances ]]; then
 	# Migrate old instances folder
 	if [[ ! -d ${INSTANCES_FOLDER} ]]; then
-		mv "${SCRIPTPATH}/compose/${INSTANCES_FOLDER_NAME}" "${INSTANCES_FOLDER}" || true
+		mv "${SCRIPTPATH}/compose/.instances" "${INSTANCES_FOLDER}" || true
 	else
-		rm -rf "${SCRIPTPATH}/compose/${INSTANCES_FOLDER_NAME}" || true
+		rm -rf "${SCRIPTPATH}/compose/.instances" || true
 	fi
 fi
 

--- a/scripts/config_create.sh
+++ b/scripts/config_create.sh
@@ -40,55 +40,74 @@ config_create() {
 
 	if [[ -f ${APPLICATION_INI_FILE} ]]; then
 		# Migrate from INI to TOML
+		notice "Migrating '{{|File|}}${APPLICATION_INI_FILE}{{[-]}}' to '{{|File|}}${APPLICATION_TOML_FILE}{{[-]}}'."
 
-		ConfigFolder="$(run_script 'config_get' ConfigFolder)"
-		[[ -z ${ConfigFolder-} ]] && ConfigFolder="$(run_script 'config_get' ConfigFolder "${DEFAULT_INI_FILE}")"
+		cp "${DEFAULT_TOML_FILE}" "${APPLICATION_TOML_FILE}" ||
+			fatal \
+				"Failed to copy default config file." \
+				"Failing command: {{|FailingCommand|}}cp \"${DEFAULT_TOML_FILE}\" \"${APPLICATION_TOML_FILE}\""
+		run_script 'set_permissions' "${APPLICATION_TOML_FILE}"
 
-		ComposeFolder="$(run_script 'config_get' ComposeFolder)"
-		[[ -z ${ComposeFolder-} ]] && ComposeFolder="$(run_script 'config_get' ComposeFolder "${DEFAULT_INI_FILE}")"
+		if run_script 'env_var_exists' ConfigFolder "${APPLICATION_INI_FILE}"; then
+			ConfigFolder="$(run_script 'config_get' ConfigFolder "${APPLICATION_INI_FILE}")"
+			set_toml_val "${APPLICATION_TOML_FILE}" paths.config_folder "${ConfigFolder}"
+		fi
 
-		Theme="$(run_script 'config_get' Theme)"
-		[[ -z ${Theme-} ]] && Theme="$(run_script 'config_get' Theme "${DEFAULT_INI_FILE}")"
+		if run_script 'env_var_exists' ComposeFolder "${APPLICATION_INI_FILE}"; then
+			ComposeFolder="$(run_script 'config_get' ComposeFolder "${APPLICATION_INI_FILE}")"
+			set_toml_val "${APPLICATION_TOML_FILE}" paths.compose_folder "${ComposeFolder}"
+		fi
+
+		if run_script 'env_var_exists' Theme "${APPLICATION_INI_FILE}"; then
+			Theme="$(run_script 'config_get' Theme "${APPLICATION_INI_FILE}")"
+			set_toml_val "${APPLICATION_TOML_FILE}" ui.theme "${Theme}"
+		fi
+
+		if run_script 'env_var_exists' PackageManager "${APPLICATION_INI_FILE}"; then
+			PackageManager="$(run_script 'config_get' PackageManager "${APPLICATION_INI_FILE}")"
+			set_toml_val "${APPLICATION_TOML_FILE}" pm.package_manager "${PackageManager}"
+		fi
 
 		# Handle old installs where LineCharacters was used in place of Borders
 		if run_script 'env_var_exists' Borders "${APPLICATION_INI_FILE}"; then
-			Borders="$(run_script 'config_get' Borders)"
+			Borders="$(run_script 'config_get' Borders "${APPLICATION_INI_FILE}")"
+			is_true "${Borders}" && Borders="true" || Borders="false"
+			set_toml_val "${APPLICATION_TOML_FILE}" ui.borders "${Borders}"
 		elif run_script 'env_var_exists' LineCharacters "${APPLICATION_INI_FILE}"; then
-			Borders="$(run_script 'config_get' LineCharacters)"
-		else
-			Borders="$(run_script 'config_get' Borders "${DEFAULT_INI_FILE}")"
+			Borders="$(run_script 'config_get' LineCharacters "${APPLICATION_INI_FILE}")"
+			is_true "${Borders}" && Borders="true" || Borders="false"
+			set_toml_val "${APPLICATION_TOML_FILE}" ui.borders "${Borders}"
 		fi
-		is_true "${Borders}" && Borders="true" || Borders="false"
 
 		if run_script 'env_var_exists' LineCharacters "${APPLICATION_INI_FILE}"; then
-			LineCharacters="$(run_script 'config_get' LineCharacters)"
-		else
-			LineCharacters="$(run_script 'config_get' LineCharacters "${DEFAULT_INI_FILE}")"
+			LineCharacters="$(run_script 'config_get' LineCharacters "${APPLICATION_INI_FILE}")"
+			is_true "${LineCharacters}" && LineCharacters="true" || LineCharacters="false"
+			set_toml_val "${APPLICATION_TOML_FILE}" ui.line_characters "${LineCharacters}"
 		fi
-		is_true "${LineCharacters}" && LineCharacters="true" || LineCharacters="false"
 
-		Scrollbar="$(run_script 'config_get' Scrollbar)"
-		[[ -z ${Scrollbar-} ]] && Scrollbar="$(run_script 'config_get' Scrollbar "${DEFAULT_INI_FILE}")"
-		is_true "${Scrollbar}" && Scrollbar="true" || Scrollbar="false"
+		if run_script 'env_var_exists' Scrollbar "${APPLICATION_INI_FILE}"; then
+			Scrollbar="$(run_script 'config_get' Scrollbar "${APPLICATION_INI_FILE}")"
+			is_true "${Scrollbar}" && Scrollbar="true" || Scrollbar="false"
+			set_toml_val "${APPLICATION_TOML_FILE}" ui.scrollbar "${Scrollbar}"
+		elif run_script 'env_var_exists' Scrollbars "${APPLICATION_INI_FILE}"; then
+			Scrollbar="$(run_script 'config_get' Scrollbars "${APPLICATION_INI_FILE}")"
+			is_true "${Scrollbar}" && Scrollbar="true" || Scrollbar="false"
+			set_toml_val "${APPLICATION_TOML_FILE}" ui.scrollbar "${Scrollbar}"
+		fi
 
-		Shadow="$(run_script 'config_get' Shadow)"
-		[[ -z ${Shadow-} ]] && Shadow="$(run_script 'config_get' Shadow "${DEFAULT_INI_FILE}")"
-		is_true "${Shadow}" && Shadow="true" || Shadow="false"
+		if run_script 'env_var_exists' Shadow "${APPLICATION_INI_FILE}"; then
+			Shadow="$(run_script 'config_get' Shadow "${APPLICATION_INI_FILE}")"
+			is_true "${Shadow}" && Shadow="true" || Shadow="false"
+			set_toml_val "${APPLICATION_TOML_FILE}" ui.shadow "${Shadow}"
+		elif run_script 'env_var_exists' Shadows "${APPLICATION_INI_FILE}"; then
+			Shadow="$(run_script 'config_get' Shadows "${APPLICATION_INI_FILE}")"
+			is_true "${Shadow}" && Shadow="true" || Shadow="false"
+			set_toml_val "${APPLICATION_TOML_FILE}" ui.shadow "${Shadow}"
+		fi
 
-		PackageManager="$(run_script 'config_get' PackageManager)"
-
-		notice "Migrating '{{|File|}}${APPLICATION_INI_FILE}{{[-]}}' to '{{|File|}}${APPLICATION_TOML_FILE}{{[-]}}'."
-
-		set_toml_val "${APPLICATION_TOML_FILE}" "paths.config_folder" "${ConfigFolder}"
-		set_toml_val "${APPLICATION_TOML_FILE}" "paths.compose_folder" "${ComposeFolder}"
-		set_toml_val "${APPLICATION_TOML_FILE}" "ui.theme" "${Theme}"
-		set_toml_val "${APPLICATION_TOML_FILE}" "ui.borders" "${Borders}"
-		set_toml_val "${APPLICATION_TOML_FILE}" "ui.line_characters" "${LineCharacters}"
-		set_toml_val "${APPLICATION_TOML_FILE}" "ui.scrollbar" "${Scrollbar}"
-		set_toml_val "${APPLICATION_TOML_FILE}" "ui.shadow" "${Shadow}"
-		set_toml_val "${APPLICATION_TOML_FILE}" "pm.package_manager" "${PackageManager}"
-
-		run_script 'set_permissions' "${APPLICATION_TOML_FILE}"
+		if [[ -z ${ComposeFolder-} ]]; then
+			detect_compose_folder
+		fi
 	else
 		# Fresh install: copy the default TOML file
 		notice "Copying '{{|File|}}${DEFAULT_TOML_FILE}{{[-]}}' to '{{|File|}}${APPLICATION_TOML_FILE}{{[-]}}'."
@@ -98,60 +117,66 @@ config_create() {
 				"Failing command: {{|FailingCommand|}}cp \"${DEFAULT_TOML_FILE}\" \"${APPLICATION_TOML_FILE}\""
 		run_script 'set_permissions' "${APPLICATION_TOML_FILE}"
 
-		# Check for a legacy compose folder and update ComposeFolder if needed
-		ConfigFolder="$(get_toml_val "${APPLICATION_TOML_FILE}" "paths.config_folder")"
-		local -a ExpandVarList=(
-			ScriptFolder "${SCRIPTPATH}"
-			XDG_CONFIG_HOME "${XDG_CONFIG_HOME}"
-			HOME "${DETECTED_HOMEDIR}"
-		)
-		local ExpandedConfigFolder
-		ExpandedConfigFolder="$(expand_vars "${ConfigFolder}" "${ExpandVarList[@]}")"
-		ExpandVarList=(
-			DOCKER_CONFIG_FOLDER "${ExpandedConfigFolder}"
-			"${ExpandVarList[@]}"
-		)
-
-		# shellcheck disable=SC2016 # Expressions don't expand in single quotes, use double quotes for that.
-		local LegacyComposeFolder='${ScriptFolder}/compose'
-		local ExpandedLegacyComposeFolder
-		ExpandedLegacyComposeFolder="$(expand_vars "${LegacyComposeFolder}" "${ExpandVarList[@]}")"
-
-		local LegacyHasFiles=false
-		if [[ -d ${ExpandedLegacyComposeFolder} ]] && ! folder_is_empty "${ExpandedLegacyComposeFolder}"; then
-			LegacyHasFiles=true
-		fi
-
-		local DefaultComposeFolder
-		DefaultComposeFolder="$(get_toml_val "${APPLICATION_TOML_FILE}" "paths.compose_folder")"
-		local ExpandedDefaultComposeFolder
-		ExpandedDefaultComposeFolder="$(expand_vars "${DefaultComposeFolder}" "${ExpandVarList[@]}")"
-
-		local DefaultHasFiles=false
-		if [[ -d ${ExpandedDefaultComposeFolder} ]] && ! folder_is_empty "${ExpandedDefaultComposeFolder}"; then
-			DefaultHasFiles=true
-		fi
-
-		if [[ ${LegacyHasFiles} == true ]] && [[ ${DefaultHasFiles} == true ]] && [[ ${ExpandedLegacyComposeFolder} != "${ExpandedDefaultComposeFolder}" ]]; then
-			local PromptMessage="Existing docker compose folders found in multiple locations.\n   Legacy:  '{{|Folder|}}${ExpandedLegacyComposeFolder}{{[-]}}'\n   Default: '{{|Folder|}}${ExpandedDefaultComposeFolder}{{[-]}}'\n\nWould you like to use the Legacy location?"
-			if run_script 'question_prompt' "Y" "${PromptMessage}" "Multiple Compose Folders Detected" "" "Legacy" "Default"; then
-				notice \
-					"Chose the Legacy compose folder location:" \
-					"   '{{|Folder|}}${ExpandedLegacyComposeFolder}{{[-]}}'"
-				set_toml_val "${APPLICATION_TOML_FILE}" "paths.compose_folder" "${LegacyComposeFolder}"
-			else
-				notice \
-					"Chose the Default compose folder location:" \
-					"   '{{|Folder|}}${ExpandedDefaultComposeFolder}{{[-]}}'"
-			fi
-		elif [[ ${LegacyHasFiles} == true ]]; then
-			set_toml_val "${APPLICATION_TOML_FILE}" "paths.compose_folder" "${LegacyComposeFolder}"
-		fi
+		detect_compose_folder
 	fi
 
 	notice ""
 	notice "$(run_script 'config_show')"
 	notice ""
+}
+
+detect_compose_folder() {
+	# Check for a legacy compose folder and update ComposeFolder if needed
+	local ConfigFolder
+	ConfigFolder="$(get_toml_val "${APPLICATION_TOML_FILE}" paths.config_folder)"
+
+	local -a ExpandVarList=(
+		ScriptFolder "${SCRIPTPATH}"
+		XDG_CONFIG_HOME "${XDG_CONFIG_HOME}"
+		HOME "${DETECTED_HOMEDIR}"
+	)
+	local ExpandedConfigFolder
+	ExpandedConfigFolder="$(expand_vars "${ConfigFolder}" "${ExpandVarList[@]}")"
+	ExpandVarList=(
+		DOCKER_CONFIG_FOLDER "${ExpandedConfigFolder}"
+		"${ExpandVarList[@]}"
+	)
+
+	# shellcheck disable=SC2016 # Expressions don't expand in single quotes, use double quotes for that.
+	local LegacyComposeFolder='${ScriptFolder}/compose'
+	local ExpandedLegacyComposeFolder
+	ExpandedLegacyComposeFolder="$(expand_vars "${LegacyComposeFolder}" "${ExpandVarList[@]}")"
+
+	local LegacyHasFiles=false
+	if [[ -d ${ExpandedLegacyComposeFolder} ]] && ! folder_is_empty "${ExpandedLegacyComposeFolder}"; then
+		LegacyHasFiles=true
+	fi
+
+	local DefaultComposeFolder
+	DefaultComposeFolder="$(get_toml_val "${APPLICATION_TOML_FILE}" paths.compose_folder)"
+	local ExpandedDefaultComposeFolder
+	ExpandedDefaultComposeFolder="$(expand_vars "${DefaultComposeFolder}" "${ExpandVarList[@]}")"
+
+	local DefaultHasFiles=false
+	if [[ -d ${ExpandedDefaultComposeFolder} ]] && ! folder_is_empty "${ExpandedDefaultComposeFolder}"; then
+		DefaultHasFiles=true
+	fi
+
+	if [[ ${LegacyHasFiles} == true ]] && [[ ${DefaultHasFiles} == true ]] && [[ ${ExpandedLegacyComposeFolder} != "${ExpandedDefaultComposeFolder}" ]]; then
+		local PromptMessage="Existing docker compose folders found in multiple locations.\n   Legacy:  '{{|Folder|}}${ExpandedLegacyComposeFolder}{{[-]}}'\n   Default: '{{|Folder|}}${ExpandedDefaultComposeFolder}{{[-]}}'\n\nWould you like to use the Legacy location?"
+		if run_script 'question_prompt' "Y" "${PromptMessage}" "Multiple Compose Folders Detected" "" "Legacy" "Default"; then
+			notice \
+				"Chose the Legacy compose folder location:" \
+				"   '{{|Folder|}}${ExpandedLegacyComposeFolder}{{[-]}}'"
+			set_toml_val "${APPLICATION_TOML_FILE}" paths.compose_folder "${LegacyComposeFolder}"
+		else
+			notice \
+				"Chose the Default compose folder location:" \
+				"   '{{|Folder|}}${ExpandedDefaultComposeFolder}{{[-]}}'"
+		fi
+	elif [[ ${LegacyHasFiles} == true ]]; then
+		set_toml_val "${APPLICATION_TOML_FILE}" paths.compose_folder "${LegacyComposeFolder}"
+	fi
 }
 
 test_config_create() {


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Improve configuration migration from legacy INI-based setups to TOML and centralize compose folder detection logic.

Bug Fixes:
- Correctly migrate settings from existing INI files only when keys are present, including legacy alternatives for UI and compose-related options.
- Fix migration paths for legacy timestamps and instances directories under the compose folder.

Enhancements:
- Initialize new TOML configs from the default template before migrating values during INI-to-TOML conversion.
- Extract compose folder detection and legacy-folder resolution into a reusable detect_compose_folder function used on both migrated and fresh installs.