### PR TITLE
Add logging to backups

### DIFF
--- a/scripts/env_backup.sh
+++ b/scripts/env_backup.sh
@@ -8,10 +8,6 @@ declare -a _dependencies_list=(
 
 env_backup() {
 	local DOCKER_VOLUME_CONFIG
-	if [[ ! -f ${COMPOSE_ENV} ]]; then
-		warn "No .env file to back up."
-		return
-	fi
 	# Update CONFIG_FOLDER and LITERAL_CONFIG_FOLDER based on DOCKER_CONFIG_FOLDER
 	local DOCKER_CONFIG_FOLDER
 	DOCKER_CONFIG_FOLDER="$(run_script 'env_get' DOCKER_CONFIG_FOLDER)"
@@ -30,8 +26,8 @@ env_backup() {
 	fi
 	if [[ -z ${DOCKER_VOLUME_CONFIG-} ]]; then
 		DOCKER_VOLUME_CONFIG="$(run_script 'var_default_value' DOCKER_VOLUME_CONFIG)"
-		run_script 'env_set_literal' DOCKER_VOLUME_CONFIG "${DOCKER_VOLUME_CONFIG}"
-		DOCKER_VOLUME_CONFIG="$(run_script 'env_get' DOCKER_VOLUME_CONFIG)"
+		DOCKER_VOLUME_CONFIG="${DOCKER_VOLUME_CONFIG#[\"\']}"
+		DOCKER_VOLUME_CONFIG="${DOCKER_VOLUME_CONFIG%[\"\']}"
 	fi
 	if [[ -z ${DOCKER_VOLUME_CONFIG-} ]]; then
 		fatal \
@@ -51,34 +47,37 @@ env_backup() {
 	BACKUPTIME="$(date +"%Y%m%d.%H.%M.%S")"
 	local BACKUP_FOLDER="${COMPOSE_BACKUPS_FOLDER}/${COMPOSE_FOLDER_NAME}.${BACKUPTIME}"
 
-	info "Copying '{{|File|}}.env{{[-]}}' file to '{{|Folder|}}${BACKUP_FOLDER}/.env{{[-]}}'"
-	mkdir -p "${BACKUP_FOLDER}" ||
-		fatal \
-			"Failed to make directory." \
-			"Failing command: {{|FailingCommand|}}mkdir -p \"${BACKUP_FOLDER}\""
-	cp "${COMPOSE_ENV}" "${BACKUP_FOLDER}/" ||
-		fatal \
-			"Failed to copy backup." \
-			"Failing command: {{|FailingCommand|}}cp \"${COMPOSE_ENV}\"/.env.app.* \"${BACKUP_FOLDER}/\""
-	if [[ -n $(${FIND} "${COMPOSE_FOLDER}" -type f -maxdepth 1 -name ".env.app.*" 2> /dev/null) ]]; then
-		cp "${COMPOSE_FOLDER}"/.env.app.* "${BACKUP_FOLDER}/" ||
+	local -a BackupList
+	readarray -t BackupList < <(
+		${FIND} "${COMPOSE_FOLDER}" -maxdepth 1 \
+			\( \
+			-type d \
+			-name "${APP_ENV_FOLDER_NAME}" \
+			-exec echo "{}/" \; \
+			\) -o \( -type f \
+			-name "${COMPOSE_OVERRIDE_NAME}" -o \
+			-name ".env" -o \
+			-name ".env.app.*" \
+			-exec echo "{}" \; \
+			\) | sort 2> /dev/null || true
+	)
+	local Indent='\t'
+	if [[ ${#BackupList[@]} -gt 0 ]]; then
+		notice \
+			"Backing up user files to folder:" \
+			"\t{{|Folder|}}${BACKUP_FOLDER}{{[-]}}"
+		info "Creating folder '{{|Folder|}}${BACKUP_FOLDER}{{[-]}}'"
+		mkdir -p "${BACKUP_FOLDER}" ||
 			fatal \
-				"Failed to copy backup." \
-				"Failing command: {{|FailingCommand|}}cp \"${COMPOSE_FOLDER}\"/.env.app.* \"${BACKUP_FOLDER}/\""
-	fi
-	if [[ -d ${APP_ENV_FOLDER} ]]; then
-		info "Copying appplication env folder to '{{|Folder|}}${BACKUP_FOLDER}/${APP_ENV_FOLDER_NAME}{{[-]}}'"
-		cp -r "${APP_ENV_FOLDER}" "${BACKUP_FOLDER}/" ||
+				"Failed to make directory." \
+				"Failing command: {{|FailingCommand|}}mkdir -p \"${BACKUP_FOLDER}\""
+		info \
+			"Backing up files:" \
+			"$(printf "${Indent}{{|File|}}%s{{[-]}}\n" "${BackupList[@]}")"
+		cp -t "${BACKUP_FOLDER}/" -r "${BackupList[@]}" ||
 			fatal \
-				"Failed to copy backup." \
-				"Failing command: {{|FailingCommand|}}cp -r \"${APP_ENV_FOLDER}\" \"${BACKUP_FOLDER}/\""
-	fi
-	if [[ -f ${COMPOSE_OVERRIDE} ]]; then
-		info "Copying override file to '{{|Folder|}}${BACKUP_FOLDER}/${COMPOSE_OVERRIDE_NAME}{{[-]}}'"
-		cp "${COMPOSE_OVERRIDE}" "${BACKUP_FOLDER}/" ||
-			fatal \
-				"Failed to copy backup." \
-				"Failing command: {{|FailingCommand|}}cp \"${COMPOSE_OVERRIDE}\" \"${BACKUP_FOLDER}/\""
+				"Failed to copy file." \
+				"Failing command: {{|FailingCommand|}}cp -t \"${BACKUP_FOLDER}/\" -r $(printf '"%s" ' "${BackupList[@]}")"
 	fi
 
 	run_script 'set_permissions' "${COMPOSE_BACKUPS_FOLDER}"

--- a/scripts/env_create.sh
+++ b/scripts/env_create.sh
@@ -20,7 +20,7 @@ env_create() {
 
 	if [[ -f ${COMPOSE_ENV} ]]; then
 		info "File '{{|File|}}${COMPOSE_ENV}{{[-]}}' found."
-		run_script 'env_sanitize'
+		run_script 'env_sanitize' --skip-backup
 	else
 		warn "File '{{|File|}}${COMPOSE_ENV}{{[-]}}' not found. Copying example template."
 		cp "${COMPOSE_ENV_DEFAULT_FILE}" "${COMPOSE_ENV}" ||
@@ -28,11 +28,11 @@ env_create() {
 				"Failed to copy file." \
 				"Failing command: {{|FailingCommand|}}cp \"${COMPOSE_ENV_DEFAULT_FILE}\" \"${COMPOSE_ENV}\""
 		run_script 'set_permissions' "${COMPOSE_ENV}"
-		run_script 'env_sanitize'
+		run_script 'env_sanitize' --skip-backup
 		if [[ -n ${DefaultApps-} && -z $(run_script 'app_list_referenced') ]]; then
 			info "Installing default applications."
 			run_script 'appvars_create' "${DefaultApps[@]}"
-			run_script 'env_sanitize'
+			run_script 'env_sanitize' --skip-backup
 		fi
 	fi
 }

--- a/scripts/env_sanitize.sh
+++ b/scripts/env_sanitize.sh
@@ -9,6 +9,7 @@ declare -a _dependencies_list=(
 env_sanitize() {
 	local -a VarsToUpdate
 	local -A UpdatedVarValue
+	local SkipBackup=${1-}
 
 	# Update the HOME variable if it is not set to the detected home directory
 	local HOME
@@ -55,7 +56,9 @@ env_sanitize() {
 	fi
 
 	# Backup the user files
-	run_script 'env_backup'
+	if [[ ${SkipBackup-} != "--skip-backup" ]]; then
+		run_script 'env_backup'
+	fi
 
 	# Migrate from old global variable names
 	run_script 'env_migrate_global'


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Improve environment backup behavior and logging, and allow env sanitization to optionally skip backups.

New Features:
- Add support for backing up multiple user env-related files and folders (core .env, app env files, env folder, and override compose file) in a single operation.

Bug Fixes:
- Handle quoted DOCKER_VOLUME_CONFIG values correctly when determining the backup destination volume.

Enhancements:
- Enhance backup logging to list all files and destination folder, and perform backups only when relevant files are present.
- Add a --skip-backup option to env_sanitize and use it from env_create to avoid unnecessary backups during env creation and default app installation steps.