### PR TITLE
Change grouping in find command in `env_backup.sh`

### DIFF
--- a/scripts/env_backup.sh
+++ b/scripts/env_backup.sh
@@ -52,12 +52,16 @@ env_backup() {
 		${FIND} "${COMPOSE_FOLDER}" -maxdepth 1 \
 			\( \
 			-type d \
+			\( \
 			-name "${APP_ENV_FOLDER_NAME}" \
+			\) \
 			-exec echo "{}/" \; \
 			\) -o \( -type f \
+			\( \
 			-name "${COMPOSE_OVERRIDE_NAME}" -o \
 			-name ".env" -o \
 			-name ".env.app.*" \
+			\) \
 			-exec echo "{}" \; \
 			\) | sort 2> /dev/null || true
 	)


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Bug Fixes:
- Fix find command grouping in env_backup.sh to ensure the intended directories and files are correctly matched during environment backup.