### PR TITLE
Convert more sed/grep calls to bash

### DIFF
--- a/scripts/env_sanitize.sh
+++ b/scripts/env_sanitize.sh
@@ -2,9 +2,7 @@
 set -Eeuo pipefail
 IFS=$'\n\t'
 
-declare -a _dependencies_list=(
-	grep
-)
+declare -a _dependencies_list=()
 
 env_sanitize() {
 	local -a VarsToUpdate
@@ -94,7 +92,7 @@ env_sanitize() {
 	for VarName in "${VarList[@]-}"; do
 		local Value
 		run_script 'env_get_into' Value "${VarName}"
-		if [[ -z ${Value-} ]] || echo "${Value-}" | ${GREP} -q 'x'; then
+		if [[ -z ${Value-} || ${Value-} == *x* ]]; then
 			# If the variable is empty or contains an "x", get the default value
 			local Default
 			run_script 'var_default_value_into' Default "${VarName}"

--- a/scripts/menu_config_vars.sh
+++ b/scripts/menu_config_vars.sh
@@ -2,9 +2,7 @@
 set -Eeuo pipefail
 IFS=$'\n\t'
 
-declare -a _dependencies_list=(
-	grep
-)
+declare -a _dependencies_list=()
 
 menu_config_vars() {
 	local APPNAME=${1-}
@@ -62,8 +60,8 @@ menu_config_vars() {
 		for line in "${CurrentGlobalEnvLines[@]-}"; do
 			LineNumber+=1
 			CurrentValueOnLine[LineNumber]="${line}"
-			local VarName
-			VarName="$(${GREP} -o -P '^\w+(?=)' <<< "${line}")"
+			local VarName=""
+			[[ ${line} =~ ^([[:alnum:]_]+) ]] && VarName="${BASH_REMATCH[1]}"
 			if [[ -n ${VarName-} ]]; then
 				# Line contains a variable
 				local DefaultLine DefaultVal
@@ -78,7 +76,7 @@ menu_config_vars() {
 				if [[ -z ${FirstVarLine-} ]]; then
 					FirstVarLine=${LineNumber}
 				fi
-			elif (${GREP} -q -P '^\s*#' <<< "${line}"); then
+			elif [[ ${line} =~ ^[[:space:]]*# ]]; then
 				# Line is a comment
 				LineColor[LineNumber]="{{|LineComment|}}"
 			else
@@ -123,7 +121,7 @@ menu_config_vars() {
 					if [[ -z ${FirstVarLine-} ]]; then
 						FirstVarLine=${LineNumber}
 					fi
-				elif (${GREP} -q -P '^\s*#' <<< "${line}"); then
+				elif [[ ${line} =~ ^[[:space:]]*# ]]; then
 					# Line is a comment
 					LineColor[LineNumber]="{{|LineComment|}}"
 				else

--- a/scripts/menu_value_prompt.sh
+++ b/scripts/menu_value_prompt.sh
@@ -4,7 +4,6 @@ IFS=$'\n\t'
 
 declare -a _dependencies_list=(
 	grep
-	sed
 )
 
 menu_value_prompt() {
@@ -371,7 +370,10 @@ menu_value_prompt() {
 				else
 					local StrippedValue="${OptionValue["${CurrentValueOption}"]}"
 					# Unqauote the value
-					StrippedValue="$(${SED} -E "s|^(['\"])(.*)\1$|\2|g" <<< "${StrippedValue}")"
+					case "${StrippedValue}" in
+						"'"*"'") StrippedValue="${StrippedValue:1:${#StrippedValue}-2}" ;;
+						'"'*'"') StrippedValue="${StrippedValue:1:${#StrippedValue}-2}" ;;
+					esac
 
 					case "${VarName}" in
 						"${APPNAME}__ENABLED")


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Replace external grep and sed usage in configuration and environment scripts with equivalent Bash pattern and regex handling.

Enhancements:
- Remove grep from script dependency lists by using Bash regular expression matching for parsing variable names and detecting comment lines in configuration menus.
- Inline Bash string matching to replace grep-based checks for character presence during environment sanitization.
- Use Bash substring operations instead of sed to strip surrounding quotes from option values in menu prompts.