### PR TITLE
Make `*_into` functions using namerefs to avoid subshells

### DIFF
--- a/scripts/app_description_from_template_into.sh
+++ b/scripts/app_description_from_template_into.sh
@@ -2,15 +2,32 @@
 set -Eeuo pipefail
 IFS=$'\n\t'
 
-declare -a _dependencies_list=()
+declare -a _dependencies_list=(
+	grep
+	sed
+)
 
-app_description_from_template() {
-	local _adft_result_
-	run_script 'app_description_from_template_into' _adft_result_ "$@"
-	echo "${_adft_result_}"
+app_description_from_template_into() {
+	# Return the description of a single appname.
+	local -n _adft_out_="${1}"
+	local _adft_appname_=${2-}
+	_adft_appname_=${_adft_appname_,,}
+	if run_script 'app_is_builtin' "${_adft_appname_}"; then
+		local _adft_labels_yml_
+		run_script 'app_instance_file_into' _adft_labels_yml_ "${_adft_appname_}" "*.labels.yml"
+		if [[ -f ${_adft_labels_yml_} ]]; then
+			_adft_out_="$(${GREP} --color=never -Po "\scom\.dockstarter\.appinfo\.description: \K.*" "${_adft_labels_yml_}" | ${SED} -E 's/^([^"].*[^"])$/"\1"/' | xargs || echo "! Missing description !")"
+		else
+			_adft_out_="! Missing application !"
+		fi
+	else
+		local _adft_AppName_
+		run_script 'app_nicename_into' _adft_AppName_ "${_adft_appname_}"
+		_adft_out_="${_adft_AppName_} is a user defined application"
+	fi
 }
 
-test_app_description_from_template() {
+test_app_description_from_template_into() {
 	local ForcePass='' # Force the tests to pass even on failure if set to a non-empty value
 	local -i result=0
 	run_script 'appvars_create' WATCHTOWER NZBGET
@@ -30,10 +47,12 @@ test_app_description_from_template() {
 	)
 	run_unit_tests_pipe "App" "App" "${ForcePass}" < <(
 		for ((i = 0; i < ${#Test[@]}; i += 2)); do
+			local Result
+			run_script 'app_description_from_template_into' Result "${Test[i]}"
 			printf '%s\n' \
 				"${Test[i]}" \
 				"${Test[i + 1]}" \
-				"$(run_script 'app_description_from_template' "${Test[i]}")"
+				"${Result}"
 		done
 	)
 	result=$?

--- a/scripts/app_description_into.sh
+++ b/scripts/app_description_into.sh
@@ -2,13 +2,23 @@
 set -Eeuo pipefail
 IFS=$'\n\t'
 
-app_description() {
-	local _ad_result_
-	run_script 'app_description_into' _ad_result_ "$@"
-	echo "${_ad_result_}"
+declare -a _dependencies_list=()
+
+app_description_into() {
+	# Return the description of a single appname.
+	local -n _adi_out_="${1}"
+	local -l _adi_appname_=${2-}
+	_adi_appname_="${_adi_appname_%:*}"
+	if run_script 'app_is_user_defined' "${_adi_appname_}"; then
+		local _adi_AppName_
+		run_script 'app_nicename_into' _adi_AppName_ "${_adi_appname_}"
+		_adi_out_="${_adi_AppName_} is a user defined application"
+	else
+		run_script 'app_description_from_template_into' _adi_out_ "${_adi_appname_}"
+	fi
 }
 
-test_app_description() {
+test_app_description_into() {
 	local ForcePass='' # Force the tests to pass even on failure if set to a non-empty value
 	local -i result=0
 	run_script 'appvars_create' WATCHTOWER NZBGET
@@ -28,10 +38,12 @@ test_app_description() {
 	)
 	run_unit_tests_pipe "App" "App" "${ForcePass}" < <(
 		for ((i = 0; i < ${#Test[@]}; i += 2)); do
+			local Result
+			run_script 'app_description_into' Result "${Test[i]}"
 			printf '%s\n' \
 				"${Test[i]}" \
 				"${Test[i + 1]}" \
-				"$(run_script 'app_description' "${Test[i]}")"
+				"${Result}"
 		done
 	)
 	result=$?

--- a/scripts/app_env_file.sh
+++ b/scripts/app_env_file.sh
@@ -2,39 +2,12 @@
 set -Eeuo pipefail
 IFS=$'\n\t'
 
-declare -a _dependencies_list=(
-	grep
-	sed
-)
+declare -a _dependencies_list=()
 
 app_env_file() {
-	local -l appname=${1:-}
-
-	local AppEnvFilename=".env.app.${appname}"
-	local OldAppEnvFilename="${appname}.env"
-	local AppEnvFile="${COMPOSE_FOLDER}/${AppEnvFilename}"
-	local OldAppEnvFile="${APP_ENV_FOLDER}/${OldAppEnvFilename}"
-
-	if [[ ! -f ${AppEnvFile} && -f ${OldAppEnvFile} ]]; then
-		# Migrate from the old env_files/appname.env files to .env.app.appname
-		notice "Renaming '{{|File|}}${OldAppEnvFile}{{[-]}}' to '{{|File|}}${AppEnvFile}{{[-]}}'"
-		RunAndLog "" "mv:notice" \
-			fatal "Failed to rename file." \
-			mv "${OldAppEnvFile}" "${AppEnvFile}"
-		local SearchString="${APP_ENV_FOLDER_NAME}/${OldAppEnvFilename}"
-		if [[ -f ${COMPOSE_OVERRIDE} ]] && ${GREP} -q -F "${SearchString}" "${COMPOSE_OVERRIDE}"; then
-			local ReplaceString="${AppEnvFilename}"
-			# Replace all references to 'env_files/appname.env' with '.env.app.appname' in the override file
-			notice "Replacing in '{{|File|}}${COMPOSE_OVERRIDE}{{[-]}}':"
-			notice "   '{{|Var|}}${SearchString}{{[-]}}' with '{{|Var|}}${ReplaceString}{{[-]}}'"
-			# Escape . to [.] to use in sed
-			SearchString="${SearchString//./[.]}"
-			RunAndLog "" "sed:notice" \
-				fatal "Failed to edit override file." \
-				"${SED}" -i "s|${SearchString}|${ReplaceString}|g" "${COMPOSE_OVERRIDE}"
-		fi
-	fi
-	echo "${AppEnvFile}"
+	local _aef_result_
+	run_script 'app_env_file_into' _aef_result_ "$@"
+	echo "${_aef_result_}"
 }
 
 test_app_env_file() {

--- a/scripts/app_env_file_into.sh
+++ b/scripts/app_env_file_into.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+declare -a _dependencies_list=(
+	grep
+	sed
+)
+
+app_env_file_into() {
+	local -n _aefi_out_="${1}"
+	local -l _aefi_appname_=${2:-}
+
+	local _aefi_AppEnvFilename_=".env.app.${_aefi_appname_}"
+	local _aefi_OldAppEnvFilename_="${_aefi_appname_}.env"
+	local _aefi_AppEnvFile_="${COMPOSE_FOLDER}/${_aefi_AppEnvFilename_}"
+	local _aefi_OldAppEnvFile_="${APP_ENV_FOLDER}/${_aefi_OldAppEnvFilename_}"
+
+	if [[ ! -f ${_aefi_AppEnvFile_} && -f ${_aefi_OldAppEnvFile_} ]]; then
+		# Migrate from the old env_files/appname.env files to .env.app.appname
+		notice "Renaming '{{|File|}}${_aefi_OldAppEnvFile_}{{[-]}}' to '{{|File|}}${_aefi_AppEnvFile_}{{[-]}}'"
+		RunAndLog "" "mv:notice" \
+			fatal "Failed to rename file." \
+			mv "${_aefi_OldAppEnvFile_}" "${_aefi_AppEnvFile_}"
+		local _aefi_SearchString_="${APP_ENV_FOLDER_NAME}/${_aefi_OldAppEnvFilename_}"
+		if [[ -f ${COMPOSE_OVERRIDE} ]] && ${GREP} -q -F "${_aefi_SearchString_}" "${COMPOSE_OVERRIDE}"; then
+			local _aefi_ReplaceString_="${_aefi_AppEnvFilename_}"
+			# Replace all references to 'env_files/appname.env' with '.env.app.appname' in the override file
+			notice "Replacing in '{{|File|}}${COMPOSE_OVERRIDE}{{[-]}}':"
+			notice "   '{{|Var|}}${_aefi_SearchString_}{{[-]}}' with '{{|Var|}}${_aefi_ReplaceString_}{{[-]}}'"
+			# Escape . to [.] to use in sed
+			_aefi_SearchString_="${_aefi_SearchString_//./[.]}"
+			RunAndLog "" "sed:notice" \
+				fatal "Failed to edit override file." \
+				"${SED}" -i "s|${_aefi_SearchString_}|${_aefi_ReplaceString_}|g" "${COMPOSE_OVERRIDE}"
+		fi
+	fi
+	_aefi_out_="${_aefi_AppEnvFile_}"
+}
+
+test_app_env_file_into() {
+	for AppName in watchtower radarr radarr__4k; do
+		local Result
+		run_script 'app_env_file_into' Result "${AppName}"
+		notice "[${AppName}] [${Result}]"
+	done
+}

--- a/scripts/app_filter_runnable.sh
+++ b/scripts/app_filter_runnable.sh
@@ -7,7 +7,7 @@ app_filter_runnable() {
 	AppList="$(xargs -n 1 <<< "$*")"
 	for AppName in ${AppList}; do
 		local -l basename
-		basename=$(run_script 'appname_to_baseappname' "${AppName}")
+		run_script 'appname_to_baseappname_into' basename "${AppName}"
 		local main_yml="${TEMPLATES_FOLDER}/${basename}/${basename}.yml"
 		local arch_yml="${TEMPLATES_FOLDER}/${basename}/${basename}.${ARCH}.yml"
 		if [[ -f ${main_yml} && -f ${arch_yml} ]]; then

--- a/scripts/app_instance_file.sh
+++ b/scripts/app_instance_file.sh
@@ -2,9 +2,7 @@
 set -Eeuo pipefail
 IFS=$'\n\t'
 
-declare -a _dependencies_list=(
-	sed
-)
+declare -a _dependencies_list=()
 
 app_instance_file() {
 	# app_instance_file AppName FilenameTemplate
@@ -12,106 +10,9 @@ app_instance_file() {
 	#
 	# app_instance_file "radarr" "*.labels.yml" will return a string similar to "/home/user/.dockstarter/instances/radarr/radarr.labels.yml"
 	# If the file does not exist, it is created from the matching file in the "templates" folder.
-
-	local -l appname=${1:-}
-	local FilenameTemplate=${2:-}
-
-	if [[ ! -d ${INSTANCES_FOLDER} ]]; then
-		mkdir -p "${INSTANCES_FOLDER}" ||
-			fatal \
-				"Failed to create folder '{{|Folder|}}${INSTANCES_FOLDER}{{[-]}}'." \
-				"Failing command: mkdir -p \"${INSTANCES_FOLDER}\""
-		run_script 'set_permissions' "${INSTANCES_FOLDER}"
-	fi
-
-	local -l baseapp
-	baseapp="$(run_script 'appname_to_baseappname' "${appname}")"
-
-	local TemplateFolder="${TEMPLATES_FOLDER}/${baseapp}"
-	local InstanceTemplateFolder="${INSTANCES_FOLDER}/${TEMPLATES_FOLDER_NAME}/${appname}"
-	local InstanceFolder="${INSTANCES_FOLDER}/${appname}"
-
-	local TemplateFile="${TemplateFolder}/${FilenameTemplate//"*"/"${baseapp}"}"
-	local InstanceTemplateFile="${InstanceTemplateFolder}/${FilenameTemplate//"*"/"${appname}"}"
-	local InstanceFile="${InstanceFolder}/${FilenameTemplate//"*"/"${appname}"}"
-
-	echo "${InstanceFile}"
-
-	if [[ ! -d ${TemplateFolder} ]]; then
-		# Template folder doesn't exist, remove any instance folders associated with it and return
-		for Folder in "${InstanceTemplateFolder}" "${InstanceFolder}"; do
-			if [[ -d ${Folder} ]]; then
-				run_script 'set_permissions' "${Folder}"
-				rm -rf "${Folder}" &> /dev/null ||
-					error \
-						"Failed to remove directory." \
-						"Failing command: {{|FailingCommand|}}rm -rf \"${Folder}\""
-			fi
-		done
-		return
-	fi
-
-	if [[ ! -f ${TemplateFile} ]]; then
-		# Template file doesn't exist, remove any instance files associated with it and return
-		for File in "${InstanceTemplateFile}" "${InstanceFile}"; do
-			if [[ -f ${File} ]]; then
-				run_script 'set_permissions' "${File}"
-				rm -f "${File}" &> /dev/null ||
-					error \
-						"Failed to remove file." \
-						"Failing command: {{|FailingCommand|}}rm -f \"${File}\""
-			fi
-		done
-		return
-	fi
-
-	if [[ -f ${InstanceFile} && -f ${InstanceTemplateFile} ]] && cmp -s "${TemplateFile}" "${InstanceTemplateFile}"; then
-		# The instance file exists, and the template file has not changed, nothing to do.
-		return
-	fi
-
-	# If we got here, the instance file needs to be created
-
-	if [[ ! -d ${InstanceFolder} ]]; then
-		# Create the folder to place the instance file in
-		mkdir -p "${InstanceFolder}" ||
-			fatal \
-				"Failed to create folder '{{|Folder|}}${InstanceFolder}{{[-]}}'." \
-				"Failing command: {{|FailingCommand|}}mkdir -p \"${InstanceFolder}\""
-		run_script 'set_permissions' "${InstanceFolder}"
-	fi
-
-	# Create the instance file based on the template file
-	local instance
-	instance="$(run_script 'appname_to_instancename' "${appname}")"
-	local __INSTANCE __Instance __instance
-	if [[ -n ${instance} ]]; then
-		__INSTANCE="__${instance^^}"
-		local cap_prefix cap_rest
-		cap_prefix="${instance%%[a-zA-Z]*}"
-		cap_rest="${instance#"${cap_prefix}"}"
-		__Instance="__${cap_prefix}${cap_rest^}"
-		__instance="__${instance,,}"
-	fi
-	${SED} -e "s/<__INSTANCE>/${__INSTANCE-}/g ; s/<__instance>/${__instance-}/g ; s/<__Instance>/${__Instance-}/g" \
-		"${TemplateFile}" > "${InstanceFile}"
-	run_script 'set_permissions' "${InstanceFile}"
-
-	if [[ ! -d ${InstanceTemplateFolder} ]]; then
-		# Create the folder to place the copy of the template file in
-		mkdir -p "${InstanceTemplateFolder}" ||
-			fatal \
-				"Failed to create folder '{{|Folder|}}${InstanceTemplateFolder}{{[-]}}'." \
-				"Failing command: {{|FailingCommand|}}mkdir -p \"${InstanceTemplateFolder}\""
-		run_script 'set_permissions' "${InstanceTemplateFolder}"
-	fi
-
-	# Copy the original template file
-	cp "${TemplateFile}" "${InstanceTemplateFile}" ||
-		fatal \
-			"Failed to copy file." \
-			"Failing command: {{|FailingCommand|}}cp \"${TemplateFile}\" \"${InstanceTemplateFile}\""
-	run_script 'set_permissions' "${InstanceTemplateFile}"
+	local _aif_result_
+	run_script 'app_instance_file_into' _aif_result_ "$@"
+	echo "${_aif_result_}"
 }
 
 test_app_instance_file() {

--- a/scripts/app_instance_file_into.sh
+++ b/scripts/app_instance_file_into.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+declare -a _dependencies_list=(
+	sed
+)
+
+app_instance_file_into() {
+	local -n _aifi_out_="${1}"
+	shift
+	local -l _aifi_appname_=${1:-}
+	local _aifi_FilenameTemplate_=${2:-}
+
+	if [[ ! -d ${INSTANCES_FOLDER} ]]; then
+		mkdir -p "${INSTANCES_FOLDER}" ||
+			fatal \
+				"Failed to create folder '{{|Folder|}}${INSTANCES_FOLDER}{{[-]}}'." \
+				"Failing command: mkdir -p \"${INSTANCES_FOLDER}\""
+		run_script 'set_permissions' "${INSTANCES_FOLDER}"
+	fi
+
+	local -l _aifi_baseapp_
+	run_script 'appname_to_baseappname_into' _aifi_baseapp_ "${_aifi_appname_}"
+
+	local _aifi_TemplateFolder_="${TEMPLATES_FOLDER}/${_aifi_baseapp_}"
+	local _aifi_InstanceTemplateFolder_="${INSTANCES_FOLDER}/${TEMPLATES_FOLDER_NAME}/${_aifi_appname_}"
+	local _aifi_InstanceFolder_="${INSTANCES_FOLDER}/${_aifi_appname_}"
+
+	local _aifi_TemplateFile_="${_aifi_TemplateFolder_}/${_aifi_FilenameTemplate_//"*"/"${_aifi_baseapp_}"}"
+	local _aifi_InstanceTemplateFile_="${_aifi_InstanceTemplateFolder_}/${_aifi_FilenameTemplate_//"*"/"${_aifi_appname_}"}"
+	local _aifi_InstanceFile_="${_aifi_InstanceFolder_}/${_aifi_FilenameTemplate_//"*"/"${_aifi_appname_}"}"
+
+	_aifi_out_="${_aifi_InstanceFile_}"
+
+	if [[ ! -d ${_aifi_TemplateFolder_} ]]; then
+		# Template folder doesn't exist, remove any instance folders associated with it and return
+		for _aifi_Folder_ in "${_aifi_InstanceTemplateFolder_}" "${_aifi_InstanceFolder_}"; do
+			if [[ -d ${_aifi_Folder_} ]]; then
+				run_script 'set_permissions' "${_aifi_Folder_}"
+				rm -rf "${_aifi_Folder_}" &> /dev/null ||
+					error \
+						"Failed to remove directory." \
+						"Failing command: {{|FailingCommand|}}rm -rf \"${_aifi_Folder_}\""
+			fi
+		done
+		return
+	fi
+
+	if [[ ! -f ${_aifi_TemplateFile_} ]]; then
+		# Template file doesn't exist, remove any instance files associated with it and return
+		for _aifi_File_ in "${_aifi_InstanceTemplateFile_}" "${_aifi_InstanceFile_}"; do
+			if [[ -f ${_aifi_File_} ]]; then
+				run_script 'set_permissions' "${_aifi_File_}"
+				rm -f "${_aifi_File_}" &> /dev/null ||
+					error \
+						"Failed to remove file." \
+						"Failing command: {{|FailingCommand|}}rm -f \"${_aifi_File_}\""
+			fi
+		done
+		return
+	fi
+
+	if [[ -f ${_aifi_InstanceFile_} && -f ${_aifi_InstanceTemplateFile_} ]] && cmp -s "${_aifi_TemplateFile_}" "${_aifi_InstanceTemplateFile_}"; then
+		# The instance file exists, and the template file has not changed, nothing to do.
+		return
+	fi
+
+	# If we got here, the instance file needs to be created
+
+	if [[ ! -d ${_aifi_InstanceFolder_} ]]; then
+		# Create the folder to place the instance file in
+		mkdir -p "${_aifi_InstanceFolder_}" ||
+			fatal \
+				"Failed to create folder '{{|Folder|}}${_aifi_InstanceFolder_}{{[-]}}'." \
+				"Failing command: {{|FailingCommand|}}mkdir -p \"${_aifi_InstanceFolder_}\""
+		run_script 'set_permissions' "${_aifi_InstanceFolder_}"
+	fi
+
+	# Create the instance file based on the template file
+	local _aifi_instance_
+	run_script 'appname_to_instancename_into' _aifi_instance_ "${_aifi_appname_}"
+	local _aifi_INSTANCE_ _aifi_Instance_ _aifi_instance_lc_
+	if [[ -n ${_aifi_instance_} ]]; then
+		_aifi_INSTANCE_="__${_aifi_instance_^^}"
+		local _aifi_cap_prefix_ _aifi_cap_rest_
+		_aifi_cap_prefix_="${_aifi_instance_%%[a-zA-Z]*}"
+		_aifi_cap_rest_="${_aifi_instance_#"${_aifi_cap_prefix_}"}"
+		_aifi_Instance_="__${_aifi_cap_prefix_}${_aifi_cap_rest_^}"
+		_aifi_instance_lc_="__${_aifi_instance_,,}"
+	fi
+	${SED} -e "s/<__INSTANCE>/${_aifi_INSTANCE_-}/g ; s/<__instance>/${_aifi_instance_lc_-}/g ; s/<__Instance>/${_aifi_Instance_-}/g" \
+		"${_aifi_TemplateFile_}" > "${_aifi_InstanceFile_}"
+	run_script 'set_permissions' "${_aifi_InstanceFile_}"
+
+	if [[ ! -d ${_aifi_InstanceTemplateFolder_} ]]; then
+		# Create the folder to place the copy of the template file in
+		mkdir -p "${_aifi_InstanceTemplateFolder_}" ||
+			fatal \
+				"Failed to create folder '{{|Folder|}}${_aifi_InstanceTemplateFolder_}{{[-]}}'." \
+				"Failing command: {{|FailingCommand|}}mkdir -p \"${_aifi_InstanceTemplateFolder_}\""
+		run_script 'set_permissions' "${_aifi_InstanceTemplateFolder_}"
+	fi
+
+	# Copy the original template file
+	cp "${_aifi_TemplateFile_}" "${_aifi_InstanceTemplateFile_}" ||
+		fatal \
+			"Failed to copy file." \
+			"Failing command: {{|FailingCommand|}}cp \"${_aifi_TemplateFile_}\" \"${_aifi_InstanceTemplateFile_}\""
+	run_script 'set_permissions' "${_aifi_InstanceTemplateFile_}"
+}
+
+test_app_instance_file_into() {
+	for AppName in watchtower watchtower__number2; do
+		for Template in "*.labels.yml" ".env"; do
+			notice "[${AppName}] [${Template}]"
+			local InstanceFile
+			run_script 'app_instance_file_into' InstanceFile "${AppName}" "${Template}"
+			notice "[${InstanceFile}]"
+			cat "${InstanceFile}"
+		done
+	done
+}

--- a/scripts/app_instance_folder.sh
+++ b/scripts/app_instance_folder.sh
@@ -3,35 +3,9 @@ set -Eeuo pipefail
 IFS=$'\n\t'
 
 app_instance_folder() {
-	# app_instance_folder AppName
-	# Returns the folder name of a folder in the instance folder for the app specified
-	#
-	# app_instance_folder "radarr"" will return a string similar to "/home/user/.dockstarter/instances/radarr"
-	# If the folder does not exist, it is created from the matching folder in the "templates" folder.
-
-	local AppName=${1:-}
-	local -l appname=${AppName}
-
-	local baseapp TemplateFolder InstanceFolder
-	baseapp="$(run_script 'appname_to_baseappname' "${appname}")"
-	TemplateFolder="${TEMPLATES_FOLDER}/${baseapp}"
-	InstanceFolder="${INSTANCES_FOLDER}/${appname}"
-
-	echo "${InstanceFolder}"
-	if [[ ! -d ${InstanceFolder} ]]; then
-		if [[ ! -d ${TemplateFolder} ]]; then
-			warn "Folder '{{|Folder|}}${TemplateFolder}{{[-]}}' does not exist."
-			return
-		fi
-		if [[ ! -d ${InstanceFolder} ]]; then
-			mkdir -p "${InstanceFolder}" ||
-				fatal \
-					"Failed to create folder '{{|Folder|}}${InstanceFolder}{{[-]}}'." \
-					"Failing command: {{|FailingCommand|}}mkdir -p \"${InstanceFolder}\""
-			run_script 'set_permissions' "${InstanceFolder}"
-		fi
-	fi
-
+	local _aifld_result_
+	run_script 'app_instance_folder_into' _aifld_result_ "$@"
+	echo "${_aifld_result_}"
 }
 
 test_app_instance_folder() {

--- a/scripts/app_instance_folder_into.sh
+++ b/scripts/app_instance_folder_into.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+declare -a _dependencies_list=()
+
+app_instance_folder_into() {
+	# app_instance_folder_into OutVar AppName
+	# Returns the folder name of a folder in the instance folder for the app specified
+	#
+	# app_instance_folder_into Result "radarr" will set Result to a string similar to "/home/user/.dockstarter/instances/radarr"
+	# If the folder does not exist, it is created from the matching folder in the "templates" folder.
+	local -n _aifld_out_="${1}"
+	local _aifld_AppName_=${2:-}
+	local -l _aifld_appname_=${_aifld_AppName_}
+
+	local _aifld_baseapp_ _aifld_TemplateFolder_ _aifld_InstanceFolder_
+	run_script 'appname_to_baseappname_into' _aifld_baseapp_ "${_aifld_appname_}"
+	_aifld_TemplateFolder_="${TEMPLATES_FOLDER}/${_aifld_baseapp_}"
+	_aifld_InstanceFolder_="${INSTANCES_FOLDER}/${_aifld_appname_}"
+
+	_aifld_out_="${_aifld_InstanceFolder_}"
+	if [[ ! -d ${_aifld_InstanceFolder_} ]]; then
+		if [[ ! -d ${_aifld_TemplateFolder_} ]]; then
+			warn "Folder '{{|Folder|}}${_aifld_TemplateFolder_}{{[-]}}' does not exist."
+			return
+		fi
+		if [[ ! -d ${_aifld_InstanceFolder_} ]]; then
+			mkdir -p "${_aifld_InstanceFolder_}" ||
+				fatal \
+					"Failed to create folder '{{|Folder|}}${_aifld_InstanceFolder_}{{[-]}}'." \
+					"Failing command: {{|FailingCommand|}}mkdir -p \"${_aifld_InstanceFolder_}\""
+			run_script 'set_permissions' "${_aifld_InstanceFolder_}"
+		fi
+	fi
+}
+
+test_app_instance_folder_into() {
+	for AppName in watchtower watchtower__number2; do
+		notice "[${AppName}]"
+		local Result
+		run_script 'app_instance_folder_into' Result "${AppName}"
+		notice "[${Result}]"
+		ls -lah "${Result}"
+	done
+}

--- a/scripts/app_is_builtin.sh
+++ b/scripts/app_is_builtin.sh
@@ -6,7 +6,7 @@ app_is_builtin() {
 	local -l appname=${1-}
 
 	local -l baseapp
-	baseapp="$(run_script 'appname_to_baseappname' "${appname}")"
+	run_script 'appname_to_baseappname_into' baseapp "${appname}"
 	[[ -d "${TEMPLATES_FOLDER}/${baseapp}" ]]
 }
 

--- a/scripts/app_is_deprecated.sh
+++ b/scripts/app_is_deprecated.sh
@@ -10,7 +10,7 @@ declare -a _dependencies_list=(
 app_is_deprecated() {
 	local -l appname=${1-}
 	local -l baseappname
-	baseappname=$(run_script 'appname_to_baseappname' "${appname}")
+	run_script 'appname_to_baseappname_into' baseappname "${appname}"
 	local labels_yml
 	labels_yml="$(run_script 'app_template_file' "${baseappname}" "*.labels.yml")"
 	local APP_DEPRECATED

--- a/scripts/app_is_disabled.sh
+++ b/scripts/app_is_disabled.sh
@@ -8,7 +8,9 @@ app_is_disabled() {
 		false
 		return
 	fi
-	is_false "$(run_script 'env_get' "${APPNAME}__ENABLED")"
+	local _aid_enabled_
+	run_script 'env_get_into' _aid_enabled_ "${APPNAME}__ENABLED"
+	is_false "${_aid_enabled_}"
 }
 
 test_app_is_disabled() {

--- a/scripts/app_is_enabled.sh
+++ b/scripts/app_is_enabled.sh
@@ -8,7 +8,9 @@ app_is_enabled() {
 		false
 		return
 	fi
-	is_true "$(run_script 'env_get' "${APPNAME}__ENABLED")"
+	local _aie_enabled_
+	run_script 'env_get_into' _aie_enabled_ "${APPNAME}__ENABLED"
+	is_true "${_aie_enabled_}"
 }
 
 test_app_is_enabled() {

--- a/scripts/app_is_nondeprecated.sh
+++ b/scripts/app_is_nondeprecated.sh
@@ -10,7 +10,7 @@ declare -a _dependencies_list=(
 app_is_nondeprecated() {
 	local -l appname=${1-}
 	local -l baseappname
-	baseappname=$(run_script 'appname_to_baseappname' "${appname}")
+	run_script 'appname_to_baseappname_into' baseappname "${appname}"
 	local labels_yml
 	labels_yml="$(run_script 'app_template_file' "${baseappname}" "*.labels.yml")"
 	local APP_DEPRECATED

--- a/scripts/app_is_runnable.sh
+++ b/scripts/app_is_runnable.sh
@@ -5,7 +5,7 @@ IFS=$'\n\t'
 app_is_runnable() {
 	local -l appname=${1-}
 	local -l basename
-	basename=$(run_script 'appname_to_baseappname' "${appname}")
+	run_script 'appname_to_baseappname_into' basename "${appname}"
 	local main_yml
 	main_yml="$(run_script 'app_template_file' "${basename}" "*.yml")"
 	local arch_yml

--- a/scripts/app_list_enabled.sh
+++ b/scripts/app_list_enabled.sh
@@ -14,7 +14,9 @@ app_list_enabled() {
 		${GREP} --color=never -o -P "^${APPNAME_REGEX}(?=__ENABLED\s*=(?<quote>['|\"]?)(?i:on|true|yes)\k<quote>)" "${COMPOSE_ENV}" | sort || true
 	)
 	for AppName in "${ENABLED_APPS[@]}"; do
-		if [[ -d "$(run_script 'app_instance_folder' "${AppName}")" ]]; then
+		local _ale_folder_
+		run_script 'app_instance_folder_into' _ale_folder_ "${AppName}"
+		if [[ -d ${_ale_folder_} ]]; then
 			echo "${AppName}"
 		fi
 	done

--- a/scripts/app_nicename.sh
+++ b/scripts/app_nicename.sh
@@ -7,29 +7,10 @@ app_nicename() {
 	local AppList
 	AppList="$(xargs -n 1 <<< "$*")"
 	for APPNAME in ${AppList}; do
-		local AppName="${APPNAME%:*}"
-		if ! run_script 'app_is_user_defined' "${AppName}"; then
-			run_script 'app_nicename_from_template' "${AppName}"
-			continue
-		fi
-
-		local -l baseapp instance
-		local BaseApp Instance
-		baseapp=$(run_script 'appname_to_baseappname' "${AppName}")
-		BaseApp="${baseapp^}"
-		instance=$(run_script 'appname_to_instancename' "${AppName}")
-		Instance=""
-		if [[ -n ${instance} ]]; then
-			# Capitalize first letter character, skipping any leading digits.
-			# e.g. "4k" → "4K", "instance" → "Instance"
-			local cap_prefix cap_rest
-			cap_prefix="${instance%%[a-zA-Z]*}"
-			cap_rest="${instance#"${cap_prefix}"}"
-			Instance="__${cap_prefix}${cap_rest^}"
-		fi
-		echo "${BaseApp}${Instance}"
+		local _an_result_
+		run_script 'app_nicename_into' _an_result_ "${APPNAME}"
+		echo "${_an_result_}"
 	done
-
 }
 
 test_app_nicename() {

--- a/scripts/app_nicename_from_template.sh
+++ b/scripts/app_nicename_from_template.sh
@@ -2,38 +2,16 @@
 set -Eeuo pipefail
 IFS=$'\n\t'
 
-declare -a _dependencies_list=(
-	grep
-	sed
-)
+declare -a _dependencies_list=()
 
 app_nicename_from_template() {
 	# Return the "NiceName" of the appname(s) passed. If there is no "NiceName", return the "Title__Case" of "appname"
 	local AppList
 	AppList="$(xargs -n 1 <<< "$*")"
 	for APPNAME in ${AppList}; do
-		local AppName="${APPNAME%:*}"
-		local -l baseapp instance
-		local BaseApp Instance
-		baseapp=$(run_script 'appname_to_baseappname' "${AppName}")
-		BaseApp="${baseapp^}"
-		labels_yml="$(run_script 'app_instance_file' "${baseapp}" "*.labels.yml")"
-		if [[ -f ${labels_yml} ]]; then
-			BaseApp="$(
-				${GREP} --color=never -Po "\scom\.dockstarter\.appinfo\.nicename: \K.*" "${labels_yml}" | ${SED} -E 's/^([^"].*[^"])$/"\1"/' | xargs
-			)"
-		fi
-		instance=$(run_script 'appname_to_instancename' "${AppName}")
-		Instance=""
-		if [[ -n ${instance} ]]; then
-			# Capitalize first letter character, skipping any leading digits.
-			# e.g. "4k" → "4K", "instance" → "Instance"
-			local cap_prefix cap_rest
-			cap_prefix="${instance%%[a-zA-Z]*}"
-			cap_rest="${instance#"${cap_prefix}"}"
-			Instance="__${cap_prefix}${cap_rest^}"
-		fi
-		echo "${BaseApp}${Instance}"
+		local _anft_result_
+		run_script 'app_nicename_from_template_into' _anft_result_ "${APPNAME}"
+		echo "${_anft_result_}"
 	done
 }
 

--- a/scripts/app_nicename_from_template_into.sh
+++ b/scripts/app_nicename_from_template_into.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+declare -a _dependencies_list=(
+	grep
+	sed
+)
+
+app_nicename_from_template_into() {
+	# Return the "NiceName" of a single appname. If there is no "NiceName", return the "Title__Case" of "appname"
+	local -n _anft_out_="${1}"
+	local _anft_AppName_="${2-}"
+	_anft_AppName_="${_anft_AppName_%:*}"
+	local -l _anft_baseapp_ _anft_instance_
+	local _anft_BaseApp_ _anft_Instance_ _anft_labels_yml_
+	run_script 'appname_to_baseappname_into' _anft_baseapp_ "${_anft_AppName_}"
+	_anft_BaseApp_="${_anft_baseapp_^}"
+	run_script 'app_instance_file_into' _anft_labels_yml_ "${_anft_baseapp_}" "*.labels.yml"
+	if [[ -f ${_anft_labels_yml_} ]]; then
+		_anft_BaseApp_="$(
+			${GREP} --color=never -Po "\scom\.dockstarter\.appinfo\.nicename: \K.*" "${_anft_labels_yml_}" | ${SED} -E 's/^([^"].*[^"])$/"\1"/' | xargs
+		)"
+	fi
+	run_script 'appname_to_instancename_into' _anft_instance_ "${_anft_AppName_}"
+	_anft_Instance_=""
+	if [[ -n ${_anft_instance_} ]]; then
+		local _anft_cap_prefix_ _anft_cap_rest_
+		_anft_cap_prefix_="${_anft_instance_%%[a-zA-Z]*}"
+		_anft_cap_rest_="${_anft_instance_#"${_anft_cap_prefix_}"}"
+		_anft_Instance_="__${_anft_cap_prefix_}${_anft_cap_rest_^}"
+	fi
+	_anft_out_="${_anft_BaseApp_}${_anft_Instance_}"
+}
+
+test_app_nicename_from_template_into() {
+	local ForcePass='' # Force the tests to pass even on failure if set to a non-empty value
+	local -i result=0
+	run_script 'appvars_create' WATCHTOWER NZBGET
+	local -a Test=(
+		WATCHTOWER Watchtower
+		SAMBA Samba
+		RADARR Radarr
+		nzbget NZBGet
+		NZBGet NZBGet
+		NZBGET NZBGet
+		NONEXISTENTAPP Nonexistentapp
+		WATCHTOWER__INSTANCE Watchtower__Instance
+		SAMBA__INSTANCE Samba__Instance
+		RADARR__INSTANCE Radarr__Instance
+		NZBGET__INSTANCE NZBGet__Instance
+		NONEXISTENTAPP__INSTANCE Nonexistentapp__Instance
+		NONEXISTENTAPP__4K Nonexistentapp__4K
+		NONEXISTENTAPP__23KKK Nonexistentapp__23Kkk
+	)
+	run_unit_tests_pipe "App" "App" "${ForcePass}" < <(
+		for ((i = 0; i < ${#Test[@]}; i += 2)); do
+			local Result
+			run_script 'app_nicename_from_template_into' Result "${Test[i]}"
+			printf '%s\n' \
+				"${Test[i]}" \
+				"${Test[i + 1]}" \
+				"${Result}"
+		done
+	)
+	result=$?
+	run_script 'appvars_purge' WATCHTOWER NZBGET
+	return ${result}
+}

--- a/scripts/app_nicename_into.sh
+++ b/scripts/app_nicename_into.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+declare -a _dependencies_list=()
+
+app_nicename_into() {
+	# Return the "NiceName" of a single appname. If there is no "NiceName", return the "Title__Case" of "appname"
+	local -n _ani_out_="${1}"
+	local _ani_AppName_="${2-}"
+	_ani_AppName_="${_ani_AppName_%:*}"
+	if ! run_script 'app_is_user_defined' "${_ani_AppName_}"; then
+		run_script 'app_nicename_from_template_into' _ani_out_ "${_ani_AppName_}"
+		return
+	fi
+
+	local -l _ani_baseapp_ _ani_instance_
+	local _ani_BaseApp_ _ani_Instance_
+	run_script 'appname_to_baseappname_into' _ani_baseapp_ "${_ani_AppName_}"
+	_ani_BaseApp_="${_ani_baseapp_^}"
+	run_script 'appname_to_instancename_into' _ani_instance_ "${_ani_AppName_}"
+	_ani_Instance_=""
+	if [[ -n ${_ani_instance_} ]]; then
+		local _ani_cap_prefix_ _ani_cap_rest_
+		_ani_cap_prefix_="${_ani_instance_%%[a-zA-Z]*}"
+		_ani_cap_rest_="${_ani_instance_#"${_ani_cap_prefix_}"}"
+		_ani_Instance_="__${_ani_cap_prefix_}${_ani_cap_rest_^}"
+	fi
+	_ani_out_="${_ani_BaseApp_}${_ani_Instance_}"
+}
+
+test_app_nicename_into() {
+	local ForcePass='' # Force the tests to pass even on failure if set to a non-empty value
+	local -i result=0
+	run_script 'appvars_create' WATCHTOWER NZBGET
+	local -a Test=(
+		WATCHTOWER Watchtower
+		SAMBA Samba
+		RADARR Radarr
+		nzbget NZBGet
+		NZBGet NZBGet
+		NZBGET NZBGet
+		NONEXISTENTAPP Nonexistentapp
+		WATCHTOWER__INSTANCE Watchtower__Instance
+		SAMBA__INSTANCE Samba__Instance
+		RADARR__INSTANCE Radarr__Instance
+		NZBGET__INSTANCE Nzbget__Instance
+		NONEXISTENTAPP__INSTANCE Nonexistentapp__Instance
+		NONEXISTENTAPP__4K Nonexistentapp__4K
+		NONEXISTENTAPP__23KKK Nonexistentapp__23Kkk
+	)
+	run_unit_tests_pipe "App" "App" "${ForcePass}" < <(
+		for ((i = 0; i < ${#Test[@]}; i += 2)); do
+			local Result
+			run_script 'app_nicename_into' Result "${Test[i]}"
+			printf '%s\n' \
+				"${Test[i]}" \
+				"${Test[i + 1]}" \
+				"${Result}"
+		done
+	)
+	result=$?
+	run_script 'appvars_purge' WATCHTOWER NZBGET
+	return ${result}
+}

--- a/scripts/app_status.sh
+++ b/scripts/app_status.sh
@@ -8,7 +8,7 @@ app_status() {
 	AppList="$(xargs -n 1 <<< "$*")"
 	for APPNAME in ${AppList}; do
 		local AppName
-		AppName="$(run_script 'app_nicename' "${APPNAME}")"
+		run_script 'app_nicename_into' AppName "${APPNAME}"
 		if run_script 'app_is_referenced' "${AppName}"; then
 			if run_script 'app_is_added' "${AppName}"; then
 				if run_script 'app_is_enabled' "${AppName}"; then

--- a/scripts/appfolders_create.sh
+++ b/scripts/appfolders_create.sh
@@ -14,10 +14,10 @@ appfolders_create() {
 	local -u APPNAME=${1-}
 	local -l appname=${APPNAME}
 	local AppName
-	AppName="$(run_script 'app_nicename' "${APPNAME}")"
+	run_script 'app_nicename_into' AppName "${APPNAME}"
 
 	local APP_FOLDERS_FILE
-	APP_FOLDERS_FILE="$(run_script 'app_instance_file' "${appname}" "*.folders")"
+	run_script 'app_instance_file_into' APP_FOLDERS_FILE "${appname}" "*.folders"
 
 	if [[ -f ${APP_FOLDERS_FILE} ]]; then
 		local -a FoldersArray=()

--- a/scripts/appname_is_valid.sh
+++ b/scripts/appname_is_valid.sh
@@ -32,7 +32,7 @@ appname_is_valid() {
 			InvalidInstanceNamesRegex="${InvalidInstanceNames[*]}"
 		}
 		local -u InstanceName
-		InstanceName="$(run_script 'appname_to_instancename' "${APPNAME}")"
+		run_script 'appname_to_instancename_into' InstanceName "${APPNAME}"
 		[[ ! ${InstanceName} =~ ${InvalidInstanceNamesRegex} ]]
 		return
 	fi

--- a/scripts/appname_to_baseappname.sh
+++ b/scripts/appname_to_baseappname.sh
@@ -3,8 +3,9 @@ set -Eeuo pipefail
 IFS=$'\n\t'
 
 appname_to_baseappname() {
-	local AppName=${1-}
-	echo "${AppName%__*}"
+	local _atbn_result_
+	run_script 'appname_to_baseappname_into' _atbn_result_ "$@"
+	echo "${_atbn_result_}"
 }
 
 test_appname_to_baseappname() {

--- a/scripts/appname_to_baseappname_into.sh
+++ b/scripts/appname_to_baseappname_into.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+declare -a _dependencies_list=()
+
+appname_to_baseappname_into() {
+	local -n _atbn_out_="${1}"
+	local _atbn_AppName_=${2-}
+	_atbn_out_="${_atbn_AppName_%__*}"
+}
+
+test_appname_to_baseappname_into() {
+	for AppName in RADARR RADARR__4K; do
+		local Result
+		run_script 'appname_to_baseappname_into' Result "${AppName}"
+		notice "[${AppName}] [${Result}]"
+	done
+}

--- a/scripts/appname_to_instancename.sh
+++ b/scripts/appname_to_instancename.sh
@@ -3,12 +3,9 @@ set -Eeuo pipefail
 IFS=$'\n\t'
 
 appname_to_instancename() {
-	local AppName=${1-}
-	if [[ ${AppName} == *"__"* ]]; then
-		echo "${AppName#*__}"
-	else
-		echo ""
-	fi
+	local _atin_result_
+	run_script 'appname_to_instancename_into' _atin_result_ "$@"
+	echo "${_atin_result_}"
 }
 
 test_appname_to_instancename() {

--- a/scripts/appname_to_instancename_into.sh
+++ b/scripts/appname_to_instancename_into.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+declare -a _dependencies_list=()
+
+appname_to_instancename_into() {
+	local -n _atin_out_="${1}"
+	local _atin_AppName_=${2-}
+	if [[ ${_atin_AppName_} == *"__"* ]]; then
+		_atin_out_="${_atin_AppName_#*__}"
+	else
+		_atin_out_=""
+	fi
+}
+
+test_appname_to_instancename_into() {
+	for AppName in RADARR RADARR__4K; do
+		local Result
+		run_script 'appname_to_instancename_into' Result "${AppName}"
+		notice "[${AppName}] [${Result}]"
+	done
+}

--- a/scripts/appvars_create.sh
+++ b/scripts/appvars_create.sh
@@ -8,7 +8,7 @@ appvars_create() {
 	for APPNAME in ${AppList^^}; do
 		local -l appname=${APPNAME}
 		local AppName
-		AppName="$(run_script 'app_nicename' "${APPNAME}")"
+		run_script 'app_nicename_into' AppName "${APPNAME}"
 		if ! run_script 'appname_is_valid' "${appname}"; then
 			error "'{{|App|}}${AppName}{{[-]}}' is not a valid application name."
 			continue
@@ -22,8 +22,8 @@ appvars_create() {
 
 		if run_script 'app_is_builtin' "${AppName}"; then
 			local AppDefaultGlobalEnvFile AppDefaultAppEnvFile AppEnvFile
-			AppDefaultGlobalEnvFile="$(run_script 'app_instance_file' "${appname}" ".env")"
-			AppDefaultAppEnvFile="$(run_script 'app_instance_file' "${appname}" ".env.app.*")"
+			run_script 'app_instance_file_into' AppDefaultGlobalEnvFile "${appname}" ".env"
+			run_script 'app_instance_file_into' AppDefaultAppEnvFile "${appname}" ".env.app.*"
 			AppEnvFile="$(run_script 'app_env_file' "${appname}")"
 
 			info "Creating environment variables for '{{|App|}}${AppName}{{[-]}}'."

--- a/scripts/appvars_migrate.sh
+++ b/scripts/appvars_migrate.sh
@@ -11,7 +11,7 @@ appvars_migrate() {
 	local -l appname=${APPNAME}
 
 	local MIGRATE_FILE
-	MIGRATE_FILE="$(run_script 'app_instance_file' "${appname}" "*.migrate")"
+	run_script 'app_instance_file_into' MIGRATE_FILE "${appname}" "*.migrate"
 
 	if [[ -f ${MIGRATE_FILE} ]]; then
 		local -a MigrateLines=()

--- a/scripts/appvars_purge.sh
+++ b/scripts/appvars_purge.sh
@@ -13,7 +13,7 @@ appvars_purge() {
 	applist="$(xargs -n 1 <<< "$*")"
 	for appname in ${applist}; do
 		local AppName
-		AppName=$(run_script 'app_nicename' "${appname}")
+		run_script 'app_nicename_into' AppName "${appname}"
 
 		local AppEnvFile
 		AppEnvFile="$(run_script 'app_env_file' "${appname}")"

--- a/scripts/appvars_rename.sh
+++ b/scripts/appvars_rename.sh
@@ -17,7 +17,7 @@ appvars_rename() {
 				"Failing command: {{|FailingCommand|}}docker stop ${FROMAPP,,}"
 		notice "Moving config folder."
 		local DOCKER_VOLUME_CONFIG
-		DOCKER_VOLUME_CONFIG="$(run_script 'env_get' DOCKER_VOLUME_CONFIG)"
+		run_script 'env_get_into' DOCKER_VOLUME_CONFIG DOCKER_VOLUME_CONFIG
 		mv "${DOCKER_VOLUME_CONFIG}/${FROMAPP,,}" "${DOCKER_VOLUME_CONFIG}/${TOAPP,,}" ||
 			warn \
 				"Failed to move folder." \

--- a/scripts/appvars_sanitize.sh
+++ b/scripts/appvars_sanitize.sh
@@ -12,12 +12,12 @@ appvars_sanitize() {
 	local -A UpdatedVarValue
 
 	local BaseAppName
-	BaseAppName="$(run_script 'appname_to_baseappname' "${AppName}")"
+	run_script 'appname_to_baseappname_into' BaseAppName "${AppName}"
 	if [[ ${BaseAppName^^} == WATCHTOWER ]]; then
 		# Don't set WATCHTOWER__NETWORK_MODE to none
 		local VarName="${AppName^^}__NETWORK_MODE"
 		local Value
-		Value="$(run_script 'env_get' "${VarName}")"
+		run_script 'env_get_into' Value "${VarName}"
 		if [[ ${Value-} == "none" ]]; then
 			VarsToUpdate+=("${VarName}")
 			UpdatedVarValue["${VarName}"]="''"
@@ -32,7 +32,7 @@ appvars_sanitize() {
 	for VarName in "${VarList[@]}"; do
 		# Get the value including quotes
 		local Value
-		Value="$(run_script 'env_get_literal' "${VarName}")"
+		run_script 'env_get_literal_into' Value "${VarName}"
 		local UpdatedValue
 		UpdatedValue="$(run_script 'sanitize_path' "${Value}")"
 		if [[ ${Value} != "${UpdatedValue}" ]]; then

--- a/scripts/docker_compose.sh
+++ b/scripts/docker_compose.sh
@@ -9,7 +9,7 @@ docker_compose() {
 	local APPNAME AppName
 	if [[ ${ComposeInput} == *" "* ]]; then
 		APPNAME=${ComposeInput#* }
-		AppName="$(run_script 'app_nicename' "${APPNAME}" | xargs)"
+		run_script 'app_nicename_into' AppName "${APPNAME}"
 		AppName="${AppName// /, }"
 	fi
 

--- a/scripts/env_backup.sh
+++ b/scripts/env_backup.sh
@@ -10,7 +10,7 @@ env_backup() {
 	local DOCKER_VOLUME_CONFIG
 	# Update CONFIG_FOLDER and LITERAL_CONFIG_FOLDER based on DOCKER_CONFIG_FOLDER
 	local DOCKER_CONFIG_FOLDER
-	DOCKER_CONFIG_FOLDER="$(run_script 'env_get' DOCKER_CONFIG_FOLDER)"
+	run_script 'env_get_into' DOCKER_CONFIG_FOLDER DOCKER_CONFIG_FOLDER
 	if [[ -z ${DOCKER_CONFIG_FOLDER-} ]]; then
 		DOCKER_CONFIG_FOLDER="$(run_script 'var_default_value' DOCKER_CONFIG_FOLDER)"
 	fi
@@ -20,9 +20,9 @@ env_backup() {
 		HOME="${HOME}" XDG_CONFIG_HOME="${XDG_CONFIG_HOME}" \
 			eval echo "${LITERAL_CONFIG_FOLDER}"
 	)"
-	DOCKER_VOLUME_CONFIG="$(run_script 'env_get' DOCKER_VOLUME_CONFIG)"
+	run_script 'env_get_into' DOCKER_VOLUME_CONFIG DOCKER_VOLUME_CONFIG
 	if [[ -z ${DOCKER_VOLUME_CONFIG-} ]]; then
-		DOCKER_VOLUME_CONFIG="$(run_script 'env_get' DOCKERCONFDIR)"
+		run_script 'env_get_into' DOCKER_VOLUME_CONFIG DOCKERCONFDIR
 	fi
 	if [[ -z ${DOCKER_VOLUME_CONFIG-} ]]; then
 		DOCKER_VOLUME_CONFIG="$(run_script 'var_default_value' DOCKER_VOLUME_CONFIG)"

--- a/scripts/env_format_lines.sh
+++ b/scripts/env_format_lines.sh
@@ -33,7 +33,7 @@ env_format_lines() {
 		if run_script 'app_is_user_defined' "${APPNAME}"; then
 			AppIsUserDefined='Y'
 		fi
-		AppName="$(run_script 'app_nicename' "${APPNAME}")"
+		run_script 'app_nicename_into' AppName "${APPNAME}"
 		AppDescription="$(run_script 'app_description' "${APPNAME}" | wordwrap_pipe 75)"
 		local HeadingTitle="${AppName}"
 		if [[ ${AppIsUserDefined} == Y ]]; then

--- a/scripts/env_get_and_expand.sh
+++ b/scripts/env_get_and_expand.sh
@@ -16,7 +16,7 @@ env_get_and_expand() {
 		shift $#
 	fi
 	local String=""
-	String="$(run_script 'env_get' "${VarName}" "${VarFile}")"
+	run_script 'env_get_into' String "${VarName}" "${VarFile}"
 	if [[ -z ${String} ]]; then
 		return
 	fi

--- a/scripts/env_get_into.sh
+++ b/scripts/env_get_into.sh
@@ -2,15 +2,42 @@
 set -Eeuo pipefail
 IFS=$'\n\t'
 
-declare -a _dependencies_list=()
+declare -a _dependencies_list=(
+	grep
+)
 
-env_get() {
-	local _eg_result_
-	run_script 'env_get_into' _eg_result_ "$@"
-	echo "${_eg_result_}"
+env_get_into() {
+	# env_get_into OutVar VarName [VarFile]
+	# env_get_into OutVar APPNAME:VarName
+	#
+	# Returns the variable "VarName" If no "VarFile" is given, uses the global .env file
+	# If "APPNAME:" is provided, gets variable from ".env.app.appname"
+	local -n _egi_out_="${1}"
+	local _egi_VarName_=${2-}
+	local _egi_VarFile_=${3:-$COMPOSE_ENV}
+
+	if ! run_script 'varname_is_valid' "${_egi_VarName_}"; then
+		error "{{[cyan]}}${_egi_VarName_}{{[-]}} is an invalid variable name."
+		return
+	fi
+
+	if [[ ${_egi_VarName_} =~ ^[A-Za-z0-9_]+: ]]; then
+		# VarName is in the form of "APPNAME:VARIABLE", set new file to use
+		local _egi_APPNAME_=${_egi_VarName_%%:*}
+		run_script 'app_env_file_into' _egi_VarFile_ "${_egi_APPNAME_}"
+		_egi_VarName_=${_egi_VarName_#"${_egi_APPNAME_}:"}
+	fi
+	if [[ -e ${_egi_VarFile_} ]]; then
+		local _egi_LiteralValue_
+		run_script 'env_get_literal_into' _egi_LiteralValue_ "${_egi_VarName_}" "${_egi_VarFile_}"
+		_egi_out_="$(${GREP} --color=never -Po "^\s*(?:(?:(?<Q>['\"]).*\k<Q>)|(?:[^\s]+(?:\s+(?!#)[^\s]+)*))" <<< "${_egi_LiteralValue_}" | xargs 2> /dev/null || true)"
+	else
+		# VarFile does not exist, give a warning
+		warn "File '{{|File|}}${_egi_VarFile_}{{[-]}}' does not exist."
+	fi
 }
 
-test_env_get() {
+test_env_get_into() {
 	# Return a "pass" for now.
 	# There is an error to be fixed in "Var_15=  Va# lue# Not a Comment"
 	local ForcePass='' # Force the tests to pass even on failure if set to a non-empty value
@@ -50,10 +77,12 @@ test_env_get() {
 	notice "$(cat "${VarFile}")"
 	run_unit_tests_pipe "Var" "Var" "${ForcePass}" < <(
 		for ((i = 0; i < ${#Test[@]}; i += 3)); do
+			local Result
+			run_script 'env_get_into' Result "${Test[i]}" "${VarFile}"
 			printf '%s\n' \
 				"${Test[i + 1]}" \
 				"${Test[i + 2]}" \
-				"$(run_script 'env_get' "${Test[i]}" "${VarFile}")"
+				"${Result}"
 		done
 	)
 	result=$?

--- a/scripts/env_get_line_into.sh
+++ b/scripts/env_get_line_into.sh
@@ -2,15 +2,40 @@
 set -Eeuo pipefail
 IFS=$'\n\t'
 
-declare -a _dependencies_list=()
+declare -a _dependencies_list=(
+	grep
+)
 
-env_get_line() {
-	local _egl_result_
-	run_script 'env_get_line_into' _egl_result_ "$@"
-	echo "${_egl_result_}"
+env_get_line_into() {
+	# env_get_line_into OutVar VarName [VarFile]
+	# env_get_line_into OutVar APPNAME:VarName
+	#
+	# Returns the variable "VarName" If no "VarFile" is given, uses the global .env file
+	# If "APPNAME:" is provided, gets variable from ".env.app.appname"
+	local -n _egli_out_="${1}"
+	local _egli_VarName_=${2-}
+	local _egli_VarFile_=${3:-$COMPOSE_ENV}
+
+	if ! run_script 'varname_is_valid' "${_egli_VarName_}"; then
+		error "'{{|Var|}}${_egli_VarName_}{{[-]}}' is an invalid variable name."
+		return
+	fi
+
+	if [[ ${_egli_VarName_} =~ ^[A-Za-z0-9_]+: ]]; then
+		# VarName is in the form of "APPNAME:VARIABLE", set new file to use
+		local _egli_APPNAME_=${_egli_VarName_%%:*}
+		run_script 'app_env_file_into' _egli_VarFile_ "${_egli_APPNAME_}"
+		_egli_VarName_=${_egli_VarName_#"${_egli_APPNAME_}:"}
+	fi
+	if [[ -e ${_egli_VarFile_} ]]; then
+		_egli_out_="$(${GREP} --color=never -Po "^\s*${_egli_VarName_}\s*=.*" "${_egli_VarFile_}" | tail -1 || true)"
+	else
+		# VarFile does not exist, give a warning
+		warn "File '{{|File|}}${_egli_VarFile_}{{[-]}}' does not exist."
+	fi
 }
 
-test_env_get_line() {
+test_env_get_line_into() {
 	local ForcePass='' # Force the tests to pass even on failure if set to a non-empty value
 	local -i result=0
 	local -a Test=(
@@ -48,10 +73,12 @@ test_env_get_line() {
 	notice "$(cat "${VarFile}")"
 	run_unit_tests_pipe "Var" "Var" "${ForcePass}" < <(
 		for ((i = 0; i < ${#Test[@]}; i += 3)); do
+			local Result
+			run_script 'env_get_line_into' Result "${Test[i]}" "${VarFile}"
 			printf '%s\n' \
 				"${Test[i + 1]}" \
 				"${Test[i + 2]}" \
-				"$(run_script 'env_get_line' "${Test[i]}" "${VarFile}")"
+				"${Result}"
 		done
 	)
 	result=$?

--- a/scripts/env_get_literal_into.sh
+++ b/scripts/env_get_literal_into.sh
@@ -4,13 +4,40 @@ IFS=$'\n\t'
 
 declare -a _dependencies_list=()
 
-env_get_literal() {
-	local _egl_result_
-	run_script 'env_get_literal_into' _egl_result_ "$@"
-	echo "${_egl_result_}"
+env_get_literal_into() {
+	# env_get_literal_into OutVar VarName [VarFile]
+	# env_get_literal_into OutVar APPNAME:VarName
+	#
+	# The string returned will be the literal value after `=`, including quotes and comments
+	#
+	# Returns the variable "VarName" If no "VarFile" is given, uses the global .env file
+	# If "APPNAME:" is provided, gets variable from ".env.app.appname"
+	local -n _eglli_out_="${1}"
+	local _eglli_VarName_=${2-}
+	local _eglli_VarFile_=${3:-$COMPOSE_ENV}
+
+	if ! run_script 'varname_is_valid' "${_eglli_VarName_}"; then
+		error "'{{|Var|}}${_eglli_VarName_}{{[-]}}' is an invalid variable name."
+		return
+	fi
+
+	if [[ ${_eglli_VarName_} =~ ^[A-Za-z0-9_]+: ]]; then
+		# VarName is in the form of "APPNAME:VARIABLE", set new file to use
+		local _eglli_APPNAME_=${_eglli_VarName_%%:*}
+		run_script 'app_env_file_into' _eglli_VarFile_ "${_eglli_APPNAME_}"
+		_eglli_VarName_=${_eglli_VarName_#"${_eglli_APPNAME_}:"}
+	fi
+	if [[ -e ${_eglli_VarFile_} ]]; then
+		local _eglli_Line_
+		run_script 'env_get_line_into' _eglli_Line_ "${_eglli_VarName_}" "${_eglli_VarFile_}"
+		_eglli_out_="${_eglli_Line_#*=}"
+	else
+		# VarFile does not exist, give a warning
+		warn "File '{{|File|}}${_eglli_VarFile_}{{[-]}}' does not exist."
+	fi
 }
 
-test_env_get_literal() {
+test_env_get_literal_into() {
 	local ForcePass='' # Force the tests to pass even on failure if set to a non-empty value
 	local -i result=0
 	local -a Test=(
@@ -48,10 +75,12 @@ test_env_get_literal() {
 	notice "$(cat "${VarFile}")"
 	run_unit_tests_pipe "Var" "Var" "${ForcePass}" < <(
 		for ((i = 0; i < ${#Test[@]}; i += 3)); do
+			local Result
+			run_script 'env_get_literal_into' Result "${Test[i]}" "${VarFile}"
 			printf '%s\n' \
 				"${Test[i + 1]}" \
 				"${Test[i + 2]}" \
-				"$(run_script 'env_get_literal' "${Test[i]}" "${VarFile}")"
+				"${Result}"
 		done
 	)
 	result=$?

--- a/scripts/env_list_app_env_defaults.sh
+++ b/scripts/env_list_app_env_defaults.sh
@@ -4,7 +4,9 @@ IFS=$'\n\t'
 
 env_list_app_env_defaults() {
 	local -l appname=${1-}
-	run_script 'env_var_list' "$(run_script 'app_instance_file' "${appname}" ".env.app.*")"
+	local _aif_
+	run_script 'app_instance_file_into' _aif_ "${appname}" ".env.app.*"
+	run_script 'env_var_list' "${_aif_}"
 }
 
 test_env_list_app_env_defaults() {

--- a/scripts/env_list_app_global_defaults.sh
+++ b/scripts/env_list_app_global_defaults.sh
@@ -4,7 +4,9 @@ IFS=$'\n\t'
 
 env_list_app_global_defaults() {
 	local -l appname=${1-}
-	run_script 'env_var_list' "$(run_script 'app_instance_file' "${appname}" ".env")"
+	local _aif_
+	run_script 'app_instance_file_into' _aif_ "${appname}" ".env"
+	run_script 'env_var_list' "${_aif_}"
 }
 
 test_env_list_app_global_defaults() {

--- a/scripts/env_sanitize.sh
+++ b/scripts/env_sanitize.sh
@@ -13,7 +13,7 @@ env_sanitize() {
 
 	# Update the HOME variable if it is not set to the detected home directory
 	local HOME
-	HOME="$(run_script 'env_get' HOME)"
+	run_script 'env_get_into' HOME HOME
 	if [[ ${HOME} != "${DETECTED_HOMEDIR}" ]]; then
 		HOME="${DETECTED_HOMEDIR}"
 		VarsToUpdate+=(HOME)
@@ -22,7 +22,7 @@ env_sanitize() {
 
 	local DOCKER_CONFIG_FOLDER DOCKER_COMPOSE_FOLDER ORIG_CONFIG_FOLDER ORIG_COMPOSE_FOLDER
 
-	ORIG_CONFIG_FOLDER="$(run_script 'env_get' DOCKER_CONFIG_FOLDER)"
+	run_script 'env_get_into' ORIG_CONFIG_FOLDER DOCKER_CONFIG_FOLDER
 	LITERAL_CONFIG_FOLDER="$(run_script 'config_get' paths.config_folder)"
 	if [[ -z ${LITERAL_CONFIG_FOLDER-} ]]; then
 		LITERAL_CONFIG_FOLDER="$(run_script 'config_get' paths.config_folder "${DEFAULT_TOML_FILE}")"
@@ -32,7 +32,7 @@ env_sanitize() {
 	fi
 	DOCKER_CONFIG_FOLDER="${LITERAL_CONFIG_FOLDER}"
 
-	ORIG_COMPOSE_FOLDER="$(run_script 'env_get' DOCKER_COMPOSE_FOLDER)"
+	run_script 'env_get_into' ORIG_COMPOSE_FOLDER DOCKER_COMPOSE_FOLDER
 	LITERAL_COMPOSE_FOLDER="$(run_script 'config_get' paths.compose_folder)"
 	if [[ -z ${LITERAL_COMPOSE_FOLDER-} ]]; then
 		LITERAL_COMPOSE_FOLDER="$(run_script 'config_get' paths.compose_folder "${DEFAULT_TOML_FILE}")"
@@ -75,7 +75,7 @@ env_sanitize() {
 	)
 	for VarName in "${VarList[@]-}"; do
 		local Value
-		Value="$(run_script 'env_get' "${VarName}")"
+		run_script 'env_get_into' Value "${VarName}"
 		if [[ -z ${Value-} ]]; then
 			# If the variable is empty get the default value
 			local Default
@@ -93,7 +93,7 @@ env_sanitize() {
 	)
 	for VarName in "${VarList[@]-}"; do
 		local Value
-		Value="$(run_script 'env_get' "${VarName}")"
+		run_script 'env_get_into' Value "${VarName}"
 		if [[ -z ${Value-} ]] || echo "${Value-}" | ${GREP} -q 'x'; then
 			# If the variable is empty or contains an "x", get the default value
 			local Default
@@ -114,7 +114,7 @@ env_sanitize() {
 	for VarName in "${VarList[@]-}"; do
 		# Get the value including quotes
 		local Value
-		Value="$(run_script 'env_get' "${VarName}")"
+		run_script 'env_get_into' Value "${VarName}"
 		local UpdatedValue
 		UpdatedValue="$(run_script 'sanitize_path' "${Value}")"
 		UpdatedValue="$(

--- a/scripts/env_update.sh
+++ b/scripts/env_update.sh
@@ -49,7 +49,7 @@ env_update() {
 				local APP_DEFAULT_GLOBAL_ENV_FILE=""
 				local -a UPDATED_APP_ENV_LINES=()
 				if ! run_script 'app_is_user_defined' "${appname}"; then
-					APP_DEFAULT_GLOBAL_ENV_FILE="$(run_script 'app_instance_file' "${appname}" ".env")"
+					run_script 'app_instance_file_into' APP_DEFAULT_GLOBAL_ENV_FILE "${appname}" ".env"
 				fi
 				run_script 'appvars_lines' "${appname}" > "${ENV_LINES_FILE}"
 				if ((${#UPDATED_ENV_LINES[@]} > 0)); then
@@ -99,7 +99,7 @@ env_update() {
 				fi
 				local APP_DEFAULT_ENV_FILE=""
 				if ! run_script 'app_is_user_defined' "${appname}"; then
-					APP_DEFAULT_ENV_FILE="$(run_script 'app_instance_file' "${appname}" ".env.app.*")"
+					run_script 'app_instance_file_into' APP_DEFAULT_ENV_FILE "${appname}" ".env.app.*"
 				fi
 				local -a UPDATED_APP_ENV_LINES=()
 				readarray -t UPDATED_APP_ENV_LINES < <(

--- a/scripts/expand_vars_using_varfile.sh
+++ b/scripts/expand_vars_using_varfile.sh
@@ -60,7 +60,7 @@ expand_vars_using_varfile() {
 
 			# Look for the variable in the file
 			if run_script 'env_var_exists' "${Key}" "${VarFile}"; then
-				Vars["${Key}"]="$(run_script 'env_get' "${Key}" "${VarFile}")"
+				run_script 'env_get_into' Vars["${Key}"] "${Key}" "${VarFile}"
 			else
 				MissingVars["${Key}"]=1
 			fi

--- a/scripts/menu_add_app.sh
+++ b/scripts/menu_add_app.sh
@@ -56,7 +56,7 @@ menu_add_app() {
 
 				local ErrorMessage=''
 				if run_script 'appname_is_valid' "${AppName}"; then
-					AppName="$(run_script 'app_nicename' "${AppName}")"
+					run_script 'app_nicename_into' AppName "${AppName}"
 					AppNameHeading="${AppName}"
 				else
 					AppNameHeading="${AppNameNone}"

--- a/scripts/menu_add_var.sh
+++ b/scripts/menu_add_var.sh
@@ -38,7 +38,7 @@ menu_add_var() {
 			appname="${APPNAME,,}"
 			VarFile="${COMPOSE_ENV}"
 		fi
-		AppName="$(run_script 'app_nicename' "${APPNAME}")"
+		run_script 'app_nicename_into' AppName "${APPNAME}"
 	fi
 
 	case "${VarType}" in
@@ -250,7 +250,9 @@ menu_add_var() {
 						elif run_script 'env_var_exists' "${VarName}"; then
 							ErrorMessage="The variable {{|Highlight|}}${VarName}{{[-]}} already exists.\n\n Please input another variable name."
 						else
-							DetectedAppName="$(run_script 'app_nicename' "$(run_script 'varname_to_appname' "${VarName}")")"
+							local _mav_detectedapp_
+							_mav_detectedapp_="$(run_script 'varname_to_appname' "${VarName}")"
+							run_script 'app_nicename_into' DetectedAppName "${_mav_detectedapp_}"
 							if [[ ${DetectedAppName^^} == "" ]]; then
 								ErrorMessage="The variable name {{|Highlight|}}${VarName}{{[-]}} is not a valid name for app {{|Highlight|}}${AppName}{{[-]}}. It would be a global variable.\n\n Please input another variable name."
 							elif [[ ${DetectedAppName^^} != "${APPNAME}" ]]; then
@@ -324,7 +326,9 @@ menu_add_var() {
 						elif run_script 'env_var_exists' "${VarName}" "${VarFile}"; then
 							ErrorMessage="The variable {{|Highlight|}}${VarName}{{[-]}} already exists.\n\n Please input another variable name."
 						elif [[ ${VarType} == GLOBAL ]]; then
-							DetectedAppName="$(run_script 'app_nicename' "$(run_script 'varname_to_appname' "${VarName}")")"
+							local _mav_detectedapp_
+							_mav_detectedapp_="$(run_script 'varname_to_appname' "${VarName}")"
+							run_script 'app_nicename_into' DetectedAppName "${_mav_detectedapp_}"
 							if [[ ${DetectedAppName} != "" ]]; then
 								ErrorMessage="The variable name {{|Highlight|}}${VarName}{{[-]}} is not a valid global variable name. It would be a variable for an app named {{|Highlight|}}${DetectedAppName}{{[-]}}\n\n Please input another variable name."
 							fi

--- a/scripts/menu_app_select.sh
+++ b/scripts/menu_app_select.sh
@@ -124,9 +124,11 @@ menu_app_select() {
 			LastAppLetter=${AppLetter}
 			update_gauge 1 "${ProcessAppList}" "_InProgress_" "_InProgress_" "${AppName}"
 			local AppDescription
-			AppDescription=$(run_script 'app_description_from_template' "${AppName}")
+			run_script 'app_description_from_template_into' AppDescription "${AppName}"
 			local AppColor="{{|ListApp|}}"
-			if [[ -n $(run_script 'appname_to_instancename' "${AppName}") ]]; then
+			local _mas_instance_
+			run_script 'appname_to_instancename_into' _mas_instance_ "${AppName}"
+			if [[ -n ${_mas_instance_} ]]; then
 				AppColor="{{|ListAppUserDefined|}}"
 			fi
 			if [[ ${AppName} =~ ^(${AddedAppsRegex})$ ]]; then

--- a/scripts/menu_config_apps.sh
+++ b/scripts/menu_config_apps.sh
@@ -14,7 +14,7 @@ menu_config_apps() {
 		local -a AppOptions=()
 		for AppName in ${AddedApps}; do
 			local AppDescription
-			AppDescription=$(run_script 'app_description' "${AppName}")
+			run_script 'app_description_into' AppDescription "${AppName}"
 			if run_script 'app_is_user_defined' "${AppName}"; then
 				AppOptions+=("${AppName}" "{{|ListAppUserDefined|}}${AppDescription}")
 			else

--- a/scripts/menu_config_vars.sh
+++ b/scripts/menu_config_vars.sh
@@ -35,8 +35,8 @@ menu_config_vars() {
 			CurrentGlobalEnvFile=$(mktemp -t "${APPLICATION_NAME}.${FUNCNAME[0]}.CurrentGlobalEnvFile.XXXXXXXXXX")
 			CurrentAppEnvFile=$(mktemp -t "${APPLICATION_NAME}.${FUNCNAME[0]}.CurrentAppEnvFile.XXXXXXXXXX")
 			if ! run_script 'app_is_user_defined' "${APPNAME}"; then
-				DefaultGlobalEnvFile="$(run_script 'app_instance_file' "${APPNAME}" ".env")"
-				DefaultAppEnvFile="$(run_script 'app_instance_file' "${APPNAME}" ".env.app.*")"
+				run_script 'app_instance_file_into' DefaultGlobalEnvFile "${APPNAME}" ".env"
+				run_script 'app_instance_file_into' DefaultAppEnvFile "${APPNAME}" ".env.app.*"
 			fi
 		else
 			Title="Edit Global Variables"

--- a/scripts/menu_heading.sh
+++ b/scripts/menu_heading.sh
@@ -44,11 +44,11 @@ menu_heading() {
 		if [[ ${AppName-} == ":"* ]]; then # ":AppName", using .env
 			AppName="${AppName#:*}"
 			VarFile="${COMPOSE_ENV}"
-			DefaultVarFile="$(run_script 'app_instance_file' "${AppName}" ".env")"
+			run_script 'app_instance_file_into' DefaultVarFile "${AppName}" ".env"
 		elif [[ ${AppName-} == *":" ]]; then # "AppName:", using appname.env
 			AppName="${AppName%:*}"
 			VarFile="$(run_script 'app_env_file' "${AppName}")"
-			DefaultVarFile="$(run_script 'app_instance_file' "${AppName}" ".env.app.*")"
+			run_script 'app_instance_file_into' DefaultVarFile "${AppName}" ".env.app.*"
 		fi
 		if [[ -n ${VarName-} ]] && run_script 'varname_is_valid' "${VarName}"; then # "appname:varname", using appname.env
 			VarIsValid='Y'
@@ -56,11 +56,11 @@ menu_heading() {
 				AppName="${VarName%:*}"
 				VarName="${VarName#*:}"
 				VarFile="$(run_script 'app_env_file' "${AppName}")"
-				DefaultVarFile="$(run_script 'app_instance_file' "${AppName}" ".env.app.*")"
+				run_script 'app_instance_file_into' DefaultVarFile "${AppName}" ".env.app.*"
 			fi
 			if [[ -z ${VarFile-} ]]; then
 				VarFile="${COMPOSE_ENV}"
-				DefaultVarFile="$(run_script 'app_instance_file' "${AppName}" ".env")"
+				run_script 'app_instance_file_into' DefaultVarFile "${AppName}" ".env"
 			fi
 		fi
 
@@ -82,7 +82,7 @@ menu_heading() {
 					VarIsUserDefined='Y'
 				fi
 			fi
-			AppName=$(run_script 'app_nicename' "${AppName}")
+			run_script 'app_nicename_into' AppName "${AppName}"
 		else # Global File or Variable
 			VarFile="${COMPOSE_ENV}"
 			DefaultVarFile="${COMPOSE_ENV_DEFAULT_FILE}"
@@ -111,7 +111,7 @@ menu_heading() {
 						Heading[Application]+="\n"
 
 						local AppDescription
-						AppDescription="$(run_script 'app_description' "${AppName}")"
+						run_script 'app_description_into' AppDescription "${AppName}"
 						set_screen_size
 						local -i ScreenCols=${COLUMNS}
 						local -i TextWidth=$((ScreenCols - D["WindowColsAdjust"] - D["TextColsAdjust"] - LabelWidth))

--- a/scripts/menu_value_prompt.sh
+++ b/scripts/menu_value_prompt.sh
@@ -36,7 +36,7 @@ menu_value_prompt() {
 		else
 			VarType="APP"
 		fi
-		AppName="$(run_script 'app_nicename' "${APPNAME}")"
+		run_script 'app_nicename_into' AppName "${APPNAME}"
 	else
 		Title="Edit Global Variable"
 		VarType="GLOBAL"
@@ -50,7 +50,7 @@ menu_value_prompt() {
 	local ValueDescription=""
 	local -A OptionHelpLine=()
 	local -A OptionValue=()
-	OptionValue["${OriginalValueOption}"]=$(run_script 'env_get_literal' "${VarName}")
+	run_script 'env_get_literal_into' OptionValue["${OriginalValueOption}"] "${VarName}"
 	OptionHelpLine["${OriginalValueOption}"]="This is the original value before before entering the editor."
 	OptionValue["${CurrentValueOption}"]="${OptionValue["${OriginalValueOption}"]}"
 	OptionHelpLine["${CurrentValueOption}"]="This is the value that will be saved when you select Done."

--- a/scripts/needs_appvars_create.sh
+++ b/scripts/needs_appvars_create.sh
@@ -43,7 +43,7 @@ needs_appvars_create() {
 			fi
 
 			local baseappname
-			baseappname="$(run_script 'appname_to_baseappname' "${appname}")"
+			run_script 'appname_to_baseappname_into' baseappname "${appname}"
 			local AppTemplateDir="${TEMPLATES_FOLDER:?}/${baseappname}"
 			if [[ -d ${AppTemplateDir} ]]; then
 				if [[ -n $(find "${AppTemplateDir}" -newer "${SentinelFile}" -print -quit) ]]; then
@@ -68,7 +68,7 @@ needs_appvars_create() {
 		fi
 
 		local baseappname
-		baseappname="$(run_script 'appname_to_baseappname' "${appname}")"
+		run_script 'appname_to_baseappname_into' baseappname "${appname}"
 		local AppTemplateDir="${TEMPLATES_FOLDER:?}/${baseappname}"
 
 		local GlobalSentinel="${timestamps_folder}/LastSynced"

--- a/scripts/needs_env_update.sh
+++ b/scripts/needs_env_update.sh
@@ -41,7 +41,9 @@ needs_env_update() {
 		APPNAME="$(run_script 'varfile_to_appname' "${VarFile}")"
 		local AppEnabledFile
 		AppEnabledFile="${timestamps_folder:?}/${filename}_${APPNAME}__ENABLED"
-		if ! cmp -s "${AppEnabledFile}" <(run_script 'env_get_line' "${APPNAME}__ENABLED" || true); then
+		local _neu_enabled_line_
+		run_script 'env_get_line_into' _neu_enabled_line_ "${APPNAME}__ENABLED" || true
+		if ! cmp -s "${AppEnabledFile}" <<< "${_neu_enabled_line_}"; then
 			return 0
 		fi
 	fi

--- a/scripts/needs_yml_merge.sh
+++ b/scripts/needs_yml_merge.sh
@@ -39,7 +39,7 @@ needs_yml_merge() {
 		# Check app-specific template directory
 		if [[ -f ${SentinelFile} ]]; then
 			local baseappname
-			baseappname="$(run_script 'appname_to_baseappname' "${appname}")"
+			run_script 'appname_to_baseappname_into' baseappname "${appname}"
 			local AppTemplateDir="${TEMPLATES_FOLDER:?}/${baseappname}"
 			if [[ -d ${AppTemplateDir} ]]; then
 				if [[ -n $(find "${AppTemplateDir}" -newer "${SentinelFile}" -print -quit) ]]; then

--- a/scripts/override_backup.sh
+++ b/scripts/override_backup.sh
@@ -9,7 +9,7 @@ declare -a _dependencies_list=(
 override_backup() {
 	if [[ -f "${SCRIPTPATH}/compose/docker-compose.override.yml" ]]; then
 		local DOCKER_VOLUME_CONFIG
-		DOCKER_VOLUME_CONFIG="$(run_script 'env_get' DOCKER_VOLUME_CONFIG)"
+		run_script 'env_get_into' DOCKER_VOLUME_CONFIG DOCKER_VOLUME_CONFIG
 		if [[ -z ${DOCKER_VOLUME_CONFIG-} ]]; then
 			fatal \
 				"'{{|Var|}}DOCKER_VOLUME_CONFIG{{[-]}}' is not set in '{{|File|}}${COMPOSE_ENV}{{[-]}}'"

--- a/scripts/unset_needs_env_update.sh
+++ b/scripts/unset_needs_env_update.sh
@@ -35,7 +35,9 @@ unset_needs_env_update() {
 		APPNAME="$(run_script 'varfile_to_appname' "${VarFile}")"
 		local AppEnabledFile
 		AppEnabledFile="${timestamps_folder}/${filename}_${APPNAME}__ENABLED"
-		run_script 'env_get_line' "${APPNAME}__ENABLED" > "${AppEnabledFile}"
+		local _uneu_enabled_line_
+		run_script 'env_get_line_into' _uneu_enabled_line_ "${APPNAME}__ENABLED"
+		echo "${_uneu_enabled_line_}" > "${AppEnabledFile}"
 		# Record the state of the global .env for this specific app
 		cp -a "${COMPOSE_ENV}" "${timestamps_folder}/${filename}_$(basename "${COMPOSE_ENV}")"
 	fi

--- a/scripts/var_default_value.sh
+++ b/scripts/var_default_value.sh
@@ -13,7 +13,7 @@ var_default_value() {
 	if [[ -n ${APPNAME} ]]; then
 		APPNAME="${APPNAME^^}"
 		appname="${APPNAME,,}"
-		AppName="$(run_script 'app_nicename' "${APPNAME}")"
+		run_script 'app_nicename_into' AppName "${APPNAME}"
 		if [[ ${VarName} == *":"* ]]; then
 			VarType="APPENV"
 			CleanVarName=${VarName#*:}
@@ -28,10 +28,12 @@ var_default_value() {
 	case "${VarType}" in
 		APP)
 			local DefaultAppVarFile
-			DefaultAppVarFile="$(run_script 'app_instance_file' "${APPNAME}" ".env")"
+			run_script 'app_instance_file_into' DefaultAppVarFile "${APPNAME}" ".env"
 			if [[ -f ${DefaultAppVarFile} ]] && run_script 'env_var_exists' "${CleanVarName}" "${DefaultAppVarFile}"; then
 				# Variable is listed in the default file, output it and return
-				run_script 'env_get_literal' "${CleanVarName}" "${DefaultAppVarFile}"
+				local _vdv_literal_
+				run_script 'env_get_literal_into' _vdv_literal_ "${CleanVarName}" "${DefaultAppVarFile}"
+				echo "${_vdv_literal_}"
 				return
 			fi
 			case "${CleanVarName}" in
@@ -68,10 +70,12 @@ var_default_value() {
 			;;
 		APPENV)
 			local DefaultAppVarFile
-			DefaultAppVarFile="$(run_script 'app_instance_file' "${APPNAME}" ".env.app.*")"
+			run_script 'app_instance_file_into' DefaultAppVarFile "${APPNAME}" ".env.app.*"
 			if [[ -f ${DefaultAppVarFile} ]] && run_script 'env_var_exists' "${CleanVarName}" "${DefaultAppVarFile}"; then
 				# Variable is listed in the default file, output it and return
-				run_script 'env_get_literal' "${CleanVarName}" "${DefaultAppVarFile}"
+				local _vdv_literal_
+				run_script 'env_get_literal_into' _vdv_literal_ "${CleanVarName}" "${DefaultAppVarFile}"
+				echo "${_vdv_literal_}"
 				return
 			fi
 			Default="''"
@@ -109,7 +113,7 @@ var_default_value() {
 				*)
 					if [[ -f ${COMPOSE_ENV_DEFAULT_FILE} ]] && run_script 'env_var_exists' "${CleanVarName}" "${COMPOSE_ENV_DEFAULT_FILE}"; then
 						# Variable is listed in the default file, output it and return
-						Default="$(run_script 'env_get_literal' "${CleanVarName}" "${COMPOSE_ENV_DEFAULT_FILE}")"
+						run_script 'env_get_literal_into' Default "${CleanVarName}" "${COMPOSE_ENV_DEFAULT_FILE}"
 					else
 						Default="''"
 					fi

--- a/scripts/yml_merge.sh
+++ b/scripts/yml_merge.sh
@@ -25,12 +25,12 @@ commands_yml_merge() {
 	for APPNAME in ${ENABLED_APPS-}; do
 		local -l appname=${APPNAME}
 		local AppName
-		AppName="$(run_script 'app_nicename' "${APPNAME}")"
+		run_script 'app_nicename_into' AppName "${APPNAME}"
 		local APP_FOLDER
-		APP_FOLDER="$(run_script 'app_instance_folder' "${appname}")"
+		run_script 'app_instance_folder_into' APP_FOLDER "${appname}"
 		if [[ -d ${APP_FOLDER}/ ]]; then
 			local main_yml
-			main_yml="$(run_script 'app_instance_file' "${appname}" "*.yml")"
+			run_script 'app_instance_file_into' main_yml "${appname}" "*.yml"
 			if [[ -f ${main_yml} ]]; then
 				if run_script 'app_is_deprecated' "${APPNAME}"; then
 					warn \
@@ -38,24 +38,24 @@ commands_yml_merge() {
 						"Please run '{{|UserCommand|}}${APPLICATION_COMMAND} --status-disable ${AppName}{{[-]}}' to disable it."
 				fi
 				local arch_yml
-				arch_yml="$(run_script 'app_instance_file' "${appname}" "*.${ARCH}.yml")"
+				run_script 'app_instance_file_into' arch_yml "${appname}" "*.${ARCH}.yml"
 				if [[ ! -f ${arch_yml} ]]; then
 					error "File '{{|File|}}${arch_yml}{{[-]}}' does not exist."
 					return 1
 				fi
 				COMPOSE_FILE="${COMPOSE_FILE}:${arch_yml}"
 				local AppNetMode
-				AppNetMode="$(run_script 'env_get' "${APPNAME}__NETWORK_MODE")"
+				run_script 'env_get_into' AppNetMode "${APPNAME}__NETWORK_MODE"
 				if [[ -z ${AppNetMode-} ]] || [[ ${AppNetMode} == "bridge" ]]; then
 					local hostname_yml
-					hostname_yml="$(run_script 'app_instance_file' "${appname}" "*.hostname.yml")"
+					run_script 'app_instance_file_into' hostname_yml "${appname}" "*.hostname.yml"
 					if [[ -f ${hostname_yml} ]]; then
 						COMPOSE_FILE="${COMPOSE_FILE}:${hostname_yml}"
 					else
 						info "File '{{|File|}}${hostname_yml}{{[-]}}' does not exist."
 					fi
 					local ports_yml
-					ports_yml="$(run_script 'app_instance_file' "${appname}" "*.ports.yml")"
+					run_script 'app_instance_file_into' ports_yml "${appname}" "*.ports.yml"
 					if [[ -f ${ports_yml} ]]; then
 						COMPOSE_FILE="${COMPOSE_FILE}:${ports_yml}"
 					else
@@ -63,7 +63,7 @@ commands_yml_merge() {
 					fi
 				elif [[ -n ${AppNetMode} ]]; then
 					local netmode_yml
-					netmode_yml="$(run_script 'app_instance_file' "${appname}" "*.netmode.yml")"
+					run_script 'app_instance_file_into' netmode_yml "${appname}" "*.netmode.yml"
 					if [[ -f ${netmode_yml} ]]; then
 						COMPOSE_FILE="${COMPOSE_FILE}:${netmode_yml}"
 					else
@@ -71,21 +71,23 @@ commands_yml_merge() {
 					fi
 				fi
 				local MultipleStorage
-				MultipleStorage="$(run_script 'env_get' DOCKER_MULTIPLE_STORAGE)"
+				run_script 'env_get_into' MultipleStorage DOCKER_MULTIPLE_STORAGE
 				local -a StorageNumbers=('')
 				if is_true "${MultipleStorage}"; then
 					StorageNumbers+=(2 3 4)
 				fi
 				for Number in "${StorageNumbers[@]}"; do
 					local StorageOn
-					StorageOn="$(run_script 'env_get' "${APPNAME}__STORAGE${Number}_ON")"
-					StorageOn="${StorageOn:-$(run_script 'env_get' "DOCKER_STORAGE${Number}_ON")}"
+					run_script 'env_get_into' StorageOn "${APPNAME}__STORAGE${Number}_ON"
+					if [[ -z ${StorageOn-} ]]; then
+						run_script 'env_get_into' StorageOn "DOCKER_STORAGE${Number}_ON"
+					fi
 					if is_true "${StorageOn}"; then
 						local StorageVolume
-						StorageVolume="$(run_script 'env_get' "DOCKER_VOLUME_STORAGE${Number}")"
+						run_script 'env_get_into' StorageVolume "DOCKER_VOLUME_STORAGE${Number}"
 						if [[ -n ${StorageVolume-} ]]; then
 							local storage_yml
-							storage_yml="$(run_script 'app_instance_file' "${appname}" "*.storage${Number}.yml")"
+							run_script 'app_instance_file_into' storage_yml "${appname}" "*.storage${Number}.yml"
 							if [[ -f ${storage_yml} ]]; then
 								COMPOSE_FILE="${COMPOSE_FILE}:${storage_yml}"
 							else
@@ -95,10 +97,10 @@ commands_yml_merge() {
 					fi
 				done
 				local AppDevices
-				AppDevices="$(run_script 'env_get' "${APPNAME}__DEVICES")"
+				run_script 'env_get_into' AppDevices "${APPNAME}__DEVICES"
 				if is_true "${AppDevices}"; then
 					local devices_yml
-					devices_yml="$(run_script 'app_instance_file' "${appname}" "*.devices.yml")"
+					run_script 'app_instance_file_into' devices_yml "${appname}" "*.devices.yml"
 					if [[ -f ${devices_yml} ]]; then
 						COMPOSE_FILE="${COMPOSE_FILE}:${devices_yml}"
 					else


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Refactor various Bash helper scripts to use new *_into variants that write results via namerefs instead of subshells, centralizing common logic in new *_into implementations while keeping external behaviour unchanged.

Enhancements:
- Introduce *_into helper scripts (e.g., app_instance_file_into, env_get_into, app_nicename_into, app_description_into, app_env_file_into, app_instance_folder_into, appname_to_instancename_into, appname_to_baseappname_into) to avoid subshells and share logic between callers.
- Update existing scripts to delegate to the new *_into helpers and simplify their implementations without changing user-visible behaviour.
- Remove now-unnecessary per-script dependency declarations where functionality is provided by the new shared helpers.

Tests:
- Add or update bash unit tests for the new *_into helpers to verify name resolution, env parsing, and description/nicename behaviour for various app and variable scenarios.