### PR TITLE
Fix env backups

### DIFF
--- a/scripts/env_backup.sh
+++ b/scripts/env_backup.sh
@@ -75,18 +75,18 @@ env_backup() {
 		info \
 			"Backing up files:" \
 			"$(printf "${Indent}{{|File|}}%s{{[-]}}\n" "${BackupList[@]}")"
-		cp -t "${BACKUP_FOLDER}/" -r "${BackupList[@]}" ||
+		cp -R "${BackupList[@]}" "${BACKUP_FOLDER}/" ||
 			fatal \
 				"Failed to copy file." \
-				"Failing command: {{|FailingCommand|}}cp -t \"${BACKUP_FOLDER}/\" -r $(printf '"%s" ' "${BackupList[@]}")"
+				"Failing command: {{|FailingCommand|}}cp -R $(printf '"%s" ' "${BackupList[@]}") \"${BACKUP_FOLDER}/\""
 	fi
 
 	run_script 'set_permissions' "${COMPOSE_BACKUPS_FOLDER}"
 
 	info "Removing old compose backups."
-	${FIND} "${COMPOSE_BACKUPS_FOLDER}" -type f -name ".env.*" -mtime +3 -delete &> /dev/null ||
+	${FIND} "${COMPOSE_BACKUPS_FOLDER}" -maxdepth 1 -type f -name ".env.*" -mtime +3 -delete &> /dev/null ||
 		warn "Old .env backups not removed."
-	${FIND} "${COMPOSE_BACKUPS_FOLDER}" -type d -name "${COMPOSE_FOLDER_NAME}.*" -mtime +3 -prune -exec rm -rf {} + &> /dev/null ||
+	${FIND} "${COMPOSE_BACKUPS_FOLDER}" -maxdepth 1 -type d -name "${COMPOSE_FOLDER_NAME}.*" -mtime +3 -exec rm -rf {} + &> /dev/null ||
 		warn "Old compose backups not removed."
 
 	# Backup location has moved


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Improve environment backup handling and cleanup behavior in the backup script.

Bug Fixes:
- Adjust file copy command in env backup script to ensure backups are correctly copied to the backup folder.
- Restrict find operations for deleting old .env and compose backups to the top-level backup directory to avoid unintended deletions.