### PR TITLE
Switch to pure bash from `grep` and `sed` across several functions

### DIFF
--- a/scripts/app_description.sh
+++ b/scripts/app_description.sh
@@ -3,9 +3,9 @@ set -Eeuo pipefail
 IFS=$'\n\t'
 
 app_description() {
-	local _ad_result_
-	run_script 'app_description_into' _ad_result_ "$@"
-	echo "${_ad_result_}"
+	local result
+	run_script 'app_description_into' result "$@"
+	echo "${result}"
 }
 
 test_app_description() {

--- a/scripts/app_description_from_template.sh
+++ b/scripts/app_description_from_template.sh
@@ -5,9 +5,9 @@ IFS=$'\n\t'
 declare -a _dependencies_list=()
 
 app_description_from_template() {
-	local _adft_result_
-	run_script 'app_description_from_template_into' _adft_result_ "$@"
-	echo "${_adft_result_}"
+	local result
+	run_script 'app_description_from_template_into' result "$@"
+	echo "${result}"
 }
 
 test_app_description_from_template() {

--- a/scripts/app_description_from_template_into.sh
+++ b/scripts/app_description_from_template_into.sh
@@ -2,10 +2,7 @@
 set -Eeuo pipefail
 IFS=$'\n\t'
 
-declare -a _dependencies_list=(
-	grep
-	sed
-)
+declare -a _dependencies_list=()
 
 app_description_from_template_into() {
 	# Return the description of a single appname.
@@ -16,7 +13,17 @@ app_description_from_template_into() {
 		local _adft_labels_yml_
 		run_script 'app_instance_file_into' _adft_labels_yml_ "${_adft_appname_}" "*.labels.yml"
 		if [[ -f ${_adft_labels_yml_} ]]; then
-			_adft_out_="$(${GREP} --color=never -Po "\scom\.dockstarter\.appinfo\.description: \K.*" "${_adft_labels_yml_}" | ${SED} -E 's/^([^"].*[^"])$/"\1"/' | xargs || echo "! Missing description !")"
+			_adft_out_="! Missing description !"
+			local _adft_line_ _adft_pattern_='[[:space:]]com\.dockstarter\.appinfo\.description: (.*)'
+			while IFS= read -r _adft_line_; do
+				if [[ ${_adft_line_} =~ ${_adft_pattern_} ]]; then
+					local _adft_val_="${BASH_REMATCH[1]}"
+					_adft_val_="${_adft_val_#\"}"
+					_adft_val_="${_adft_val_%\"}"
+					_adft_out_="${_adft_val_}"
+					break
+				fi
+			done < "${_adft_labels_yml_}"
 		else
 			_adft_out_="! Missing application !"
 		fi

--- a/scripts/app_env_file.sh
+++ b/scripts/app_env_file.sh
@@ -5,9 +5,9 @@ IFS=$'\n\t'
 declare -a _dependencies_list=()
 
 app_env_file() {
-	local _aef_result_
-	run_script 'app_env_file_into' _aef_result_ "$@"
-	echo "${_aef_result_}"
+	local result
+	run_script 'app_env_file_into' result "$@"
+	echo "${result}"
 }
 
 test_app_env_file() {

--- a/scripts/app_instance_file.sh
+++ b/scripts/app_instance_file.sh
@@ -10,9 +10,9 @@ app_instance_file() {
 	#
 	# app_instance_file "radarr" "*.labels.yml" will return a string similar to "/home/user/.dockstarter/instances/radarr/radarr.labels.yml"
 	# If the file does not exist, it is created from the matching file in the "templates" folder.
-	local _aif_result_
-	run_script 'app_instance_file_into' _aif_result_ "$@"
-	echo "${_aif_result_}"
+	local result
+	run_script 'app_instance_file_into' result "$@"
+	echo "${result}"
 }
 
 test_app_instance_file() {

--- a/scripts/app_instance_folder.sh
+++ b/scripts/app_instance_folder.sh
@@ -3,9 +3,9 @@ set -Eeuo pipefail
 IFS=$'\n\t'
 
 app_instance_folder() {
-	local _aifld_result_
-	run_script 'app_instance_folder_into' _aifld_result_ "$@"
-	echo "${_aifld_result_}"
+	local result
+	run_script 'app_instance_folder_into' result "$@"
+	echo "${result}"
 }
 
 test_app_instance_folder() {

--- a/scripts/app_is_deprecated.sh
+++ b/scripts/app_is_deprecated.sh
@@ -2,10 +2,7 @@
 set -Eeuo pipefail
 IFS=$'\n\t'
 
-declare -a _dependencies_list=(
-	grep
-	sed
-)
+declare -a _dependencies_list=()
 
 app_is_deprecated() {
 	local -l appname=${1-}
@@ -13,9 +10,17 @@ app_is_deprecated() {
 	run_script 'appname_to_baseappname_into' baseappname "${appname}"
 	local labels_yml
 	run_script 'app_template_file_into' labels_yml "${baseappname}" "*.labels.yml"
-	local APP_DEPRECATED
+	local APP_DEPRECATED=""
 	if [[ -f ${labels_yml} ]]; then
-		APP_DEPRECATED="$(${GREP} --color=never -Po "\scom\.dockstarter\.appinfo\.deprecated: \K.*" "${labels_yml}" | ${SED} -E 's/^([^"].*[^"])$/"\1"/' | xargs || echo false)"
+		local line pattern='[[:space:]]com\.dockstarter\.appinfo\.deprecated: (.*)'
+		while IFS= read -r line; do
+			if [[ ${line} =~ ${pattern} ]]; then
+				APP_DEPRECATED="${BASH_REMATCH[1]}"
+				APP_DEPRECATED="${APP_DEPRECATED#\"}"
+				APP_DEPRECATED="${APP_DEPRECATED%\"}"
+				break
+			fi
+		done < "${labels_yml}"
 	fi
 	if [[ ${APP_DEPRECATED-} == "true" ]]; then
 		return 0

--- a/scripts/app_is_disabled.sh
+++ b/scripts/app_is_disabled.sh
@@ -8,9 +8,9 @@ app_is_disabled() {
 		false
 		return
 	fi
-	local _aid_enabled_
-	run_script 'env_get_into' _aid_enabled_ "${APPNAME}__ENABLED"
-	is_false "${_aid_enabled_}"
+	local enabled
+	run_script 'env_get_into' enabled "${APPNAME}__ENABLED"
+	is_false "${enabled}"
 }
 
 test_app_is_disabled() {

--- a/scripts/app_is_enabled.sh
+++ b/scripts/app_is_enabled.sh
@@ -8,9 +8,9 @@ app_is_enabled() {
 		false
 		return
 	fi
-	local _aie_enabled_
-	run_script 'env_get_into' _aie_enabled_ "${APPNAME}__ENABLED"
-	is_true "${_aie_enabled_}"
+	local enabled
+	run_script 'env_get_into' enabled "${APPNAME}__ENABLED"
+	is_true "${enabled}"
 }
 
 test_app_is_enabled() {

--- a/scripts/app_is_nondeprecated.sh
+++ b/scripts/app_is_nondeprecated.sh
@@ -2,10 +2,7 @@
 set -Eeuo pipefail
 IFS=$'\n\t'
 
-declare -a _dependencies_list=(
-	grep
-	sed
-)
+declare -a _dependencies_list=()
 
 app_is_nondeprecated() {
 	local -l appname=${1-}
@@ -13,9 +10,17 @@ app_is_nondeprecated() {
 	run_script 'appname_to_baseappname_into' baseappname "${appname}"
 	local labels_yml
 	run_script 'app_template_file_into' labels_yml "${baseappname}" "*.labels.yml"
-	local APP_DEPRECATED
+	local APP_DEPRECATED=""
 	if [[ -f ${labels_yml} ]]; then
-		APP_DEPRECATED="$(${GREP} --color=never -Po "\scom\.dockstarter\.appinfo\.deprecated: \K.*" "${labels_yml}" | ${SED} -E 's/^([^"].*[^"])$/"\1"/' | xargs || echo false)"
+		local line pattern='[[:space:]]com\.dockstarter\.appinfo\.deprecated: (.*)'
+		while IFS= read -r line; do
+			if [[ ${line} =~ ${pattern} ]]; then
+				APP_DEPRECATED="${BASH_REMATCH[1]}"
+				APP_DEPRECATED="${APP_DEPRECATED#\"}"
+				APP_DEPRECATED="${APP_DEPRECATED%\"}"
+				break
+			fi
+		done < "${labels_yml}"
 	fi
 	if [[ ${APP_DEPRECATED-} == "false" ]]; then
 		return 0

--- a/scripts/app_list_enabled.sh
+++ b/scripts/app_list_enabled.sh
@@ -14,9 +14,9 @@ app_list_enabled() {
 		${GREP} --color=never -o -P "^${APPNAME_REGEX}(?=__ENABLED\s*=(?<quote>['|\"]?)(?i:on|true|yes)\k<quote>)" "${COMPOSE_ENV}" | sort || true
 	)
 	for AppName in "${ENABLED_APPS[@]}"; do
-		local _ale_folder_
-		run_script 'app_instance_folder_into' _ale_folder_ "${AppName}"
-		if [[ -d ${_ale_folder_} ]]; then
+		local folder
+		run_script 'app_instance_folder_into' folder "${AppName}"
+		if [[ -d ${folder} ]]; then
 			echo "${AppName}"
 		fi
 	done

--- a/scripts/app_nicename.sh
+++ b/scripts/app_nicename.sh
@@ -7,9 +7,9 @@ app_nicename() {
 	local AppList
 	AppList="$(xargs -n 1 <<< "$*")"
 	for APPNAME in ${AppList}; do
-		local _an_result_
-		run_script 'app_nicename_into' _an_result_ "${APPNAME}"
-		echo "${_an_result_}"
+		local result
+		run_script 'app_nicename_into' result "${APPNAME}"
+		echo "${result}"
 	done
 }
 

--- a/scripts/app_nicename_from_template.sh
+++ b/scripts/app_nicename_from_template.sh
@@ -9,9 +9,9 @@ app_nicename_from_template() {
 	local AppList
 	AppList="$(xargs -n 1 <<< "$*")"
 	for APPNAME in ${AppList}; do
-		local _anft_result_
-		run_script 'app_nicename_from_template_into' _anft_result_ "${APPNAME}"
-		echo "${_anft_result_}"
+		local result
+		run_script 'app_nicename_from_template_into' result "${APPNAME}"
+		echo "${result}"
 	done
 }
 

--- a/scripts/app_nicename_from_template_into.sh
+++ b/scripts/app_nicename_from_template_into.sh
@@ -2,10 +2,7 @@
 set -Eeuo pipefail
 IFS=$'\n\t'
 
-declare -a _dependencies_list=(
-	grep
-	sed
-)
+declare -a _dependencies_list=()
 
 app_nicename_from_template_into() {
 	# Return the "NiceName" of a single appname. If there is no "NiceName", return the "Title__Case" of "appname"
@@ -18,9 +15,16 @@ app_nicename_from_template_into() {
 	_anft_BaseApp_="${_anft_baseapp_^}"
 	run_script 'app_instance_file_into' _anft_labels_yml_ "${_anft_baseapp_}" "*.labels.yml"
 	if [[ -f ${_anft_labels_yml_} ]]; then
-		_anft_BaseApp_="$(
-			${GREP} --color=never -Po "\scom\.dockstarter\.appinfo\.nicename: \K.*" "${_anft_labels_yml_}" | ${SED} -E 's/^([^"].*[^"])$/"\1"/' | xargs
-		)"
+		local _anft_line_ _anft_pattern_='[[:space:]]com\.dockstarter\.appinfo\.nicename: (.*)'
+		while IFS= read -r _anft_line_; do
+			if [[ ${_anft_line_} =~ ${_anft_pattern_} ]]; then
+				local _anft_val_="${BASH_REMATCH[1]}"
+				_anft_val_="${_anft_val_#\"}"
+				_anft_val_="${_anft_val_%\"}"
+				_anft_BaseApp_="${_anft_val_}"
+				break
+			fi
+		done < "${_anft_labels_yml_}"
 	fi
 	run_script 'appname_to_instancename_into' _anft_instance_ "${_anft_AppName_}"
 	_anft_Instance_=""

--- a/scripts/appname_to_baseappname.sh
+++ b/scripts/appname_to_baseappname.sh
@@ -3,9 +3,9 @@ set -Eeuo pipefail
 IFS=$'\n\t'
 
 appname_to_baseappname() {
-	local _atbn_result_
-	run_script 'appname_to_baseappname_into' _atbn_result_ "$@"
-	echo "${_atbn_result_}"
+	local result
+	run_script 'appname_to_baseappname_into' result "$@"
+	echo "${result}"
 }
 
 test_appname_to_baseappname() {

--- a/scripts/appname_to_instancename.sh
+++ b/scripts/appname_to_instancename.sh
@@ -3,9 +3,9 @@ set -Eeuo pipefail
 IFS=$'\n\t'
 
 appname_to_instancename() {
-	local _atin_result_
-	run_script 'appname_to_instancename_into' _atin_result_ "$@"
-	echo "${_atin_result_}"
+	local result
+	run_script 'appname_to_instancename_into' result "$@"
+	echo "${result}"
 }
 
 test_appname_to_instancename() {

--- a/scripts/env_get.sh
+++ b/scripts/env_get.sh
@@ -5,9 +5,9 @@ IFS=$'\n\t'
 declare -a _dependencies_list=()
 
 env_get() {
-	local _eg_result_
-	run_script 'env_get_into' _eg_result_ "$@"
-	echo "${_eg_result_}"
+	local result
+	run_script 'env_get_into' result "$@"
+	echo "${result}"
 }
 
 test_env_get() {

--- a/scripts/env_get_line.sh
+++ b/scripts/env_get_line.sh
@@ -5,9 +5,9 @@ IFS=$'\n\t'
 declare -a _dependencies_list=()
 
 env_get_line() {
-	local _egl_result_
-	run_script 'env_get_line_into' _egl_result_ "$@"
-	echo "${_egl_result_}"
+	local result
+	run_script 'env_get_line_into' result "$@"
+	echo "${result}"
 }
 
 test_env_get_line() {

--- a/scripts/env_get_literal.sh
+++ b/scripts/env_get_literal.sh
@@ -5,9 +5,9 @@ IFS=$'\n\t'
 declare -a _dependencies_list=()
 
 env_get_literal() {
-	local _egl_result_
-	run_script 'env_get_literal_into' _egl_result_ "$@"
-	echo "${_egl_result_}"
+	local result
+	run_script 'env_get_literal_into' result "$@"
+	echo "${result}"
 }
 
 test_env_get_literal() {

--- a/scripts/env_list_app_env_defaults.sh
+++ b/scripts/env_list_app_env_defaults.sh
@@ -4,9 +4,9 @@ IFS=$'\n\t'
 
 env_list_app_env_defaults() {
 	local -l appname=${1-}
-	local _aif_
-	run_script 'app_instance_file_into' _aif_ "${appname}" ".env.app.*"
-	run_script 'env_var_list' "${_aif_}"
+	local instance_file
+	run_script 'app_instance_file_into' instance_file "${appname}" ".env.app.*"
+	run_script 'env_var_list' "${instance_file}"
 }
 
 test_env_list_app_env_defaults() {

--- a/scripts/env_list_app_global_defaults.sh
+++ b/scripts/env_list_app_global_defaults.sh
@@ -4,9 +4,9 @@ IFS=$'\n\t'
 
 env_list_app_global_defaults() {
 	local -l appname=${1-}
-	local _aif_
-	run_script 'app_instance_file_into' _aif_ "${appname}" ".env"
-	run_script 'env_var_list' "${_aif_}"
+	local instance_file
+	run_script 'app_instance_file_into' instance_file "${appname}" ".env"
+	run_script 'env_var_list' "${instance_file}"
 }
 
 test_env_list_app_global_defaults() {

--- a/scripts/menu_config_vars.sh
+++ b/scripts/menu_config_vars.sh
@@ -66,9 +66,9 @@ menu_config_vars() {
 			VarName="$(${GREP} -o -P '^\w+(?=)' <<< "${line}")"
 			if [[ -n ${VarName-} ]]; then
 				# Line contains a variable
-				local DefaultLine _DefaultVal_
-				run_script 'var_default_value_into' _DefaultVal_ "${VarName}"
-				DefaultLine="${VarName}=${_DefaultVal_}"
+				local DefaultLine DefaultVal
+				run_script 'var_default_value_into' DefaultVal "${VarName}"
+				DefaultLine="${VarName}=${DefaultVal}"
 				if [[ ${line} == "${DefaultLine}" ]]; then
 					LineColor[LineNumber]="{{|LineVar|}}"
 				else
@@ -97,9 +97,9 @@ menu_config_vars() {
 			CurrentValueOnLine[LineNumber]=""
 			LineColor[LineNumber]="{{|LineOther|}}"
 			LineNumber+=1
-			local _AppEnvFilePath_
-			run_script 'app_env_file_into' _AppEnvFilePath_ "${APPNAME}"
-			CurrentValueOnLine[LineNumber]="*** ${_AppEnvFilePath_} ***"
+			local AppEnvFilePath
+			run_script 'app_env_file_into' AppEnvFilePath "${APPNAME}"
+			CurrentValueOnLine[LineNumber]="*** ${AppEnvFilePath} ***"
 			LineColor[LineNumber]="{{|LineHeading|}}"
 			run_script 'appvars_lines' "${APPNAME}:" > "${CurrentAppEnvFile}"
 			local -a CurrentAppEnvLines

--- a/scripts/menu_options_package_manager.sh
+++ b/scripts/menu_options_package_manager.sh
@@ -33,9 +33,9 @@ menu_options_package_manager() {
 		run_script 'package_manager_nicename_into' Tag "${PackageManager}"
 		PM_Tag+=("${Tag}")
 		PM_PackageManager["${Tag}"]="${PackageManager}"
-		local _pm_desc_
-		run_script 'package_manager_description_into' _pm_desc_ "${PackageManager}"
-		PM_Item["${Tag}"]="${_pm_desc_}"
+		local desc
+		run_script 'package_manager_description_into' desc "${PackageManager}"
+		PM_Item["${Tag}"]="${desc}"
 		if [[ ${PackageManager} == "${CurrentPackageManager}" ]]; then
 			LastChoice="${Tag}"
 		fi

--- a/scripts/menu_options_theme.sh
+++ b/scripts/menu_options_theme.sh
@@ -21,11 +21,11 @@ menu_options_theme() {
 		DisplayNames+=("${DisplayName}")
 		ConfigValues+=("${ConfigValue}")
 		IsUserTheme+=("${UserTheme}")
-		local _td_ _ta_
-		run_script 'theme_description_into' _td_ "${ConfigValue}"
-		run_script 'theme_author_into' _ta_ "${ConfigValue}"
-		ThemeDescription["${ConfigValue}"]="${_td_}"
-		ThemeAuthor["${ConfigValue}"]="${_ta_}"
+		local desc author
+		run_script 'theme_description_into' desc "${ConfigValue}"
+		run_script 'theme_author_into' author "${ConfigValue}"
+		ThemeDescription["${ConfigValue}"]="${desc}"
+		ThemeAuthor["${ConfigValue}"]="${author}"
 	done < <(run_script 'theme_list_data')
 
 	# Check if the configured theme appears in the list; if not, prepend an orphaned placeholder

--- a/scripts/needs_yml_merge.sh
+++ b/scripts/needs_yml_merge.sh
@@ -33,9 +33,9 @@ needs_yml_merge() {
 	run_script 'app_list_enabled_into' EnabledApps
 	for AppName in "${EnabledApps[@]-}"; do
 		local -l appname=${AppName}
-		local _AppEnvFile_
-		run_script 'app_env_file_into' _AppEnvFile_ "${appname}"
-		if file_changed "${_AppEnvFile_}"; then
+		local AppEnvFile
+		run_script 'app_env_file_into' AppEnvFile "${appname}"
+		if file_changed "${AppEnvFile}"; then
 			# .env.app.appname has changed, return true
 			return 0
 		fi

--- a/scripts/unset_needs_env_update.sh
+++ b/scripts/unset_needs_env_update.sh
@@ -12,9 +12,9 @@ unset_needs_env_update() {
 		local -a ReferencedApps
 		run_script 'app_list_referenced_into' ReferencedApps
 		for AppName in "${ReferencedApps[@]-}"; do
-			local _AppEnvFile_
-			run_script 'app_env_file_into' _AppEnvFile_ "${AppName}"
-			run_script 'unset_needs_env_update' "${_AppEnvFile_}"
+			local AppEnvFile
+			run_script 'app_env_file_into' AppEnvFile "${AppName}"
+			run_script 'unset_needs_env_update' "${AppEnvFile}"
 		done
 		return
 	fi

--- a/scripts/unset_needs_yml_merge.sh
+++ b/scripts/unset_needs_yml_merge.sh
@@ -16,9 +16,9 @@ unset_needs_yml_merge() {
 	local -a EnabledApps
 	run_script 'app_list_enabled_into' EnabledApps
 	for AppName in "${EnabledApps[@]-}"; do
-		local _AppEnvFile_
-		run_script 'app_env_file_into' _AppEnvFile_ "${AppName}"
-		make_timestamp_file "${_AppEnvFile_}"
+		local AppEnvFile
+		run_script 'app_env_file_into' AppEnvFile "${AppName}"
+		make_timestamp_file "${AppEnvFile}"
 	done
 }
 


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Refactor various Bash utility scripts to avoid external grep/sed dependencies and standardize result variable naming while preserving existing behavior.

Enhancements:
- Replace grep/sed-based parsing of labels.yml metadata with pure Bash line-reading and pattern matching in nicename, description, and deprecation helpers.
- Remove declared grep and sed dependencies from affected *_from_template_into and app deprecation scripts.
- Simplify wrapper scripts by renaming generic output variables to a consistent local result variable and propagating it via echo.