### PR TITLE
Allow empty and non-existent `style` in `{{|style:fg:bg:flags|}}`

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -142,7 +142,7 @@ resolve_styles() {
 			local esc_dir_s="${dir_s//\]/\\\]}"
 			esc_dir_s="${esc_dir_s//\|/\\|}"
 			esc_dir_s="${esc_dir_s//\}/\\\}}"
-			regex="(${esc_sem_p}|${esc_dir_p})([^]|}]+)(${esc_sem_s}|${esc_dir_s})"
+			regex="(${esc_sem_p}|${esc_dir_p})([^]|}]*)(${esc_sem_s}|${esc_dir_s})"
 
 			[[ ${val} =~ ${regex} ]] || break
 			full_match="${BASH_REMATCH[0]}"
@@ -164,7 +164,7 @@ resolve_styles() {
 			fi
 		else
 			# Default syntax: {{|...|}} or {{[...]}}
-			regex='\{\{(\[|\|)([^]|}]+)(\]|\|)\}\}'
+			regex='\{\{(\[|\|)([^]|}]*)(\]|\|)\}\}'
 			[[ ${val} =~ ${regex} ]] || break
 			full_match="${BASH_REMATCH[0]}"
 			local type="${BASH_REMATCH[1]}"


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Bug Fixes:
- Fix style resolution so that {{|style:fg:bg:flags|}} tokens are correctly matched even when the style section is empty or omitted.