### PR TITLE
Remove adding of deprecated `IUS` repos in `yum`

### DIFF
--- a/scripts/pm_yum_repos.sh
+++ b/scripts/pm_yum_repos.sh
@@ -3,36 +3,7 @@ set -Eeuo pipefail
 IFS=$'\n\t'
 
 pm_yum_repos() {
-	#shellcheck disable=SC2034 #(warning): Title appears unused. Verify use (or export if used externally).
-	local Title="Update Repositories"
-	notice "Updating repositories. Please be patient, this can take a while."
-	local MKTEMP_GET_IUS
-	MKTEMP_GET_IUS=$(mktemp -t "${APPLICATION_NAME}.${FUNCNAME[0]}.MKTEMP_GET_IUS.XXXXXXXXXX") ||
-		fatal \
-			"Failed to create temporary IUS repo install script." \
-			"Failing command: {{|FailingCommand|}}mktemp -t \"${APPLICATION_NAME}.${FUNCNAME[0]}.MKTEMP_GET_IUS.XXXXXXXXXX\""
-	info "Downloading IUS install script."
-	curl -fsSL setup.ius.io -o "${MKTEMP_GET_IUS}" &> /dev/null ||
-		fatal \
-			"Failed to get IUS install script." \
-			"Failing command: {{|FailingCommand|}}curl -fsSL setup.ius.io -o \"${MKTEMP_GET_IUS}\""
-
-	info "Running IUS install script."
-	local COMMAND
-	local REDIRECT='&> /dev/null '
-	if [[ -n ${VERBOSE-} ]]; then
-		#shellcheck disable=SC2016 # (info): Expressions don't expand in single quotes, use double quotes for that.
-		REDIRECT='run_command_dialog "${Title}" "${COMMAND}" "" '
-	fi
-	COMMAND="sudo bash ${MKTEMP_GET_IUS}"
-	eval "${REDIRECT}${COMMAND}" ||
-		warn \
-			"Failed to install IUS." \
-			"Failing command: {{|FailingCommand|}}${COMMAND}"
-	rm -f "${MKTEMP_GET_IUS}" ||
-		warn \
-			"Failed to remove temporary IUS repo install script." \
-			"Failing command: {{|FailingCommand|}}rm -f \"${MKTEMP_GET_IUS}\""
+	info "Package manager '{{|UserCommand|}}yum{{[-]}}' does not require additional repositories."
 }
 
 test_pm_yum_repos() {


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Enhancements:
- Replace the IUS installation logic in yum repo setup with a simple informational message indicating no additional repositories are required.