### PR TITLE
Escape special characters when resolving symantic styles

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -272,7 +272,10 @@ resolve_styles() {
 			fi
 			replacement="${resolved}"
 		fi
-		val="${val//"${full_match}"/"${replacement}"}"
+		local safe_match="${full_match//\[/\\[}"
+		safe_match="${safe_match//\*/\\*}"
+		safe_match="${safe_match//\?/\\?}"
+		val="${val//"${safe_match}"/"${replacement}"}"
 	done
 	printf '%s\n' "${val}"
 }


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Bug Fixes:
- Prevent incorrect replacements or shell expansion errors when style placeholders contain characters like [, * or ? in resolve_styles.