### PR TITLE
Fix migration of ui.borders for very old INI files

### DIFF
--- a/scripts/config_create.sh
+++ b/scripts/config_create.sh
@@ -54,8 +54,6 @@ config_create() {
 		)
 
 		local -A TOMLtoINIMap_booleans=(
-			["ui.borders"]="Borders:LineCharacters"
-			["ui.line_characters"]="LineCharacters"
 			["ui.scrollbar"]="Scrollbar:Scrollbars"
 			["ui.shadow"]="Shadow:Shadows"
 		)
@@ -76,6 +74,25 @@ config_create() {
 					"$(run_script 'config_get' "${TOMLtoINIMap_strings["${Key}"]}" "${APPLICATION_INI_FILE}")"
 			fi
 		done
+
+		# Migrate LineCharacters to ui.borders if Borders doesn't exist (old INI settings)
+		if run_script 'env_var_exists' Borders "${APPLICATION_INI_FILE}"; then
+			set_toml_val \
+				"${APPLICATION_TOML_FILE}" \
+				ui.borders \
+				"$(string_to_bool "$(run_script 'config_get' Borders "${APPLICATION_INI_FILE}")")"
+			if run_script 'env_var_exists' LineCharacters "${APPLICATION_INI_FILE}"; then
+				set_toml_val \
+					"${APPLICATION_TOML_FILE}" \
+					ui.line_characters \
+					"$(string_to_bool "$(run_script 'config_get' LineCharacters "${APPLICATION_INI_FILE}")")"
+			fi
+		elif run_script 'env_var_exists' LineCharacters "${APPLICATION_INI_FILE}"; then
+			set_toml_val \
+				"${APPLICATION_TOML_FILE}" \
+				ui.borders \
+				"$(string_to_bool "$(run_script 'config_get' LineCharacters "${APPLICATION_INI_FILE}")")"
+		fi
 
 		for Key in "${!TOMLtoINIMap_booleans[@]}"; do
 			local VarList


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Bug Fixes:
- Correctly map legacy Borders and LineCharacters INI settings to ui.borders and ui.line_characters TOML keys for very old configuration files.