### PR TITLE
Add `*_list_into` functions to read into array namerefs

### DIFF
--- a/scripts/app_is_referenced.sh
+++ b/scripts/app_is_referenced.sh
@@ -10,12 +10,15 @@ app_is_referenced() {
 	local APPNAME=${1:-}
 
 	# Check for app variables in the global .env file
-	if [[ -n $(run_script 'appvars_list' "${APPNAME}") ]]; then
+	local -a AppVars
+	run_script 'appvars_list_into' AppVars "${APPNAME}"
+	if [[ -n ${AppVars[*]-} ]]; then
 		return 0
 	fi
 
 	# Check for app variables in the .env.app.appname file
-	if [[ -n $(run_script 'appvars_list' "${APPNAME}:") ]]; then
+	run_script 'appvars_list_into' AppVars "${APPNAME}:"
+	if [[ -n ${AppVars[*]-} ]]; then
 		return 0
 	fi
 

--- a/scripts/app_list.sh
+++ b/scripts/app_list.sh
@@ -8,7 +8,9 @@ declare -a _dependencies_list=(
 
 app_list() {
 	local -a AppList
-	readarray -t AppList < <(run_script 'app_nicename' "$(run_script 'app_list_builtin')")
+	local -a BuiltinApps
+	run_script 'app_list_builtin_into' BuiltinApps
+	readarray -t AppList < <(run_script 'app_nicename' "${BuiltinApps[*]}")
 	local -a TableContents=(Application Deprecated Added Disabled)
 	for AppName in "${AppList[@]}"; do
 		local Deprecated=''

--- a/scripts/app_list_added_into.sh
+++ b/scripts/app_list_added_into.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+app_list_added_into() {
+	local -n _alai_out_="${1}"
+	readarray -t _alai_out_ < <(run_script 'app_list_added')
+}
+
+test_app_list_added_into() {
+	warn "CI does not test app_list_added_into."
+}

--- a/scripts/app_list_builtin_into.sh
+++ b/scripts/app_list_builtin_into.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+app_list_builtin_into() {
+	local -n _albi_out_="${1}"
+	readarray -t _albi_out_ < <(run_script 'app_list_builtin')
+}
+
+test_app_list_builtin_into() {
+	warn "CI does not test app_list_builtin_into."
+}

--- a/scripts/app_list_deprecated.sh
+++ b/scripts/app_list_deprecated.sh
@@ -3,7 +3,9 @@ set -Eeuo pipefail
 IFS=$'\n\t'
 
 app_list_deprecated() {
-	for APPNAME in $(run_script 'app_list_builtin'); do
+	local -a BuiltinApps
+	run_script 'app_list_builtin_into' BuiltinApps
+	for APPNAME in "${BuiltinApps[@]-}"; do
 		if run_script 'app_is_deprecated' "${APPNAME}"; then
 			echo "${APPNAME}"
 		fi

--- a/scripts/app_list_deprecated_into.sh
+++ b/scripts/app_list_deprecated_into.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+app_list_deprecated_into() {
+	local -n _aldep_out_="${1}"
+	readarray -t _aldep_out_ < <(run_script 'app_list_deprecated')
+}
+
+test_app_list_deprecated_into() {
+	warn "CI does not test app_list_deprecated_into."
+}

--- a/scripts/app_list_disabled.sh
+++ b/scripts/app_list_disabled.sh
@@ -14,7 +14,7 @@ app_list_disabled() {
 	readarray -t DISABLED_APPS < <(
 		${GREP} --color=never -o -P "^${APPNAME_REGEX}(?=__ENABLED\s*=(?!(?<quote>['|\"]?)(?i:on|true|yes)\k<quote>))" "${COMPOSE_ENV}" | sort || true
 	)
-	readarray -t BUILTIN_APPS < <(run_script 'app_list_builtin')
+	run_script 'app_list_builtin_into' BUILTIN_APPS
 	local -a COMBINED=("${DISABLED_APPS[@]}" "${BUILTIN_APPS[@]}")
 	printf "%s\n" "${COMBINED[@]}" | sort | uniq -d
 }

--- a/scripts/app_list_disabled_into.sh
+++ b/scripts/app_list_disabled_into.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+app_list_disabled_into() {
+	local -n _aldis_out_="${1}"
+	readarray -t _aldis_out_ < <(run_script 'app_list_disabled')
+}
+
+test_app_list_disabled_into() {
+	warn "CI does not test app_list_disabled_into."
+}

--- a/scripts/app_list_enabled_into.sh
+++ b/scripts/app_list_enabled_into.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+app_list_enabled_into() {
+	local -n _alei_out_="${1}"
+	readarray -t _alei_out_ < <(run_script 'app_list_enabled')
+}
+
+test_app_list_enabled_into() {
+	warn "CI does not test app_list_enabled_into."
+}

--- a/scripts/app_list_nondeprecated.sh
+++ b/scripts/app_list_nondeprecated.sh
@@ -3,7 +3,9 @@ set -Eeuo pipefail
 IFS=$'\n\t'
 
 app_list_nondeprecated() {
-	for APPNAME in $(run_script 'app_list_builtin'); do
+	local -a BuiltinApps
+	run_script 'app_list_builtin_into' BuiltinApps
+	for APPNAME in "${BuiltinApps[@]-}"; do
 		if run_script 'app_is_nondeprecated' "${APPNAME}"; then
 			echo "${APPNAME}"
 		fi

--- a/scripts/app_list_nondeprecated_into.sh
+++ b/scripts/app_list_nondeprecated_into.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+app_list_nondeprecated_into() {
+	local -n _alndep_out_="${1}"
+	readarray -t _alndep_out_ < <(run_script 'app_list_nondeprecated')
+}
+
+test_app_list_nondeprecated_into() {
+	warn "CI does not test app_list_nondeprecated_into."
+}

--- a/scripts/app_list_referenced.sh
+++ b/scripts/app_list_referenced.sh
@@ -18,7 +18,9 @@ app_list_referenced() {
 		run_script 'app_list_hasvarfile'
 	)
 	for AppName in "${AppList[@]-}"; do
-		if [[ -n ${AppName} && -n $(run_script 'appvars_list' "${AppName}:") ]]; then
+		local -a AppVars
+		run_script 'appvars_list_into' AppVars "${AppName}:"
+		if [[ -n ${AppName} && -n ${AppVars[*]-} ]]; then
 			ReferencedApps+=("${AppName}")
 		fi
 	done

--- a/scripts/app_list_referenced_into.sh
+++ b/scripts/app_list_referenced_into.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+app_list_referenced_into() {
+	local -n _alri_out_="${1}"
+	readarray -t _alri_out_ < <(run_script 'app_list_referenced')
+}
+
+test_app_list_referenced_into() {
+	warn "CI does not test app_list_referenced_into."
+}

--- a/scripts/appvars_create_all.sh
+++ b/scripts/appvars_create_all.sh
@@ -10,11 +10,11 @@ appvars_create_all() {
 	fi
 	run_script 'env_create'
 	run_script 'appvars_migrate_enabled_lines'
-	local AddedApps
-	AddedApps="$(run_script 'app_list_added')"
-	if [[ -n ${AddedApps-} ]]; then
+	local -a AddedApps
+	run_script 'app_list_added_into' AddedApps
+	if [[ -n ${AddedApps[*]-} ]]; then
 		notice "Creating environment variables for added apps. Please be patient, this can take a while."
-		run_script 'appvars_create' "${AddedApps}"
+		run_script 'appvars_create' "${AddedApps[@]}"
 	else
 		notice "File '{{|File|}}${COMPOSE_ENV}{{[-]}}' does not contain any added apps."
 	fi

--- a/scripts/appvars_list_into.sh
+++ b/scripts/appvars_list_into.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+appvars_list_into() {
+	local -n _avli_out_="${1}"
+	shift
+	readarray -t _avli_out_ < <(run_script 'appvars_list' "$@")
+}
+
+test_appvars_list_into() {
+	warn "CI does not test appvars_list_into."
+}

--- a/scripts/appvars_migrate_all.sh
+++ b/scripts/appvars_migrate_all.sh
@@ -4,9 +4,9 @@ IFS=$'\n\t'
 
 appvars_migrate_all() {
 	run_script 'appvars_migrate_enabled_lines'
-	local ENABLED_APPS
-	ENABLED_APPS=$(run_script 'app_list_enabled')
-	for APPNAME in ${ENABLED_APPS-}; do
+	local -a EnabledApps
+	run_script 'app_list_enabled_into' EnabledApps
+	for APPNAME in "${EnabledApps[@]-}"; do
 		run_script 'appvars_migrate' "${APPNAME}"
 	done
 }

--- a/scripts/appvars_purge.sh
+++ b/scripts/appvars_purge.sh
@@ -22,7 +22,7 @@ appvars_purge() {
 		local -a CurrentAppEnvVars DefaultAppEnvVars AppEnvVarsToRemove AppEnvLinesToRemove
 		local GlobalVarsRegex AppEnvVarsRegex
 
-		readarray -t CurrentGlobalVars <<< "$(run_script 'appvars_list' "${appname}")"
+		run_script 'appvars_list_into' CurrentGlobalVars "${appname}"
 		if [[ -n ${CurrentGlobalVars-} ]]; then
 			readarray -t DefaultGlobalVars <<< "$(run_script 'env_list_app_global_defaults' "${appname}")"
 			# Get the list of current variables also in the default list
@@ -37,7 +37,7 @@ appvars_purge() {
 			readarray -t GlobalLinesToRemove <<< "$(${GREP} -P "^\s*${GlobalVarsRegex}\s*=" "${COMPOSE_ENV}" || true)"
 		fi
 
-		readarray -t CurrentAppEnvVars <<< "$(run_script 'appvars_list' "${appname}:")"
+		run_script 'appvars_list_into' CurrentAppEnvVars "${appname}:"
 		if [[ -n ${CurrentAppEnvVars-} ]]; then
 			readarray -t DefaultAppEnvVars <<< "$(run_script 'env_list_app_env_defaults' "${appname}")"
 			# Get the list of current variables also in the default list

--- a/scripts/appvars_purge_all.sh
+++ b/scripts/appvars_purge_all.sh
@@ -4,12 +4,12 @@ IFS=$'\n\t'
 
 appvars_purge_all() {
 	local Title="Purge All Variables"
-	local DISABLED_APPS
-	DISABLED_APPS="$(run_script 'app_list_disabled')"
-	if [[ -n ${DISABLED_APPS-} ]]; then
+	local -a DisabledApps
+	run_script 'app_list_disabled_into' DisabledApps
+	if [[ -n ${DisabledApps[*]-} ]]; then
 		if [[ ${CI-} == true ]] || run_script 'question_prompt' Y "Would you like to purge variables for all disabled apps?" "${Title}" "${ASSUMEYES:+Y}"; then
 			info "Purging disabled app variables."
-			for APPNAME in ${DISABLED_APPS-}; do
+			for APPNAME in "${DisabledApps[@]-}"; do
 				run_script 'appvars_purge' "${APPNAME}"
 			done
 		fi

--- a/scripts/env_create.sh
+++ b/scripts/env_create.sh
@@ -29,7 +29,9 @@ env_create() {
 				"Failing command: {{|FailingCommand|}}cp \"${COMPOSE_ENV_DEFAULT_FILE}\" \"${COMPOSE_ENV}\""
 		run_script 'set_permissions' "${COMPOSE_ENV}"
 		run_script 'env_sanitize' --skip-backup
-		if [[ -n ${DefaultApps-} && -z $(run_script 'app_list_referenced') ]]; then
+		local -a ReferencedApps
+		run_script 'app_list_referenced_into' ReferencedApps
+		if [[ -n ${DefaultApps-} && -z ${ReferencedApps[*]-} ]]; then
 			info "Installing default applications."
 			run_script 'appvars_create' "${DefaultApps[@]}"
 			run_script 'env_sanitize' --skip-backup

--- a/scripts/env_format_lines_into.sh
+++ b/scripts/env_format_lines_into.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+env_format_lines_into() {
+	local -n _efli_out_="${1}"
+	shift
+	readarray -t _efli_out_ < <(run_script 'env_format_lines' "$@")
+}
+
+test_env_format_lines_into() {
+	warn "CI does not test env_format_lines_into."
+}

--- a/scripts/env_merge_newonly.sh
+++ b/scripts/env_merge_newonly.sh
@@ -20,8 +20,8 @@ env_merge_newonly() {
 		warn "File '{{|File|}}${MergeFromFile}{{[-]}}' does not exist."
 	else
 		local -a MergeFromVars MergeToVars VarsToAdd
-		readarray -t MergeFromVars < <(run_script 'env_var_list' "${MergeFromFile}")
-		readarray -t MergeToVars < <(run_script 'env_var_list' "${MergeToFile}")
+		run_script 'env_var_list_into' MergeFromVars "${MergeFromFile}"
+		run_script 'env_var_list_into' MergeToVars "${MergeToFile}"
 		readarray -t VarsToAdd < <(comm -23 <(printf '%s\n' "${MergeFromVars[@]}" | sort) <(printf '%s\n' "${MergeToVars[@]}" | sort))
 		if [[ -n ${VarsToAdd[*]-} ]]; then
 			local old_IFS="${IFS}"

--- a/scripts/env_update.sh
+++ b/scripts/env_update.sh
@@ -40,9 +40,7 @@ env_update() {
 		run_script 'appvars_lines' "" > "${ENV_LINES_FILE}"
 
 		local -a UPDATED_ENV_LINES=()
-		readarray -t UPDATED_ENV_LINES < <(
-			run_script 'env_format_lines' "${ENV_LINES_FILE}" "${COMPOSE_ENV_DEFAULT_FILE}" ""
-		)
+		run_script 'env_format_lines_into' UPDATED_ENV_LINES "${ENV_LINES_FILE}" "${COMPOSE_ENV_DEFAULT_FILE}" ""
 
 		if [[ -n ${applist[*]-} ]]; then
 			for appname in "${applist[@]}"; do
@@ -55,9 +53,9 @@ env_update() {
 				if ((${#UPDATED_ENV_LINES[@]} > 0)); then
 					UPDATED_ENV_LINES+=("")
 				fi
-				readarray -t -O ${#UPDATED_ENV_LINES[@]} UPDATED_ENV_LINES < <(
-					run_script 'env_format_lines' "${ENV_LINES_FILE}" "${APP_DEFAULT_GLOBAL_ENV_FILE}" "${appname}"
-				)
+				local -a NewLines
+				run_script 'env_format_lines_into' NewLines "${ENV_LINES_FILE}" "${APP_DEFAULT_GLOBAL_ENV_FILE}" "${appname}"
+				UPDATED_ENV_LINES+=("${NewLines[@]-}")
 			done
 		fi
 		RunAndLog "" "rm:notice" \
@@ -102,9 +100,7 @@ env_update() {
 					run_script 'app_instance_file_into' APP_DEFAULT_ENV_FILE "${appname}" ".env.app.*"
 				fi
 				local -a UPDATED_APP_ENV_LINES=()
-				readarray -t UPDATED_APP_ENV_LINES < <(
-					run_script 'env_format_lines' "${APP_ENV_FILE}" "${APP_DEFAULT_ENV_FILE}" "${appname}"
-				)
+				run_script 'env_format_lines_into' UPDATED_APP_ENV_LINES "${APP_ENV_FILE}" "${APP_DEFAULT_ENV_FILE}" "${appname}"
 				local MKTEMP_APP_ENV_UPDATED
 				MKTEMP_APP_ENV_UPDATED=$(mktemp -t "${APPLICATION_NAME}.${FUNCNAME[0]}.MKTEMP_APP_ENV_UPDATED.XXXXXXXXXX") ||
 					fatal \

--- a/scripts/env_var_list_into.sh
+++ b/scripts/env_var_list_into.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+env_var_list_into() {
+	local -n _evli_out_="${1}"
+	shift
+	readarray -t _evli_out_ < <(run_script 'env_var_list' "$@")
+}
+
+test_env_var_list_into() {
+	warn "CI does not test env_var_list_into."
+}

--- a/scripts/menu_app_select.sh
+++ b/scripts/menu_app_select.sh
@@ -53,7 +53,7 @@ menu_app_select() {
 		local -a AppList AddedApps BuiltinApps
 		local AddedAppsRegex=''
 
-		readarray -t AddedApps < <(run_script 'app_list_added')
+		run_script 'app_list_added_into' AddedApps
 		update_gauge 1
 
 		readarray -t AddedApps < <(run_script 'app_filter_runnable' "${AddedApps[@]-}" | sort -f -u)
@@ -91,7 +91,7 @@ menu_app_select() {
 		ProgressStepNumber=0
 		update_gauge 0 "${FindBuiltinApps}" "_Waiting_" "_InProgress_"
 
-		readarray -t BuiltinApps < <(run_script 'app_list_nondeprecated')
+		run_script 'app_list_nondeprecated_into' BuiltinApps
 		update_gauge 1
 
 		readarray -t BuiltinApps < <(run_script 'app_filter_runnable' "${BuiltinApps[@]}")

--- a/scripts/menu_config_vars.sh
+++ b/scripts/menu_config_vars.sh
@@ -58,9 +58,7 @@ menu_config_vars() {
 		fi
 		run_script 'appvars_lines' "${APPNAME}" > "${CurrentGlobalEnvFile}"
 		local -a CurrentGlobalEnvLines
-		readarray -t CurrentGlobalEnvLines < <(
-			run_script 'env_format_lines' "${CurrentGlobalEnvFile}" "${DefaultGlobalEnvFile}" "${APPNAME}"
-		)
+		run_script 'env_format_lines_into' CurrentGlobalEnvLines "${CurrentGlobalEnvFile}" "${DefaultGlobalEnvFile}" "${APPNAME}"
 		for line in "${CurrentGlobalEnvLines[@]-}"; do
 			LineNumber+=1
 			CurrentValueOnLine[LineNumber]="${line}"
@@ -105,9 +103,7 @@ menu_config_vars() {
 			LineColor[LineNumber]="{{|LineHeading|}}"
 			run_script 'appvars_lines' "${APPNAME}:" > "${CurrentAppEnvFile}"
 			local -a CurrentAppEnvLines
-			readarray -t CurrentAppEnvLines < <(
-				run_script 'env_format_lines' "${CurrentAppEnvFile}" "${DefaultAppEnvFile}" "${APPNAME}"
-			)
+			run_script 'env_format_lines_into' CurrentAppEnvLines "${CurrentAppEnvFile}" "${DefaultAppEnvFile}" "${APPNAME}"
 			for line in "${CurrentAppEnvLines[@]}"; do
 				LineNumber+=1
 				CurrentValueOnLine[LineNumber]="${line}"

--- a/scripts/menu_options_package_manager.sh
+++ b/scripts/menu_options_package_manager.sh
@@ -18,7 +18,7 @@ menu_options_package_manager() {
 	run_script 'config_get_into' CurrentPackageManager pm.package_manager || true
 
 	local -a PackageManagerList
-	readarray -t PackageManagerList < <(run_script 'package_manager_list')
+	run_script 'package_manager_list_into' PackageManagerList
 
 	local LastChoice="${PM_AutoDetect_Tag}"
 

--- a/scripts/needs_appvars_create.sh
+++ b/scripts/needs_appvars_create.sh
@@ -22,9 +22,9 @@ needs_appvars_create() {
 		# BULK MODE
 		# 2. Check Added Apps List
 		local AddedAppsFile="${timestamps_folder}/AddedApps"
-		local AddedApps
-		AddedApps="$(run_script 'app_list_added')"
-		if [[ ! -f ${AddedAppsFile} ]] || ! cmp -s "${AddedAppsFile}" <(printf '%s\n' "${AddedApps}"); then
+		local -a AddedApps
+		run_script 'app_list_added_into' AddedApps
+		if [[ ! -f ${AddedAppsFile} ]] || ! cmp -s "${AddedAppsFile}" <(printf '%s\n' "${AddedApps[@]-}"); then
 			return 0
 		fi
 
@@ -34,7 +34,7 @@ needs_appvars_create() {
 			return 0
 		fi
 
-		for AppName in ${AddedApps}; do
+		for AppName in "${AddedApps[@]-}"; do
 			local -l appname=${AppName}
 			local AppEnvFile
 			run_script 'app_env_file_into' AppEnvFile "${appname}"

--- a/scripts/needs_env_update.sh
+++ b/scripts/needs_env_update.sh
@@ -24,7 +24,9 @@ needs_env_update() {
 		if file_changed "${VarFile}"; then
 			return 0
 		fi
-		if [[ ! -f ${ReferencedAppsFile} ]] || ! cmp -s "${ReferencedAppsFile}" <(run_script 'app_list_referenced' || true); then
+		local -a ReferencedApps
+		run_script 'app_list_referenced_into' ReferencedApps || true
+		if [[ ! -f ${ReferencedAppsFile} ]] || ! cmp -s "${ReferencedAppsFile}" <(printf '%s\n' "${ReferencedApps[@]-}"); then
 			return 0
 		fi
 		return 1

--- a/scripts/needs_yml_merge.sh
+++ b/scripts/needs_yml_merge.sh
@@ -29,7 +29,9 @@ needs_yml_merge() {
 	# Sentinel file for YML merge (use docker-compose.yml marker as reference)
 	local SentinelFile="${timestamps_folder}/docker-compose.yml"
 
-	for AppName in $(run_script 'app_list_enabled'); do
+	local -a EnabledApps
+	run_script 'app_list_enabled_into' EnabledApps
+	for AppName in "${EnabledApps[@]-}"; do
 		local -l appname=${AppName}
 		local _AppEnvFile_
 		run_script 'app_env_file_into' _AppEnvFile_ "${appname}"

--- a/scripts/package_manager_existing_list_into.sh
+++ b/scripts/package_manager_existing_list_into.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+package_manager_existing_list_into() {
+	local -n _pmeli_out_="${1}"
+	readarray -t _pmeli_out_ < <(run_script 'package_manager_existing_list')
+}
+
+test_package_manager_existing_list_into() {
+	warn "CI does not test package_manager_existing_list_into."
+}

--- a/scripts/package_manager_existing_table.sh
+++ b/scripts/package_manager_existing_table.sh
@@ -9,7 +9,7 @@ declare -a _dependencies_list=(
 package_manager_existing_table() {
 	local -a TableArray=()
 	local -a PackageManagerList
-	readarray -t PackageManagerList < <(run_script 'package_manager_existing_list')
+	run_script 'package_manager_existing_list_into' PackageManagerList
 	for PackageManagerName in "${PackageManagerList[@]-}"; do
 		local PackageManagerDescription PackageManagerNicename
 		PackageManagerDescription="$(run_script 'package_manager_description' "${PackageManagerName}")"

--- a/scripts/package_manager_list_into.sh
+++ b/scripts/package_manager_list_into.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+package_manager_list_into() {
+	local -n _pmli_out_="${1}"
+	readarray -t _pmli_out_ < <(run_script 'package_manager_list')
+}
+
+test_package_manager_list_into() {
+	warn "CI does not test package_manager_list_into."
+}

--- a/scripts/package_manager_table.sh
+++ b/scripts/package_manager_table.sh
@@ -9,7 +9,7 @@ declare -a _dependencies_list=(
 package_manager_table() {
 	local -a TableArray=()
 	local -a PackageManagerList
-	readarray -t PackageManagerList < <(run_script 'package_manager_list')
+	run_script 'package_manager_list_into' PackageManagerList
 	for PackageManagerName in "${PackageManagerList[@]-}"; do
 		local PackageManagerDescription PackageManagerNicename
 		PackageManagerDescription="$(run_script 'package_manager_description' "${PackageManagerName}")"

--- a/scripts/unset_needs_appvars_create.sh
+++ b/scripts/unset_needs_appvars_create.sh
@@ -17,12 +17,12 @@ unset_needs_appvars_create() {
 		cp -a "${COMPOSE_ENV}" "${timestamps_folder}/$(basename "${COMPOSE_ENV}")"
 
 		# 2. Record Added Apps List
-		local AddedApps
-		AddedApps="$(run_script 'app_list_added')"
-		printf '%s\n' "${AddedApps}" > "${timestamps_folder}/AddedApps"
+		local -a AddedApps
+		run_script 'app_list_added_into' AddedApps
+		printf '%s\n' "${AddedApps[@]-}" > "${timestamps_folder}/AddedApps"
 
 		# 3. Record app-specific .env state for all added apps
-		for AppName in ${AddedApps}; do
+		for AppName in "${AddedApps[@]-}"; do
 			local AppEnvFile
 			run_script 'app_env_file_into' AppEnvFile "${AppName}"
 			if [[ -f ${AppEnvFile} ]]; then
@@ -41,7 +41,7 @@ unset_needs_appvars_create() {
 		touch "${timestamps_folder}/LastSynced_${APPNAME}"
 		# Also update the app env timestamp if it exists
 		local AppEnvFile
-		AppEnvFile="$(run_script 'app_env_file' "${AppName}")"
+		run_script 'app_env_file_into' AppEnvFile "${AppName}"
 		if [[ -f ${AppEnvFile} ]]; then
 			cp -a "${AppEnvFile}" "${timestamps_folder}/$(basename "${AppEnvFile}")"
 		fi

--- a/scripts/unset_needs_env_update.sh
+++ b/scripts/unset_needs_env_update.sh
@@ -9,7 +9,9 @@ unset_needs_env_update() {
 
 	if [[ -z ${VarFile} ]]; then
 		run_script 'unset_needs_env_update' "${COMPOSE_ENV}"
-		for AppName in $(run_script 'app_list_referenced'); do
+		local -a ReferencedApps
+		run_script 'app_list_referenced_into' ReferencedApps
+		for AppName in "${ReferencedApps[@]-}"; do
 			local _AppEnvFile_
 			run_script 'app_env_file_into' _AppEnvFile_ "${AppName}"
 			run_script 'unset_needs_env_update' "${_AppEnvFile_}"
@@ -31,7 +33,9 @@ unset_needs_env_update() {
 	if [[ ${VarFile} == "${COMPOSE_ENV}" ]]; then
 		local ReferencedAppsFile
 		ReferencedAppsFile="${timestamps_folder}/${filename}_ReferencedApps"
-		run_script 'app_list_referenced' > "${ReferencedAppsFile}"
+		local -a ReferencedApps
+		run_script 'app_list_referenced_into' ReferencedApps
+		printf '%s\n' "${ReferencedApps[@]-}" > "${ReferencedAppsFile}"
 	else
 		local -u APPNAME
 		APPNAME="$(run_script 'varfile_to_appname' "${VarFile}")"

--- a/scripts/unset_needs_yml_merge.sh
+++ b/scripts/unset_needs_yml_merge.sh
@@ -13,7 +13,9 @@ unset_needs_yml_merge() {
 	fi
 	make_timestamp_file "${DOCKER_COMPOSE_FILE}"
 	make_timestamp_file "${COMPOSE_ENV}"
-	for AppName in $(run_script 'app_list_enabled'); do
+	local -a EnabledApps
+	run_script 'app_list_enabled_into' EnabledApps
+	for AppName in "${EnabledApps[@]-}"; do
 		local _AppEnvFile_
 		run_script 'app_env_file_into' _AppEnvFile_ "${AppName}"
 		make_timestamp_file "${_AppEnvFile_}"

--- a/scripts/yml_merge.sh
+++ b/scripts/yml_merge.sh
@@ -20,9 +20,9 @@ commands_yml_merge() {
 	fi
 	local COMPOSE_FILE=""
 	notice "Adding enabled app templates to merge '{{|File|}}docker-compose.yml{{[-]}}'. Please be patient, this can take a while."
-	local ENABLED_APPS
-	ENABLED_APPS="$(run_script 'app_list_enabled')"
-	for APPNAME in ${ENABLED_APPS-}; do
+	local -a EnabledApps
+	run_script 'app_list_enabled_into' EnabledApps
+	for APPNAME in "${EnabledApps[@]-}"; do
 		local -l appname=${APPNAME}
 		local AppName
 		run_script 'app_nicename_into' AppName "${APPNAME}"


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Introduce helper scripts that populate array namerefs from existing list-style scripts and update callers to use them for environment and app list handling.

Enhancements:
- Add *_list_into and *_into helper scripts to write results of list-producing commands directly into referenced arrays.
- Refactor environment management and app variable scripts to use array-based helpers instead of parsing command output with command substitution and word splitting.
- Improve handling of app, package manager, and env var lists by consistently treating them as arrays across scripts.