### PR TITLE
Create and use `string_to_bool` to normalize strings to `true` or `false`

### DIFF
--- a/includes/misc_functions.sh
+++ b/includes/misc_functions.sh
@@ -84,6 +84,10 @@ is_false() {
 	! is_true "${1-}"
 }
 
+string_to_bool() {
+	is_true "${1-}" && echo "true" || echo "false"
+}
+
 folder_is_empty() {
 	local dir=${1}
 	(

--- a/scripts/config_create.sh
+++ b/scripts/config_create.sh
@@ -70,38 +70,31 @@ config_create() {
 
 		# Handle old installs where LineCharacters was used in place of Borders
 		if run_script 'env_var_exists' Borders "${APPLICATION_INI_FILE}"; then
-			Borders="$(run_script 'config_get' Borders "${APPLICATION_INI_FILE}")"
-			is_true "${Borders}" && Borders="true" || Borders="false"
+			Borders=$(string_to_bool "$(run_script 'config_get' Borders "${APPLICATION_INI_FILE}")")
 			set_toml_val "${APPLICATION_TOML_FILE}" ui.borders "${Borders}"
 		elif run_script 'env_var_exists' LineCharacters "${APPLICATION_INI_FILE}"; then
-			Borders="$(run_script 'config_get' LineCharacters "${APPLICATION_INI_FILE}")"
-			is_true "${Borders}" && Borders="true" || Borders="false"
+			Borders=$(string_to_bool "$(run_script 'config_get' LineCharacters "${APPLICATION_INI_FILE}")")
 			set_toml_val "${APPLICATION_TOML_FILE}" ui.borders "${Borders}"
 		fi
 
 		if run_script 'env_var_exists' LineCharacters "${APPLICATION_INI_FILE}"; then
-			LineCharacters="$(run_script 'config_get' LineCharacters "${APPLICATION_INI_FILE}")"
-			is_true "${LineCharacters}" && LineCharacters="true" || LineCharacters="false"
+			LineCharacters=$(string_to_bool "$(run_script 'config_get' LineCharacters "${APPLICATION_INI_FILE}")")
 			set_toml_val "${APPLICATION_TOML_FILE}" ui.line_characters "${LineCharacters}"
 		fi
 
 		if run_script 'env_var_exists' Scrollbar "${APPLICATION_INI_FILE}"; then
-			Scrollbar="$(run_script 'config_get' Scrollbar "${APPLICATION_INI_FILE}")"
-			is_true "${Scrollbar}" && Scrollbar="true" || Scrollbar="false"
+			Scrollbar=$(string_to_bool "$(run_script 'config_get' Scrollbar "${APPLICATION_INI_FILE}")")
 			set_toml_val "${APPLICATION_TOML_FILE}" ui.scrollbar "${Scrollbar}"
 		elif run_script 'env_var_exists' Scrollbars "${APPLICATION_INI_FILE}"; then
-			Scrollbar="$(run_script 'config_get' Scrollbars "${APPLICATION_INI_FILE}")"
-			is_true "${Scrollbar}" && Scrollbar="true" || Scrollbar="false"
+			Scrollbar=$(string_to_bool "$(run_script 'config_get' Scrollbars "${APPLICATION_INI_FILE}")")
 			set_toml_val "${APPLICATION_TOML_FILE}" ui.scrollbar "${Scrollbar}"
 		fi
 
 		if run_script 'env_var_exists' Shadow "${APPLICATION_INI_FILE}"; then
-			Shadow="$(run_script 'config_get' Shadow "${APPLICATION_INI_FILE}")"
-			is_true "${Shadow}" && Shadow="true" || Shadow="false"
+			Shadow=$(string_to_bool "$(run_script 'config_get' Shadow "${APPLICATION_INI_FILE}")")
 			set_toml_val "${APPLICATION_TOML_FILE}" ui.shadow "${Shadow}"
 		elif run_script 'env_var_exists' Shadows "${APPLICATION_INI_FILE}"; then
-			Shadow="$(run_script 'config_get' Shadows "${APPLICATION_INI_FILE}")"
-			is_true "${Shadow}" && Shadow="true" || Shadow="false"
+			Shadow=$(string_to_bool "$(run_script 'config_get' Shadows "${APPLICATION_INI_FILE}")")
 			set_toml_val "${APPLICATION_TOML_FILE}" ui.shadow "${Shadow}"
 		fi
 


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Normalize configuration boolean values using a shared helper to convert strings to explicit "true"/"false" values.

Enhancements:
- Introduce a reusable string_to_bool helper to consistently map truthy/falsy strings to canonical boolean strings.
- Update config creation logic to use the new helper for UI-related options (borders, line characters, scrollbars, shadows).