### PR TITLE
Re-work config file reading and writing

### DIFF
--- a/includes/cmdline.sh
+++ b/includes/cmdline.sh
@@ -606,14 +606,14 @@ run_command() {
 	)
 
 	CommandConfigVar+=(
-		["--theme-shadows"]="shadow"
-		["--theme-no-shadows"]="shadow"
-		["--theme-scrollbar"]="scrollbar"
-		["--theme-no-scrollbar"]="scrollbar"
-		["--theme-lines"]="line_characters"
-		["--theme-no-lines"]="line_characters"
-		["--theme-borders"]="borders"
-		["--theme-no-borders"]="borders"
+		["--theme-shadows"]="ui.shadow"
+		["--theme-no-shadows"]="ui.shadow"
+		["--theme-scrollbar"]="ui.scrollbar"
+		["--theme-no-scrollbar"]="ui.scrollbar"
+		["--theme-lines"]="ui.line_characters"
+		["--theme-no-lines"]="ui.line_characters"
+		["--theme-borders"]="ui.borders"
+		["--theme-no-borders"]="ui.borders"
 	)
 
 	CommandConfigValue=(
@@ -939,7 +939,7 @@ run_command() {
 				notice \
 					"${Notice}"
 			fi
-			set_toml_val "${APPLICATION_TOML_FILE}" "ui.${ConfigVar}" "${ConfigValue}" || result=$?
+			run_script 'config_set' "${ConfigVar}" "${ConfigValue}" || result=$?
 			if use_dialog_box; then
 				run_script 'menu_dialog_example' "${Title}" "${CURRENT_COMMANDLINE}"
 			fi

--- a/includes/dialog_functions.sh
+++ b/includes/dialog_functions.sh
@@ -150,7 +150,20 @@ _dialog_() {
 
 # Check to see if we should use a dialog box
 use_dialog_box() {
-	[[ ${PROMPT:-CLI} == GUI && -t 1 && -t 2 ]]
+	# Not in GUI mode? Definitely NO.
+	[[ ${PROMPT:-CLI} != GUI ]] && return 1
+	# Are we ready to start a new one? (Both stdout/stderr are TTYs)
+	if [[ -t 1 && -t 2 ]]; then
+		return 0
+	fi
+	# Otherwise (like a notice capture where only stdout is redirected), return NO.
+	return 1
+}
+
+in_dialog_box() {
+	# If we are in GUI mode, AND stdout is redirected, AND stderr is ALSO redirected
+	# then we are almost certainly inside a '|& dialog_pipe' call.
+	[[ ${PROMPT:-CLI} == GUI && ! -t 1 && ! -t 2 ]]
 }
 
 # Pipe to Dialog Box Function
@@ -175,7 +188,7 @@ run_script_dialog() {
 	local TimeOut=${3:-0}
 	local SCRIPTSNAME=${4-}
 	shift 4
-	if use_dialog_box; then
+	if use_dialog_box && ! in_dialog_box; then
 		# Using the GUI, pipe output to a dialog box
 		coproc {
 			dialog_pipe "${Title}" "${SubTitle}" "${TimeOut}"

--- a/includes/misc_functions.sh
+++ b/includes/misc_functions.sh
@@ -285,21 +285,7 @@ table_pipe() {
 	readarray -t ColWidths < <(longest_columns "${Cols}" "${VisibleData[@]}")
 
 	local -A CharSet
-	if is_true "${D["LineCharacters"]-}"; then
-		CharSet=(
-			["TopLeft"]="┌"
-			["TopRight"]="┐"
-			["BottomLeft"]="└"
-			["BottomRight"]="┘"
-			["Horizontal"]="─"
-			["Vertical"]="│"
-			["Cross"]="┼"
-			["TLeft"]="├"
-			["TRight"]="┤"
-			["TTop"]="┬"
-			["TBottom"]="┴"
-		)
-	else
+	if is_false "${D["LineCharacters"]-}" || in_dialog_box; then
 		CharSet=(
 			["TopLeft"]="+"
 			["TopRight"]="+"
@@ -312,6 +298,20 @@ table_pipe() {
 			["TRight"]="|"
 			["TTop"]="-"
 			["TBottom"]="-"
+		)
+	else
+		CharSet=(
+			["TopLeft"]="┌"
+			["TopRight"]="┐"
+			["BottomLeft"]="└"
+			["BottomRight"]="┘"
+			["Horizontal"]="─"
+			["Vertical"]="│"
+			["Cross"]="┼"
+			["TLeft"]="├"
+			["TRight"]="┤"
+			["TTop"]="┬"
+			["TBottom"]="┴"
 		)
 	fi
 
@@ -376,7 +376,13 @@ table() {
 	shift
 	local -a Headings=("${@:1:Cols}")
 	local -a Data=("${@:Cols+1}")
-	printf '%s\n' "${Data[@]}" | table_pipe "${Cols}" "${Headings[@]}" | resolve_strings C
+	if use_dialog_box || [[ -t 1 ]]; then
+		printf '%s\n' "${Data[@]}" | table_pipe "${Cols}" "${Headings[@]}" | resolve_strings C
+	else
+		# Captured/Piped call: Output RAW TAGS
+		# (This lets notice handle the resolution later)
+		printf '%s\n' "${Data[@]}" | table_pipe "${Cols}" "${Headings[@]}"
+	fi
 }
 
 wordwrap_pipe() {
@@ -444,7 +450,90 @@ get_toml_val() {
 			return 0
 		fi
 	done < "${file}"
+
+	# Key or section not found
+	return 1
+}
+
+get_ini_val() {
+	# get_ini_val VarFile VarName
+	local ConfigFile=${1-}
+	local VarName=${2-}
+
+	if [[ -z ${VarName} || -z ${ConfigFile} || ! -f ${ConfigFile} ]]; then
+		# VarName or ConfigFile empty strings, or ConfigFile does not exist, return
+		return 1
+	fi
+
+	local Line
+	local Val=""
+	local Found=false
+	while IFS= read -r Line || [[ -n ${Line} ]]; do
+		# Skip comments and empty lines
+		[[ ${Line} =~ ^[[:space:]]*# ]] && continue
+		[[ -z ${Line} ]] && continue
+
+		# Check if line contains Key=Value
+		if [[ ${Line} =~ ^[[:space:]]*${VarName}[[:space:]]*= ]]; then
+			# Extract Key and Value
+			local Key="${Line%%=*}"
+			local Value="${Line#*=}"
+
+			# Trim whitespace from Key
+			Key="${Key#"${Key%%[![:space:]]*}"}"
+			Key="${Key%"${Key##*[![:space:]]}"}"
+
+			# Check if this is the requested key
+			if [[ ${Key} == "${VarName}" ]]; then
+				Val="${Value}"
+				Found=true
+				# Keep reading to get the last occurrence (tail -1 behavior)
+			fi
+		fi
+	done < "${ConfigFile}"
+
+	if [[ ${Found} == false ]]; then
+		# Key was not found in the config file
+		return 1
+	fi
+
+	# Trim leading whitespace
+	Val="${Val#"${Val%%[![:space:]]*}"}"
+	# Trim trailing whitespace
+	Val="${Val%"${Val##*[![:space:]]}"}"
+
+	# Strip single quotes if present on both ends
+	if [[ ${Val} == \'*\' ]]; then
+		Val="${Val#\'}"
+		Val="${Val%\'}"
+	# Strip double quotes if present on both ends
+	elif [[ ${Val} == \"*\" ]]; then
+		Val="${Val#\"}"
+		Val="${Val%\"}"
+	fi
+
+	printf '%s\n' "${Val}"
 	return 0
+}
+
+get_ini_val_string() {
+	get_ini_val "$@"
+}
+
+get_ini_val_bool() {
+	# get_ini_val_bool FILE KEY
+	# Returns the value of KEY in FILE, normalized to "true" or "false".
+	local file=${1-}
+	local key=${2-}
+
+	local Value
+	if Value="$(get_ini_val "${file}" "${key}")"; then
+		string_to_bool "${Value}"
+		return 0
+	fi
+
+	# Key not found
+	return 1
 }
 
 set_toml_val() {
@@ -525,7 +614,14 @@ get_toml_val_string() {
 	# Returns the value of KEY within [SECTION] in FILE.
 	local file=${1-}
 	local section_key="${2-}"
-	get_toml_val "${file}" "${section_key}"
+	local Value
+	if Value="$(get_toml_val "${file}" "${section_key}")"; then
+		printf '%s\n' "${Value}"
+		return 0
+	fi
+
+	# Key or section not found
+	return 1
 }
 
 set_toml_val_string() {
@@ -555,7 +651,14 @@ get_toml_val_bool() {
 	local file=${1-}
 	local section_key="${2-}"
 
-	string_to_bool "$(get_toml_val "${file}" "${section_key}")"
+	local Value
+	if Value="$(get_toml_val "${file}" "${section_key}")"; then
+		string_to_bool "${Value}"
+		return 0
+	fi
+
+	# Key or section not found
+	return 1
 }
 
 set_toml_val_bool() {
@@ -575,7 +678,14 @@ get_toml_val_int() {
 	local file=${1-}
 	local section_key="${2-}"
 
-	string_to_int "$(get_toml_val "${file}" "${section_key}")"
+	local Value
+	if Value="$(get_toml_val "${file}" "${section_key}")"; then
+		string_to_int "${Value}"
+		return 0
+	fi
+
+	# Key or section not found
+	return 1
 }
 
 set_toml_val_int() {

--- a/scripts/apply_config.sh
+++ b/scripts/apply_config.sh
@@ -3,12 +3,15 @@ set -Eeuo pipefail
 IFS=$'\n\t'
 
 apply_config() {
-	run_script 'config_create'
+	if [[ ! -f ${APPLICATION_TOML_FILE} ]]; then
+		run_script 'config_create'
+		return
+	fi
 
 	#shellcheck disable=SC2034 # (warning): LITERAL_CONFIG_FOLDER appears unused. Verify use (or export if used externally).
-	LITERAL_CONFIG_FOLDER="$(get_toml_val_string "${APPLICATION_TOML_FILE}" "paths.config_folder")"
+	LITERAL_CONFIG_FOLDER="$(run_script 'config_get' paths.config_folder)"
 	#shellcheck disable=SC2034 # (warning): LITERAL_COMPOSE_FOLDER appears unused. Verify use (or export if used externally).
-	LITERAL_COMPOSE_FOLDER="$(get_toml_val_string "${APPLICATION_TOML_FILE}" "paths.compose_folder")"
+	LITERAL_COMPOSE_FOLDER="$(run_script 'config_get' paths.compose_folder)"
 	set_global_variables
 	run_script 'config_theme'
 	run_script 'config_package_manager'

--- a/scripts/config_create.sh
+++ b/scripts/config_create.sh
@@ -3,7 +3,6 @@ set -Eeuo pipefail
 IFS=$'\n\t'
 
 config_create() {
-
 	# Early return if the TOML config already exists
 	if [[ -f ${APPLICATION_TOML_FILE} ]]; then
 		return 0
@@ -20,92 +19,63 @@ config_create() {
 
 	local ComposeFolderFound=false
 	# Handle legacy config files
-	if [[ -f ${SCRIPTPATH}/${APPLICATION_INI_NAME} || -f ${SCRIPTPATH}/menu.ini || -f ${XDG_CONFIG_HOME}/${APPLICATION_INI_NAME} ]]; then
-		for LegacyIniFile in "${XDG_CONFIG_HOME}/${APPLICATION_INI_NAME}" "${SCRIPTPATH}/${APPLICATION_INI_NAME}" "${SCRIPTPATH}/menu.ini"; do
-			if [[ -f ${LegacyIniFile} ]]; then
-				if [[ ${LegacyIniFile} == "${APPLICATION_INI_FILE}" ]]; then
-					continue
-				fi
-				notice "Renaming '{{|File|}}${LegacyIniFile}{{[-]}}' to '{{|File|}}${APPLICATION_INI_FILE}{{[-]}}'."
-				mv "${LegacyIniFile}" "${APPLICATION_INI_FILE}" ||
-					fatal \
-						"Failed to rename old config file." \
-						"Failing command: {{|FailingCommand|}}mv \"${LegacyIniFile}\" \"${APPLICATION_INI_FILE}\""
-				break
-			fi
-		done
-		run_script 'set_permissions' "${APPLICATION_INI_FILE}"
+	local -a LegacyIniFiles=(
+		"${APPLICATION_INI_FILE}"
+		"${XDG_CONFIG_HOME}/${APPLICATION_INI_NAME}"
+		"${SCRIPTPATH}/${APPLICATION_INI_NAME}"
+		"${SCRIPTPATH}/menu.ini"
+	)
+	local LegacyIniFile=""
+	for CheckLegacyIniFile in "${LegacyIniFiles[@]}"; do
+		if [[ -f ${CheckLegacyIniFile} ]]; then
+			LegacyIniFile="${CheckLegacyIniFile}"
+			break
+		fi
+	done
+	if [[ -n ${LegacyIniFile} ]]; then
+		# Display the configuration options in the old config file
+		notice "Migrating '{{|File|}}${LegacyIniFile}{{[-]}}' to '{{|File|}}${APPLICATION_TOML_FILE}{{[-]}}'."
+		local Heading="Configuration options in old config file '{{|File|}}${LegacyIniFile}{{[-]}}':"
+		notice ""
+		notice "$(run_script 'config_show' "${LegacyIniFile}" "${Heading}")"
+		notice ""
+		if [[ ${LegacyIniFile} != "${APPLICATION_INI_FILE}" ]]; then
+			# Move the found legacy config file to the standard location
+			notice "Renaming '{{|File|}}${LegacyIniFile}{{[-]}}' to '{{|File|}}${APPLICATION_INI_FILE}{{[-]}}'."
+			mv "${LegacyIniFile}" "${APPLICATION_INI_FILE}" ||
+				fatal \
+					"Failed to rename old config file." \
+					"Failing command: {{|FailingCommand|}}mv \"${LegacyIniFile}\" \"${APPLICATION_INI_FILE}\""
+			run_script 'set_permissions' "${APPLICATION_INI_FILE}"
+		fi
 	fi
-
 	if [[ -f ${APPLICATION_INI_FILE} ]]; then
-		# Migrate from INI to TOML
-		notice "Migrating '{{|File|}}${APPLICATION_INI_FILE}{{[-]}}' to '{{|File|}}${APPLICATION_TOML_FILE}{{[-]}}'."
-
 		cp "${DEFAULT_TOML_FILE}" "${APPLICATION_TOML_FILE}" ||
 			fatal \
 				"Failed to copy default config file." \
 				"Failing command: {{|FailingCommand|}}cp \"${DEFAULT_TOML_FILE}\" \"${APPLICATION_TOML_FILE}\""
 		run_script 'set_permissions' "${APPLICATION_TOML_FILE}"
 
-		local -A TOMLtoINIMap_strings=(
-			["paths.config_folder"]="ConfigFolder"
-			["ui.theme"]="Theme"
-			["pm.package_manager"]="PackageManager"
+		local -a ConfigOptions=(
+			"paths.config_folder"
+			"ui.theme"
+			"pm.package_manager"
+			"ui.scrollbar"
+			"ui.shadow"
+			"ui.borders"
+			"ui.line_characters"
 		)
 
-		local -A TOMLtoINIMap_booleans=(
-			["ui.scrollbar"]="Scrollbar:Scrollbars"
-			["ui.shadow"]="Shadow:Shadows"
-		)
-
-		if run_script 'env_var_exists' ComposeFolder "${APPLICATION_INI_FILE}"; then
-			set_toml_val_string \
-				"${APPLICATION_TOML_FILE}" \
-				paths.compose_folder \
-				"$(run_script 'config_get' ComposeFolder "${APPLICATION_INI_FILE}")"
+		local Value
+		if Value=$(run_script 'config_get' paths.compose_folder "${APPLICATION_INI_FILE}"); then
+			run_script 'config_set' paths.compose_folder "${Value}"
 			ComposeFolderFound=true
 		fi
 
-		for Key in "${!TOMLtoINIMap_strings[@]}"; do
-			if run_script 'env_var_exists' "${TOMLtoINIMap_strings["${Key}"]}" "${APPLICATION_INI_FILE}"; then
-				set_toml_val_string \
-					"${APPLICATION_TOML_FILE}" \
-					"${Key}" \
-					"$(run_script 'config_get' "${TOMLtoINIMap_strings["${Key}"]}" "${APPLICATION_INI_FILE}")"
+		for Key in "${ConfigOptions[@]}"; do
+			if Value=$(run_script 'config_get' "${Key}" "${APPLICATION_INI_FILE}"); then
+				run_script 'config_set' "${Key}" "${Value}"
 			fi
-		done
-
-		# Migrate LineCharacters to ui.borders if Borders doesn't exist (old INI settings)
-		if run_script 'env_var_exists' Borders "${APPLICATION_INI_FILE}"; then
-			set_toml_val_bool \
-				"${APPLICATION_TOML_FILE}" \
-				ui.borders \
-				"$(run_script 'config_get' Borders "${APPLICATION_INI_FILE}")"
-			if run_script 'env_var_exists' LineCharacters "${APPLICATION_INI_FILE}"; then
-				set_toml_val_bool \
-					"${APPLICATION_TOML_FILE}" \
-					ui.line_characters \
-					"$(run_script 'config_get' LineCharacters "${APPLICATION_INI_FILE}")"
-			fi
-		elif run_script 'env_var_exists' LineCharacters "${APPLICATION_INI_FILE}"; then
-			set_toml_val_bool \
-				"${APPLICATION_TOML_FILE}" \
-				ui.borders \
-				"$(run_script 'config_get' LineCharacters "${APPLICATION_INI_FILE}")"
-		fi
-
-		for Key in "${!TOMLtoINIMap_booleans[@]}"; do
-			local VarList
-			VarList="${TOMLtoINIMap_booleans["${Key}"]}"
-			for Val in ${VarList//:/ }; do
-				if run_script 'env_var_exists' "${Val}" "${APPLICATION_INI_FILE}"; then
-					set_toml_val_bool \
-						"${APPLICATION_TOML_FILE}" \
-						"${Key}" \
-						"$(run_script 'config_get' "${Val}" "${APPLICATION_INI_FILE}")"
-					break
-				fi
-			done
 		done
 	else
 		# Fresh install: copy the default TOML file
@@ -121,6 +91,8 @@ config_create() {
 		detect_compose_folder
 	fi
 
+	run_script 'apply_config'
+
 	notice ""
 	notice "$(run_script 'config_show')"
 	notice ""
@@ -129,7 +101,7 @@ config_create() {
 detect_compose_folder() {
 	# Check for a legacy compose folder and update ComposeFolder if needed
 	local ConfigFolder
-	ConfigFolder="$(get_toml_val_string "${APPLICATION_TOML_FILE}" paths.config_folder)"
+	ConfigFolder="$(run_script 'config_get' paths.config_folder)"
 
 	local -a ExpandVarList=(
 		ScriptFolder "${SCRIPTPATH}"
@@ -154,7 +126,7 @@ detect_compose_folder() {
 	fi
 
 	local DefaultComposeFolder
-	DefaultComposeFolder="$(get_toml_val_string "${APPLICATION_TOML_FILE}" paths.compose_folder)"
+	DefaultComposeFolder="$(run_script 'config_get' paths.compose_folder)"
 	local ExpandedDefaultComposeFolder
 	ExpandedDefaultComposeFolder="$(expand_vars "${DefaultComposeFolder}" "${ExpandVarList[@]}")"
 
@@ -169,14 +141,15 @@ detect_compose_folder() {
 			notice \
 				"Chose the Legacy compose folder location:" \
 				"   '{{|Folder|}}${ExpandedLegacyComposeFolder}{{[-]}}'"
-			set_toml_val_string "${APPLICATION_TOML_FILE}" paths.compose_folder "${LegacyComposeFolder}"
+			run_script 'config_set' paths.compose_folder "${LegacyComposeFolder}"
 		else
 			notice \
 				"Chose the Default compose folder location:" \
 				"   '{{|Folder|}}${ExpandedDefaultComposeFolder}{{[-]}}'"
+			run_script 'config_set' paths.compose_folder "${DefaultComposeFolder}"
 		fi
 	elif [[ ${LegacyHasFiles} == true ]]; then
-		set_toml_val_string "${APPLICATION_TOML_FILE}" paths.compose_folder "${LegacyComposeFolder}"
+		run_script 'config_set' paths.compose_folder "${LegacyComposeFolder}"
 	fi
 }
 

--- a/scripts/config_get.sh
+++ b/scripts/config_get.sh
@@ -3,57 +3,25 @@ set -Eeuo pipefail
 IFS=$'\n\t'
 
 config_get() {
-	# config_get GET_VAR [VAR_FILE]
-	local GET_VAR=${1-}
-	local VAR_FILE=${2:-$APPLICATION_INI_FILE}
+	# config_get section_key [config_file]
+	local section_key=${1-}
+	local config_file=${2:-$APPLICATION_TOML_FILE}
 
-	if [[ -f ${VAR_FILE} ]]; then
-		local Line
-		local Val=""
-		while IFS= read -r Line || [[ -n ${Line} ]]; do
-			# Skip comments and empty lines
-			[[ ${Line} =~ ^[[:space:]]*# ]] && continue
-			[[ -z ${Line} ]] && continue
+	local file_extension=${config_file##*.}
 
-			# Check if line contains Key=Value
-			if [[ ${Line} =~ ^[[:space:]]*${GET_VAR}[[:space:]]*= ]]; then
-				# Extract Key and Value
-				local Key="${Line%%=*}"
-				local Value="${Line#*=}"
+	case ${file_extension} in
+		toml)
+			run_script 'config_toml_get' "${section_key}" "${config_file}"
+			return
+			;;
+		ini)
+			run_script 'config_ini_get' "${section_key}" "${config_file}"
+			return
+			;;
+	esac
 
-				# Trim whitespace from Key
-				Key="${Key#"${Key%%[![:space:]]*}"}"
-				Key="${Key%"${Key##*[![:space:]]}"}"
-
-				# Check if this is the requested key
-				if [[ ${Key} == "${GET_VAR}" ]]; then
-					Val="${Value}"
-					# Keep reading to get the last occurrence (tail -1 behavior)
-				fi
-			fi
-		done < "${VAR_FILE}"
-
-		# Trim leading whitespace
-		Val="${Val#"${Val%%[![:space:]]*}"}"
-		# Trim trailing whitespace
-		Val="${Val%"${Val##*[![:space:]]}"}"
-
-		# Strip single quotes if present on both ends
-		if [[ ${Val} == \'*\' ]]; then
-			Val="${Val#\'}"
-			Val="${Val%\'}"
-		# Strip double quotes if present on both ends
-		elif [[ ${Val} == \"*\" ]]; then
-			Val="${Val#\"}"
-			Val="${Val%\"}"
-		fi
-
-		printf '%s\n' "${Val}"
-	else
-		# VAR_FILE does not exist, give a warning
-		warn "File '{{|File|}}${VAR_FILE}{{[-]}}' does not exist."
-	fi
-
+	# Invalid file extension
+	return 1
 }
 
 test_config_get() {

--- a/scripts/config_ini_get.sh
+++ b/scripts/config_ini_get.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+config_ini_get() {
+	# config_ini_get [SECTION_KEY] [CONFIG_FILE]
+	local section_key=${1-}
+	local config_file=${2:-$APPLICATION_INI_FILE}
+
+	local file_extension=${config_file##*.}
+	if [[ ${file_extension} != "ini" ]]; then
+		return 1
+	fi
+
+	local -A IniMap=(
+		["paths.config_folder"]="ConfigFolder"
+		["paths.compose_folder"]="ComposeFolder"
+		["pm.package_manager"]="PackageManager"
+		["ui.theme"]="Theme"
+		["ui.scrollbar"]="Scrollbar:Scrollbars"
+		["ui.shadow"]="Shadow:Shadows"
+	)
+
+	local -A Config_booleans=(
+		["ui.borders"]=1
+		["ui.line_characters"]=1
+		["ui.scrollbar"]=1
+		["ui.shadow"]=1
+	)
+
+	local -A Config_strings=(
+		["paths.config_folder"]=1
+		["paths.compose_folder"]=1
+		["pm.package_manager"]=1
+		["ui.theme"]=1
+	)
+
+	local VarType
+	if [[ -v Config_booleans[${section_key}] ]]; then
+		# Boolean variable
+		VarType="bool"
+	elif [[ -v Config_strings[${section_key}] ]]; then
+		# String variable
+		VarType="string"
+	else
+		# Variable not found
+		return 1
+	fi
+
+	case ${section_key} in
+		ui.borders)
+			local Value
+			if Value=$(get_ini_val_${VarType} "${config_file}" Borders); then
+				printf "%s\n" "${Value}"
+				return 0
+			elif Value=$(get_ini_val_${VarType} "${config_file}" LineCharacters); then
+				# Old INI files used LineCharacters for the Borders property
+				printf "%s\n" "${Value}"
+				return 0
+			fi
+			;;
+		ui.line_characters)
+			local Value
+			if ! get_ini_val_${VarType} "${config_file}" Borders > /dev/null; then
+				# Old INI files used LineCharacters for the Borders property
+				return 1
+			fi
+			if Value=$(get_ini_val_${VarType} "${config_file}" LineCharacters); then
+				printf "%s\n" "${Value}"
+				return 0
+			fi
+			;;
+		*)
+			if [[ -v IniMap["${section_key}"] ]]; then
+				for Var in ${IniMap["${section_key}"]//:/ }; do
+					local Value
+					if ! Value=$(get_ini_val_${VarType} "${config_file}" "${Var}"); then
+						continue
+					fi
+					printf "%s\n" "${Value}"
+					return 0
+				done
+			fi
+			;;
+	esac
+	return 1
+}
+
+test_config_ini_get() {
+	warn "CI does not test config_ini_get."
+}

--- a/scripts/config_package_manager.sh
+++ b/scripts/config_package_manager.sh
@@ -23,10 +23,10 @@ config_package_manager() {
 					"$(run_script 'package_manager_table')"
 				return 1
 			fi
-			set_toml_val_string "${APPLICATION_TOML_FILE}" "pm.package_manager" "${PackageManager}"
+			run_script 'config_set' pm.package_manager "${PackageManager}"
 			notice "Package manager set to '{{|UserCommand|}}${PackageManager}{{[-]}}'."
 		else
-			set_toml_val_string "${APPLICATION_TOML_FILE}" "pm.package_manager" ""
+			run_script 'config_set' pm.package_manager ""
 			notice "Package manager set to autodetect."
 		fi
 

--- a/scripts/config_set.sh
+++ b/scripts/config_set.sh
@@ -2,32 +2,23 @@
 set -Eeuo pipefail
 IFS=$'\n\t'
 
-declare -a _dependencies_list=(
-	sed
-)
-
 config_set() {
 	# config_set SET_VAR NEW_VAL [VAR_FILE]
-	local SET_VAR=${1-}
-	local NEW_VAL=${2-}
-	local VAR_FILE=${3-$APPLICATION_INI_FILE}
+	local section_key=${1-}
+	local value=${2-}
+	local config_file=${3:-$APPLICATION_TOML_FILE}
 
-	if [[ ${VAR_FILE} == "${APPLICATION_INI_FILE}" && ${SET_VAR} == PackageManager ]]; then
-		unset 'PM'
-	fi
+	local file_extension=${config_file##*.}
 
-	# https://unix.stackexchange.com/questions/422165/escape-double-quotes-in-variable/422170#422170
-	NEW_VAL="$(printf "%s\n" "${NEW_VAL-}" | ${SED} -e "s/'/'\"'\"'/g" -e "1s/^/'/" -e "\$s/\$/'/")"
+	case ${file_extension} in
+		toml)
+			run_script 'config_toml_set' "${section_key}" "${value}" "${config_file}"
+			return
+			;;
+	esac
 
-	if [[ ! -f ${VAR_FILE} ]]; then
-		# VAR_FILE does not exist, create it
-		touchfile "${VAR_FILE}"
-	fi
-	${SED} -i "/^\s*${SET_VAR}\s*=/d" "${VAR_FILE}" || true
-	echo "${SET_VAR}=${NEW_VAL}" >> "${VAR_FILE}" ||
-		fatal \
-			"Failed to set {{|Var|}}${SET_VAR}=${NEW_VAL}{{[-]}}" \
-			"Failing command: {{|FailingCommand|}} \"echo ${SET_VAR}=${NEW_VAL}\" >> \"${VAR_FILE}\""
+	# Invalid file extension
+	return 1
 }
 
 test_config_set() {

--- a/scripts/config_show.sh
+++ b/scripts/config_show.sh
@@ -3,6 +3,10 @@ set -Eeuo pipefail
 IFS=$'\n\t'
 
 config_show() {
+	local ConfigFile=${1:-${APPLICATION_TOML_FILE}}
+	local DefaultTitle="Configuration options stored in '{{|File|}}${ConfigFile}{{[-]}}':"
+	local ConfigTitle=${2-${DefaultTitle}}
+
 	local -a Keys=(
 		"paths.config_folder"
 		"paths.compose_folder"
@@ -28,22 +32,25 @@ config_show() {
 	local -a TableArray=()
 	for Key in "${Keys[@]}"; do
 		local Value
-		Value="$(get_toml_val "${APPLICATION_TOML_FILE}" "${Key}")"
-
-		local ExpandedValue=""
-		if [[ ${Key} == "paths.config_folder" || ${Key} == "paths.compose_folder" ]]; then
-			ExpandedValue="$(
-				expand_vars "${Value}" \
-					HOME "${DETECTED_HOMEDIR}" \
-					ScriptFolder "${SCRIPTPATH}" \
-					XDG_CONFIG_HOME "${XDG_CONFIG_HOME}"
-			)"
+		if ! Value="$(run_script 'config_get' "${Key}" "${ConfigFile}")"; then
+			continue
 		fi
-
-		local ValueColor="{{|Var|}}"
-		if [[ ${Key} == "paths.config_folder" || ${Key} == "paths.compose_folder" ]]; then
-			ValueColor="{{|Folder|}}"
-		fi
+		local ValueColor ExpandedValue
+		case ${Key} in
+			paths.config_folder | paths.compose_folder)
+				ValueColor="{{|Folder|}}"
+				ExpandedValue="$(
+					expand_vars "${Value}" \
+						HOME "${DETECTED_HOMEDIR}" \
+						ScriptFolder "${SCRIPTPATH}" \
+						XDG_CONFIG_HOME "${XDG_CONFIG_HOME}"
+				)"
+				;;
+			*)
+				ValueColor="{{|Var|}}"
+				ExpandedValue=""
+				;;
+		esac
 
 		local DisplayValue="${ValueColor}${Value}{{[-]}}"
 		local DisplayExpandedValue=""
@@ -54,7 +61,16 @@ config_show() {
 		TableArray+=("${DisplayNames[${Key}]}" "${DisplayValue}" "${DisplayExpandedValue}")
 	done
 
-	resolve_strings C "Configuration options stored in '{{|File|}}${APPLICATION_TOML_FILE}{{[-]}}':"
+	if [[ -n ${ConfigTitle} ]]; then
+		if [[ -t 1 ]]; then
+			# Direct CLI call: Resolve now
+			resolve_strings C "${ConfigTitle}"
+		else
+			# Captured for a notice: Output raw tags
+			printf '%s\n' "${ConfigTitle}"
+		fi
+	fi
+
 	table 3 \
 		"{{|UsageCommand|}}Option{{[-]}}" "{{|UsageCommand|}}Value{{[-]}}" "{{|UsageCommand|}}Expanded Value{{[-]}}" \
 		"${TableArray[@]}"

--- a/scripts/config_theme.sh
+++ b/scripts/config_theme.sh
@@ -114,17 +114,17 @@ config_theme() {
 	)
 
 	local sem_p sem_s dir_p dir_s
-	sem_p="$(get_toml_val_string "${ThemeFile}" "syntax.semantic_prefix")"
+	sem_p="$(get_toml_val_string "${ThemeFile}" syntax.semantic_prefix)"
 	[[ -z ${sem_p} ]] && sem_p="{{|"
-	sem_s="$(get_toml_val_string "${ThemeFile}" "syntax.semantic_suffix")"
+	sem_s="$(get_toml_val_string "${ThemeFile}" syntax.semantic_suffix)"
 	[[ -z ${sem_s} ]] && sem_s="|}}"
-	dir_p="$(get_toml_val_string "${ThemeFile}" "syntax.direct_prefix")"
+	dir_p="$(get_toml_val_string "${ThemeFile}" syntax.direct_prefix)"
 	[[ -z ${dir_p} ]] && dir_p="{{["
-	dir_s="$(get_toml_val_string "${ThemeFile}" "syntax.direct_suffix")"
+	dir_s="$(get_toml_val_string "${ThemeFile}" syntax.direct_suffix)"
 	[[ -z ${dir_s} ]] && dir_s="]}}"
 
 	local -a VarList
-	readarray -t VarList < <(get_toml_section_key_list "${ThemeFile}" "colors")
+	readarray -t VarList < <(get_toml_section_key_list "${ThemeFile}" colors)
 	local VarName
 	for VarName in "${VarList[@]-}"; do
 		DC["${VarName}"]="$(get_toml_val_string "${ThemeFile}" "colors.${VarName}")"
@@ -134,14 +134,14 @@ config_theme() {
 		DC["${StyleName}"]="$(resolve_styles DC "${DC["${StyleName}"]}" "${sem_p}" "${sem_s}" "${dir_p}" "${dir_s}")"
 	done
 
-	D["ThemeName"]="$(get_toml_val_string "${ThemeFile}" "metadata.name")"
+	D["ThemeName"]="$(get_toml_val_string "${ThemeFile}" metadata.name)"
 	local DialogOptions="--colors --output-fd 1 --cr-wrap --no-collapse"
 
 	local LineCharacters Borders Scrollbar Shadow
-	Borders="$(get_toml_val_bool "${APPLICATION_TOML_FILE}" "ui.borders")"
-	LineCharacters="$(get_toml_val_bool "${APPLICATION_TOML_FILE}" "ui.line_characters")"
-	Scrollbar="$(get_toml_val_bool "${APPLICATION_TOML_FILE}" "ui.scrollbar")"
-	Shadow="$(get_toml_val_bool "${APPLICATION_TOML_FILE}" "ui.shadow")"
+	Borders="$(run_script 'config_get' ui.borders)"
+	LineCharacters="$(run_script 'config_get' ui.line_characters)"
+	Scrollbar="$(run_script 'config_get' ui.scrollbar)"
+	Shadow="$(run_script 'config_get' ui.shadow)"
 
 	D+=(
 		["Borders"]="${Borders}"
@@ -177,7 +177,7 @@ config_theme() {
 
 	run_script 'set_permissions' "${DIALOGRC}"
 
-	set_toml_val_string "${APPLICATION_TOML_FILE}" "ui.theme" "${ThemeName}"
+	run_script 'config_set' ui.theme "${ThemeName}"
 }
 
 test_config_theme() {

--- a/scripts/config_toml_get.sh
+++ b/scripts/config_toml_get.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+config_toml_get() {
+	# config_toml_get [SECTION_KEY] [CONFIG_FILE]
+	local section_key=${1-}
+	local config_file=${2:-$APPLICATION_TOML_FILE}
+
+	local file_extension=${config_file##*.}
+	if [[ ${file_extension} != "toml" ]]; then
+		return 1
+	fi
+
+	local -A Config_booleans=(
+		["ui.borders"]=1
+		["ui.line_characters"]=1
+		["ui.scrollbar"]=1
+		["ui.shadow"]=1
+	)
+
+	local -A Config_strings=(
+		["paths.config_folder"]=1
+		["paths.compose_folder"]=1
+		["pm.package_manager"]=1
+		["ui.theme"]=1
+	)
+
+	local VarType
+	if [[ -v Config_booleans[${section_key}] ]]; then
+		VarType="bool"
+	elif [[ -v Config_strings[${section_key}] ]]; then
+		VarType="string"
+	else
+		VarType="string"
+	fi
+
+	get_toml_val_${VarType} "${config_file}" "${section_key}"
+}
+
+test_config_toml_get() {
+	warn "CI does not test config_toml_get."
+}

--- a/scripts/config_toml_set.sh
+++ b/scripts/config_toml_set.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+config_toml_set() {
+	# config_toml_set SECTION_KEY VALUE [CONFIG_FILE]
+	local section_key=${1-}
+	local value=${2-}
+	local config_file=${3:-$APPLICATION_TOML_FILE}
+
+	local -A Config_booleans=(
+		["ui.borders"]=1
+		["ui.line_characters"]=1
+		["ui.scrollbar"]=1
+		["ui.shadow"]=1
+	)
+
+	local -A Config_strings=(
+		["paths.config_folder"]=1
+		["paths.compose_folder"]=1
+		["pm.package_manager"]=1
+		["ui.theme"]=1
+	)
+
+	local VarType
+	if [[ -v Config_booleans[${section_key}] ]]; then
+		VarType="bool"
+	elif [[ -v Config_strings[${section_key}] ]]; then
+		VarType="string"
+	else
+		# Variable not found, assume string
+		VarType="string"
+	fi
+
+	set_toml_val_${VarType} "${config_file}" "${section_key}" "${value}"
+}
+
+test_config_toml_set() {
+	warn "CI does not test config_toml_set."
+}

--- a/scripts/env_sanitize.sh
+++ b/scripts/env_sanitize.sh
@@ -22,9 +22,9 @@ env_sanitize() {
 	local DOCKER_CONFIG_FOLDER DOCKER_COMPOSE_FOLDER ORIG_CONFIG_FOLDER ORIG_COMPOSE_FOLDER
 
 	ORIG_CONFIG_FOLDER="$(run_script 'env_get' DOCKER_CONFIG_FOLDER)"
-	LITERAL_CONFIG_FOLDER="$(get_toml_val_string "${APPLICATION_TOML_FILE}" "paths.config_folder")"
+	LITERAL_CONFIG_FOLDER="$(run_script 'config_get' paths.config_folder)"
 	if [[ -z ${LITERAL_CONFIG_FOLDER-} ]]; then
-		LITERAL_CONFIG_FOLDER="$(get_toml_val_string "${DEFAULT_TOML_FILE}" "paths.config_folder")"
+		LITERAL_CONFIG_FOLDER="$(run_script 'config_get' paths.config_folder "${DEFAULT_TOML_FILE}")"
 	fi
 	if [[ -z ${LITERAL_CONFIG_FOLDER-} ]]; then
 		LITERAL_CONFIG_FOLDER="${ORIG_CONFIG_FOLDER}"
@@ -32,9 +32,9 @@ env_sanitize() {
 	DOCKER_CONFIG_FOLDER="${LITERAL_CONFIG_FOLDER}"
 
 	ORIG_COMPOSE_FOLDER="$(run_script 'env_get' DOCKER_COMPOSE_FOLDER)"
-	LITERAL_COMPOSE_FOLDER="$(get_toml_val_string "${APPLICATION_TOML_FILE}" "paths.compose_folder")"
+	LITERAL_COMPOSE_FOLDER="$(run_script 'config_get' paths.compose_folder)"
 	if [[ -z ${LITERAL_COMPOSE_FOLDER-} ]]; then
-		LITERAL_COMPOSE_FOLDER="$(get_toml_val_string "${DEFAULT_TOML_FILE}" "paths.compose_folder")"
+		LITERAL_COMPOSE_FOLDER="$(run_script 'config_get' paths.compose_folder "${DEFAULT_TOML_FILE}")"
 	fi
 	if [[ -z ${LITERAL_COMPOSE_FOLDER-} ]]; then
 		LITERAL_COMPOSE_FOLDER="${ORIG_COMPOSE_FOLDER}"

--- a/scripts/menu_options_display.sh
+++ b/scripts/menu_options_display.sh
@@ -33,7 +33,7 @@ menu_options_display() {
 		local Opts=()
 		for Option in "${DrawLineOption}" "${ShowBordersOption}" "${ShowScrollbarOption}" "${ShowShadowOption}"; do
 			local Value
-			Value="$(get_toml_val_bool "${APPLICATION_TOML_FILE}" "ui.${OptionVariable["${Option}"]}")"
+			Value="$(run_script 'config_get' "ui.${OptionVariable["${Option}"]}")"
 			if is_true "${Value}"; then
 				EnabledOptions+=("${Option}")
 				Opts+=("${Option}" "${OptionDescription["${Option}"]}" ON)
@@ -66,12 +66,12 @@ menu_options_display() {
 				if [[ -n ${OptionsToTurnOff[*]-} || ${OptionsToTurnOn[*]-} ]]; then
 					if [[ -n ${OptionsToTurnOff[*]-} ]]; then
 						for Option in "${OptionsToTurnOff[@]}"; do
-							set_toml_val_bool "${APPLICATION_TOML_FILE}" "ui.${OptionVariable["${Option}"]}" "false"
+							run_script 'config_set' "ui.${OptionVariable["${Option}"]}" false
 						done
 					fi
 					if [[ -n ${OptionsToTurnOn[*]-} ]]; then
 						for Option in "${OptionsToTurnOn[@]}"; do
-							set_toml_val_bool "${APPLICATION_TOML_FILE}" "ui.${OptionVariable["${Option}"]}" "true"
+							run_script 'config_set' "ui.${OptionVariable["${Option}"]}" true
 						done
 					fi
 					run_script 'config_theme' &> /dev/null

--- a/scripts/menu_options_package_manager.sh
+++ b/scripts/menu_options_package_manager.sh
@@ -15,7 +15,7 @@ menu_options_package_manager() {
 	run_script 'config_package_manager' &> /dev/null
 
 	local CurrentPackageManager
-	CurrentPackageManager="$(get_toml_val_string "${APPLICATION_TOML_FILE}" "pm.package_manager")"
+	CurrentPackageManager="$(run_script 'config_get' pm.package_manager)"
 
 	local -a PackageManagerList
 	readarray -t PackageManagerList < <(run_script 'package_manager_list')

--- a/scripts/theme_name.sh
+++ b/scripts/theme_name.sh
@@ -3,7 +3,7 @@ set -Eeuo pipefail
 IFS=$'\n\t'
 
 theme_name() {
-	get_toml_val_string "${APPLICATION_TOML_FILE}" "ui.theme"
+	run_script 'config_get' ui.theme
 }
 
 test_theme_name() {


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Unify configuration access around section-based getters/setters for TOML and legacy INI files, and improve how configuration is applied and displayed across CLI and dialog UIs.

Bug Fixes:
- Ensure UI border and line-character settings are correctly derived from legacy INI files, including older LineCharacters/Borders combinations.
- Prevent nested or inappropriate dialog invocations by distinguishing when code is already running inside a dialog pipe.
- Avoid resolving semantic color tags when output is being captured or piped, so downstream notice handling can process them correctly.

Enhancements:
- Introduce format-aware config_get/config_set helpers that delegate to TOML- or INI-specific handlers based on file extension.
- Add dedicated config_ini_get, config_toml_get, and config_toml_set scripts to encapsulate config parsing and writing logic, including type handling for booleans and strings.
- Refine migration from legacy INI to TOML by centralizing key mapping, handling UI options consistently, and running apply_config after migration.
- Update UI-related scripts (theme, menu options, package manager, theme CLI flags) to use the new config access helpers and section-style keys.
- Adjust dialog and table rendering helpers to better distinguish between interactive GUI/TTY usage and captured output, avoiding premature tag resolution and ensuring ASCII borders inside dialog boxes.
- Improve config_show to support arbitrary config files/titles, skip missing keys, and respect TTY vs captured output when resolving color tags.
- Make apply_config and env_sanitize rely on the new config_get interface for reading paths and only create configs when needed.