### PR TITLE
Skip writing files if they haven't' changed

### DIFF
--- a/scripts/env_update.sh
+++ b/scripts/env_update.sh
@@ -72,9 +72,11 @@ env_update() {
 		printf '%s\n' "${UPDATED_ENV_LINES[@]}" > "${MKTEMP_ENV_UPDATED}" ||
 			fatal \
 				"Failed to write temporary '{{|File|}}.env{{[-]}}' update file."
-		RunAndLog "" "cp:notice" \
-			fatal "Failed to copy file." \
-			cp -f "${MKTEMP_ENV_UPDATED}" "${COMPOSE_ENV}"
+		if [[ ! -f ${COMPOSE_ENV} ]] || ! cmp -s "${MKTEMP_ENV_UPDATED}" "${COMPOSE_ENV}" 2> /dev/null; then
+			RunAndLog "" "cp:notice" \
+				fatal "Failed to copy file." \
+				cp -f "${MKTEMP_ENV_UPDATED}" "${COMPOSE_ENV}"
+		fi
 		RunAndLog "" "rm:notice" \
 			warn "Failed to remove temporary {{|File|}}.env{{[-]}} update file." \
 			rm -f "${MKTEMP_ENV_UPDATED}"
@@ -111,9 +113,11 @@ env_update() {
 				printf '%s\n' "${UPDATED_APP_ENV_LINES[@]}" > "${MKTEMP_APP_ENV_UPDATED}" ||
 					fatal \
 						"Failed to write temporary '{{|File|}}.env.app.${appname}{{[-]}}' update file."
-				RunAndLog "" "cp:notice" \
-					fatal "Failed to copy file." \
-					cp -f "${MKTEMP_APP_ENV_UPDATED}" "${APP_ENV_FILE}"
+				if [[ ! -f ${APP_ENV_FILE} ]] || ! cmp -s "${MKTEMP_APP_ENV_UPDATED}" "${APP_ENV_FILE}" 2> /dev/null; then
+					RunAndLog "" "cp:notice" \
+						fatal "Failed to copy file." \
+						cp -f "${MKTEMP_APP_ENV_UPDATED}" "${APP_ENV_FILE}"
+				fi
 				RunAndLog "" "rm:notice" \
 					warn "Failed to remove temporary '{{|File|}}.env.app.${appname}{{[-]}}' update file." \
 					rm -f "${MKTEMP_APP_ENV_UPDATED}"

--- a/scripts/yml_merge.sh
+++ b/scripts/yml_merge.sh
@@ -124,14 +124,27 @@ commands_yml_merge() {
 
 	info "Running compose config to create '{{|File|}}docker-compose.yml{{[-]}}' file from enabled templates."
 	export COMPOSE_FILE="${COMPOSE_FILE#:}"
+	local MKTEMP_COMPOSE_YML
+	MKTEMP_COMPOSE_YML=$(mktemp -t "${APPLICATION_NAME}.${FUNCNAME[0]}.MKTEMP_COMPOSE_YML.XXXXXXXXXX") ||
+		fatal \
+			"Failed to create temporary '{{|File|}}docker-compose.yml{{[-]}}' file." \
+			"Failing command: {{|FailingCommand|}}mktemp -t \"${APPLICATION_NAME}.${FUNCNAME[0]}.MKTEMP_COMPOSE_YML.XXXXXXXXXX\""
 	local -i result=0
-	eval "docker compose --project-directory ${COMPOSE_FOLDER}/ config > ${COMPOSE_FOLDER}/docker-compose.yml" || result=$?
+	docker compose --project-directory "${COMPOSE_FOLDER}/" config > "${MKTEMP_COMPOSE_YML}" || result=$?
 	if [[ ${result} != 0 ]]; then
+		rm -f "${MKTEMP_COMPOSE_YML}"
 		error \
 			"Failed to output compose config." \
-			"Failing command: {{|FailingCommand|}}docker compose --project-directory ${COMPOSE_FOLDER}/ config > \"${COMPOSE_FOLDER}/docker-compose.yml\""
+			"Failing command: {{|FailingCommand|}}docker compose --project-directory ${COMPOSE_FOLDER}/ config > \"${MKTEMP_COMPOSE_YML}\""
 		return ${result}
 	fi
+	if [[ ! -f ${COMPOSE_FOLDER}/docker-compose.yml ]] || ! cmp -s "${MKTEMP_COMPOSE_YML}" "${COMPOSE_FOLDER}/docker-compose.yml"; then
+		cp -f "${MKTEMP_COMPOSE_YML}" "${COMPOSE_FOLDER}/docker-compose.yml" ||
+			fatal \
+				"Failed to copy file." \
+				"Failing command: {{|FailingCommand|}}cp -f \"${MKTEMP_COMPOSE_YML}\" \"${COMPOSE_FOLDER}/docker-compose.yml\""
+	fi
+	rm -f "${MKTEMP_COMPOSE_YML}"
 	info "Merging '{{|File|}}docker-compose.yml{{[-]}}' complete."
 	run_script 'unset_needs_yml_merge'
 	return 0


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Avoid rewriting docker-compose and env files when their contents have not changed.

Bug Fixes:
- Prevent unnecessary rewrites of docker-compose.yml by generating output in a temporary file and only copying when contents differ.
- Prevent unnecessary rewrites of .env and app-specific .env files by comparing temporary updates to existing files before copying.