### PR TITLE
Add back `whiptail` as an optional replacement to `dialog`

### DIFF
--- a/assets/defaults/dockstarter.toml
+++ b/assets/defaults/dockstarter.toml
@@ -3,11 +3,13 @@ config_folder = '${XDG_CONFIG_HOME}'
 compose_folder = '${XDG_CONFIG_HOME}/compose'
 
 [ui]
+display_engine = 'dialog'
 theme = 'DockSTARTer'
 borders = true
 line_characters = true
 scrollbar = true
 shadow = true
+large_buttons = true
 
 [pm]
 package_manager = ''

--- a/includes/cmdline.sh
+++ b/includes/cmdline.sh
@@ -108,6 +108,19 @@ parse_arguments() {
 					break
 					;;
 
+				--config-display-engine)
+					if [[ ${OPTIND} -gt $# || ${!OPTIND} == "-"* ]]; then
+						cmdline_error \
+							"${OPTION}" \
+							"Command %c requires a display engine name." \
+							"${ParsedArgs[@]}" "${CurrentFlags[@]}" "${CurrentCommand[@]}" "${OPTION}"
+						exit 1
+					fi
+					CurrentCommand+=("${OPTION}" "${!OPTIND}")
+					OPTIND+=1
+					break
+					;;
+
 				--config-pm)
 					if [[ ${OPTIND} -gt $# || ${!OPTIND} == "-"* ]]; then
 						cmdline_error \
@@ -430,6 +443,7 @@ run_command() {
 		["--add"]="appvars_create"
 		["-c"]="docker_compose"
 		["--compose"]="docker_compose"
+		["--config-display-engine"]="config_display_engine"
 		["--config-pm"]="config_package_manager"
 		["--config-pm-auto"]="config_package_manager"
 		["--config-pm-list"]="package_manager_list"
@@ -496,6 +510,8 @@ run_command() {
 		["app-select"]="menu_app_select"
 		["options"]="menu_options"
 		["options-display"]="menu_options_display"
+		["options-display-engine"]="menu_options_display_engine"
+		["display-engine"]="menu_options_display_engine"
 		["display"]="menu_options_display"
 		["options-theme"]="menu_options_theme"
 		["theme"]="menu_options_theme"
@@ -516,6 +532,7 @@ run_command() {
 		["-a"]=1
 		["--add"]=1
 		["-e"]=1
+		["--config-display-engine"]=1
 		["--config-pm"]=1
 		["--config-pm-auto"]=1
 		["--config-pm-list"]=1
@@ -536,6 +553,7 @@ run_command() {
 	CommandTitle+=(
 		["-a"]="Add Application"
 		["--add"]="Add Application"
+		["--config-display-engine"]="Select display engine"
 		["--config-pm"]="Select package manager"
 		["--config-pm-auto"]="Select package manager"
 		["--config-pm-list"]="List known package managers"
@@ -741,13 +759,8 @@ run_command() {
 			local EnvCreate="${MenuCommandEnvCreate["${MenuCommand}"]-}"
 			local EnvUpdate="${MenuCommandEnvUpdate["${MenuCommand}"]-}"
 			local UpperCase="${MenuCommandUpperCase["${MenuCommand}"]-}"
-			if [[ -z ${DIALOG-} ]]; then
-				fatal_notrace \
-					"The GUI requires the '{{|Folder|}}dialog{{[-]}}' command to be installed." \
-					"'{{|Program|}}dialog{{[-]}}' command not found. Run '{{|UserCommand|}}${APPLICATION_COMMAND} -i{{[-]}}' to install all dependencies." \
-					"" \
-					"Unable to start GUI without the '{{|Folder|}}dialog{{[-]}}' command."
-			fi
+
+			check_display_engine
 
 			if [[ ${#ParamsArray[@]} -gt 1 ]]; then
 				# --menu MenuCommand Parameter ...
@@ -765,6 +778,7 @@ run_command() {
 					config-apps | apps) ;&
 					config-app-select | app-select | select) ;&
 					config-global | global) ;&
+					config-display-engine | display-engine) ;&
 					options-display | display) ;&
 					options-theme | theme)
 						if [[ -z ${Script} ]]; then
@@ -788,6 +802,7 @@ run_command() {
 			;;
 		-a | --add) ;&
 		-c | --compose) ;&
+		--config-display-engine) ;&
 		--config-pm) ;&
 		--config-pm-list | --config-pm-table) ;&
 		--config-pm-existing-list | --config-pm-existing-table) ;&
@@ -817,18 +832,12 @@ run_command() {
 				run_script 'env_backup'
 			fi
 			if [[ ${RequireDialog-} ]]; then
-				if [[ -z ${DIALOG-} ]]; then
-					fatal_notrace \
-						"The GUI requires the '{{|Folder|}}dialog{{[-]}}' command to be installed." \
-						"'{{|Program|}}dialog{{[-]}}' command not found. Run '{{|UserCommand|}}${APPLICATION_COMMAND} -i{{[-]}}' to install all dependencies." \
-						"" \
-						"Unable to start GUI without the '{{|Folder|}}dialog{{[-]}}' command."
-				fi
+				check_display_engine
 				declare -gx PROMPT="GUI"
 				run_script "${Script}" "${ParamsArray[@]-}" || result=$?
 			else
 				if [[ ${UseDialog} ]]; then
-					run_script_dialog "${Title}" "${SubTitle}" "" \
+					run_script_tui "${Title}" "${SubTitle}" "" \
 						"${Script}" "${ParamsArray[@]-}" || result=$?
 				else
 					run_script "${Script}" "${ParamsArray[@]-}" || result=$?
@@ -851,18 +860,12 @@ run_command() {
 				run_script 'env_backup'
 			fi
 			if [[ ${RequireDialog-} ]]; then
-				if [[ -z ${DIALOG-} ]]; then
-					fatal \
-						"The GUI requires the '{{|Folder|}}dialog{{[-]}}' command to be installed." \
-						"'{{|Program|}}dialog{{[-]}}' command not found. Run '{{|UserCommand|}}${APPLICATION_COMMAND} -i{{[-]}}' to install all dependencies." \
-						"" \
-						"Unable to start GUI without the '{{|Folder|}}dialog{{[-]}}' command."
-				fi
+				check_display_engine
 				declare -gx PROMPT="GUI"
 				run_script "${Script}" "" || result=$?
 			else
 				if [[ ${UseDialog} ]]; then
-					run_script_dialog "${Title}" "${SubTitle}" "" \
+					run_script_tui "${Title}" "${SubTitle}" "" \
 						"${Script}" "" || result=$?
 				else
 					run_script "${Script}" "" || result=$?
@@ -878,11 +881,7 @@ run_command() {
 				fatal \
 					"No script is defined for command '{{|UserCommand|}}${Command}{{[-]}}'."
 			fi
-			[[ -z ${DIALOG-} ]] && fatal_notrace \
-				"The GUI requires the '{{|Folder|}}dialog{{[-]}}' command to be installed." \
-				"'{{|Program|}}dialog{{[-]}}' command not found. Run '{{|UserCommand|}}${APPLICATION_COMMAND} -i{{[-]}}' to install all dependencies." \
-				"" \
-				"Unable to start GUI without the '{{|Folder|}}dialog{{[-]}}' command."
+			check_display_engine
 			declare -gx PROMPT="GUI"
 			local AppName="${ParamsArray[0]-}"
 			if [[ -z ${AppName} ]]; then
@@ -914,7 +913,7 @@ run_command() {
 			fi
 			notice \
 				"${NoticeText}"
-			if use_dialog_box; then
+			if use_tui_box; then
 				run_script 'config_theme' "${ThemeName}" && run_script 'menu_dialog_example' "" "${CURRENT_COMMANDLINE}" || result=$?
 			else
 				run_script 'config_theme' "${ThemeName}" || result=$?
@@ -943,7 +942,7 @@ run_command() {
 					"${Notice}"
 			fi
 			run_script 'config_set' "${ConfigVar}" "${ConfigValue}" || result=$?
-			if use_dialog_box; then
+			if use_tui_box; then
 				run_script 'menu_dialog_example' "${Title}" "${CURRENT_COMMANDLINE}"
 			fi
 			;;
@@ -953,15 +952,13 @@ run_command() {
 				fatal \
 					"No script is defined for command '{{|UserCommand|}}${Command}{{[-]}}'."
 			fi
-			if use_dialog_box; then
-				for AppName in $(xargs -n1 <<< "${ParamsArray[0]}"); do
-					run_script "${Script}" "${AppName}"
-				done |& dialog_pipe "${Title}" "${SubTitle}" ""
-			else
-				for AppName in $(xargs -n1 <<< "${ParamsArray[0]}"); do
-					run_script "${Script}" "${AppName}"
-				done || result=$?
-			fi
+			#shellcheck disable=SC2034 # (warning): PipePID is passed by name to tui_pipe_open/close via nameref and appears unused to shellcheck.
+			local -i PipeFD PipePID
+			tui_pipe_open PipeFD PipePID "${Title}" "${SubTitle}" ""
+			for AppName in $(xargs -n1 <<< "${ParamsArray[0]}"); do
+				run_script "${Script}" "${AppName}"
+			done >&${PipeFD} 2>&1 || result=$?
+			tui_pipe_close PipeFD PipePID
 			;;
 
 		--env-get | --env-get-lower) ;&
@@ -972,15 +969,13 @@ run_command() {
 					"No script is defined for command '{{|UserCommand|}}${Command}{{[-]}}'."
 			fi
 			[[ -n ${UpperCase} ]] && ParamsArray=("${ParamsArray[@]^^}")
-			if use_dialog_box; then
-				for VarName in "${ParamsArray[@]}"; do
-					run_script "${Script}" "${VarName}"
-				done |& dialog_pipe "${Title}" "${SubTitle}" ""
-			else
-				for VarName in "${ParamsArray[@]}"; do
-					run_script "${Script}" "${VarName}"
-				done || result=$?
-			fi
+			#shellcheck disable=SC2034 # (warning): PipePID is passed by name to tui_pipe_open/close via nameref and appears unused to shellcheck.
+			local -i PipeFD PipePID
+			tui_pipe_open PipeFD PipePID "${Title}" "${SubTitle}" ""
+			for VarName in "${ParamsArray[@]}"; do
+				run_script "${Script}" "${VarName}"
+			done >&${PipeFD} 2>&1 || result=$?
+			tui_pipe_close PipeFD PipePID
 			;;
 
 		--env-get= | --env-get-lower=) ;&
@@ -991,8 +986,8 @@ run_command() {
 					"No script is defined for command '{{|UserCommand|}}${Command}{{[-]}}'."
 			fi
 			[[ -n ${UpperCase} ]] && EqualsParam="${EqualsParam^^}"
-			if use_dialog_box; then
-				run_script_dialog "${Title}" "${SubTitle}" "" \
+			if use_tui_box; then
+				run_script_tui "${Title}" "${SubTitle}" "" \
 					"${Script}" "${EqualsParam}"
 			else
 				run_script "${Script}" "${EqualsParam}" || result=$?
@@ -1038,7 +1033,7 @@ run_command() {
 			fi
 			local -a _list_
 			run_script "${Script}_into" _list_
-			run_script_dialog \
+			run_script_tui \
 				"${Title}" \
 				"${SubTitle}" \
 				"" \
@@ -1067,12 +1062,12 @@ set_flags() {
 				declare -gx FORCE=true
 				;;
 			-g | --gui)
-				if [[ -n ${DIALOG-} ]]; then
+				if [[ -n ${DIALOG-} || -n ${WHIPTAIL-} ]]; then
 					declare -gx PROMPT="GUI"
 				else
 					warn \
-						"The '{{|UserCommand|}}${APPLICATION_COMMAND} ${flag}{{[-]}}' option requires the '{{|Folder|}}dialog$}NC}' command to be installed." \
-						"'{{|Program|}}dialog{{[-]}}' command not found. Run '{{|UserCommand|}}${APPLICATION_COMMAND} -i{{[-]}}' to install all dependencies." \
+						"The '{{|UserCommand|}}${APPLICATION_COMMAND} ${flag}{{[-]}}' option requires the '{{|Folder|}}dialog$}NC}' or '{{|Folder|}}whiptail$}NC}' command to be installed." \
+						"'{{|Program|}}dialog{{[-]}}' or '{{|Program|}}whiptail{{[-]}}' command not found. Run '{{|UserCommand|}}${APPLICATION_COMMAND} -i{{[-]}}' to install all dependencies." \
 						"" \
 						"Coninuing without '{{|UserCommand|}}${flag}{{[-]}}' option."
 				fi
@@ -1186,4 +1181,13 @@ ${Message}
 
 ${UsageText}
 EOF
+}
+
+check_display_engine() {
+	[[ -n ${DIALOG-} || -n ${WHIPTAIL-} ]] && return
+	fatal_notrace \
+		"The GUI requires the '{{|UserCommand|}}dialog{{[-]}}' or '{{|UserCommand|}}whiptail{{[-]}}' command to be installed." \
+		"'{{|UserCommand|}}dialog{{[-]}}' or '{{|UserCommand|}}whiptail{{[-]}}' command not found. Run '{{|UserCommand|}}${APPLICATION_COMMAND} -i{{[-]}}' to install all dependencies." \
+		"" \
+		"Unable to start GUI without the '{{|UserCommand|}}dialog{{[-]}}' or '{{|UserCommand|}}whiptail{{[-]}}' command."
 }

--- a/includes/misc_functions.sh
+++ b/includes/misc_functions.sh
@@ -287,7 +287,7 @@ table_pipe() {
 	readarray -t ColWidths < <(longest_columns "${Cols}" "${VisibleData[@]}")
 
 	local -A CharSet
-	if is_false "${D["LineCharacters"]-}" || in_dialog_box; then
+	if is_false "${D["ui.LineCharacters"]-}" || in_tui_box; then
 		CharSet=(
 			["TopLeft"]="+"
 			["TopRight"]="+"
@@ -378,7 +378,7 @@ table() {
 	shift
 	local -a Headings=("${@:1:Cols}")
 	local -a Data=("${@:Cols+1}")
-	if use_dialog_box || [[ -t 1 ]]; then
+	if use_tui_box || [[ -t 1 ]]; then
 		printf '%s\n' "${Data[@]}" | table_pipe "${Cols}" "${Headings[@]}" | resolve_strings C
 	else
 		# Captured/Piped call: Output RAW TAGS

--- a/includes/pm_variables.sh
+++ b/includes/pm_variables.sh
@@ -62,6 +62,7 @@ declare -argx PM__COMMAND_DEPS=(
 	"ip"
 	"sed"
 	"stat"
+	"whiptail"
 )
 
 declare -argx PM_BREW_COMMAND_DEPS=(
@@ -74,6 +75,7 @@ declare -argx PM_BREW_COMMAND_DEPS=(
 	"ip"
 	"gsed"
 	"gstat"
+	"whiptail"
 )
 
 declare -argx PM_PORT_COMMAND_DEPS=(
@@ -86,6 +88,7 @@ declare -argx PM_PORT_COMMAND_DEPS=(
 	"ip"
 	"gsed"
 	"gstat"
+	"whiptail"
 )
 
 declare -Argx PM__DEP_PACKAGE=()
@@ -119,6 +122,12 @@ pm_check_dependency() {
 			declare -gx DIALOG
 			DIALOG="$(command -v "${Dep}")"
 			[[ -n ${DIALOG} ]]
+			return
+			;;
+		whiptail)
+			declare -gx WHIPTAIL
+			WHIPTAIL="$(command -v "${Dep}")"
+			[[ -n ${WHIPTAIL} ]]
 			return
 			;;
 		gfind | find)
@@ -195,7 +204,7 @@ pm_check_dependencies() {
 			notice | warn | error | fatal)
 				${NoticeType} "$(
 					printf \
-						"Dependency '{{|Folder|}}%s{{[-]}}' is not installed.\n" \
+						"Dependency '{{|UserCommand|}}%s{{[-]}}' is not installed.\n" \
 						"${Dependencies[@]}"
 				)" \
 					"Not all dependencies are installed." \

--- a/includes/tui_functions.sh
+++ b/includes/tui_functions.sh
@@ -4,6 +4,8 @@ IFS=$'\n\t'
 
 declare -gx DIALOG
 DIALOG=$(command -v dialog) || true
+declare -gx WHIPTAIL
+WHIPTAIL=$(command -v whiptail) || true
 
 declare -Agx DC
 declare -Agx D
@@ -14,12 +16,13 @@ declare -rgx DIALOG_OPTIONS_NAME='.dialogoptions'
 declare -rgx DIALOGRC="${TEMP_FOLDER}/${DIALOGRC_NAME}"
 declare -rgx DIALOG_OPTIONS_FILE="${TEMP_FOLDER}/${DIALOG_OPTIONS_NAME}"
 
+declare -rigx DIALOG_CANCEL=1
 declare -rigx DIALOGTIMEOUT=3
 declare -rigx DIALOG_OK=0
-declare -rigx DIALOG_CANCEL=1
 declare -rigx DIALOG_HELP=2
 declare -rigx DIALOG_EXTRA=3
 declare -rigx DIALOG_ITEM_HELP=4
+declare -rigx DIALOG_EXIT=5
 declare -rigx DIALOG_ERROR=254
 declare -rigx DIALOG_ESC=255
 declare -ragx DIALOG_BUTTONS=(
@@ -28,13 +31,24 @@ declare -ragx DIALOG_BUTTONS=(
 	[DIALOG_HELP]="HELP"
 	[DIALOG_EXTRA]="EXTRA"
 	[DIALOG_ITEM_HELP]="ITEM_HELP"
+	[DIALOG_EXIT]="EXIT"
 	[DIALOG_ERROR]="ERROR"
 	[DIALOG_ESC]="ESC"
 )
 
+declare -agx WHIPTAIL_OPTIONS=''
+
 declare -gx BACKTITLE=''
 
 declare -igx LINES COLUMNS
+
+use_dialog() {
+	[[ ${D["ui.display_engine"]-} == dialog && -n ${DIALOG-} ]]
+}
+
+use_whiptail() {
+	[[ ${D["ui.display_engine"]-} == whiptail && -n ${WHIPTAIL-} ]]
+}
 
 set_screen_size() {
 	if [[ -z ${D["_defined_"]-} ]]; then
@@ -44,7 +58,7 @@ set_screen_size() {
 	LINES=$(tput lines)
 }
 
-_dialog_backtitle_() {
+_tui_backtitle_() {
 	local LeftHeading CenterHeading RightHeading
 
 	local LeftHeading="{{|Hostname|}}${HOSTNAME}{{[-]}}"
@@ -127,15 +141,18 @@ _dialog_backtitle_() {
 		RightPadding=0
 	fi
 
-	BACKTITLE="$(
-		printf "%s%*s%s%*s%s" \
-			"${LeftHeading}" \
-			"${LeftPadding}" " " \
-			"${CenterHeading}" \
-			"${RightPadding}" " " \
-			"${RightHeading}"
-	)"
-	resolve_styles_into BACKTITLE DC "${BACKTITLE}"
+	printf -v BACKTITLE "%s%*s%s%*s%s" \
+		"${LeftHeading}" \
+		"${LeftPadding}" " " "${CenterHeading}" "${RightPadding}" " " \
+		"${RightHeading}"
+
+	if use_dialog; then
+		# Using dialog, resolve styles to dialog codes
+		resolve_styles_into BACKTITLE DC "${BACKTITLE}"
+	else
+		# Using whiptail, strip styles
+		strip_styles_into BACKTITLE "${BACKTITLE}"
+	fi
 }
 
 _dialog_() {
@@ -145,23 +162,35 @@ _dialog_() {
 		resolve_styles_into _rsi_opt_ DC "${Option}"
 		DialogOptions+=("${_rsi_opt_}")
 	done
-	_dialog_backtitle_
+
+	_tui_backtitle_
 	${DIALOG} --file "${DIALOG_OPTIONS_FILE}" --backtitle "${BACKTITLE}" "${DialogOptions[@]}"
+}
+_whiptail_() {
+	local -a WhiptailOptions=()
+	local Option _ssi_opt_
+	for Option in "$@"; do
+		strip_styles_into _ssi_opt_ "${Option}"
+		WhiptailOptions+=("${_ssi_opt_}")
+	done
+
+	_tui_backtitle_
+	${WHIPTAIL} "${WHIPTAIL_OPTIONS[@]}" --backtitle "${BACKTITLE}" "${WhiptailOptions[@]}" 3>&1 1>&2 2>&3
 }
 
 # Check to see if we are already inside a dialog box
-in_dialog_box() {
+in_tui_box() {
 	# If we are in GUI mode, AND stdout is redirected, AND stderr is ALSO redirected
-	# then we are almost certainly inside a '|& dialog_pipe' call.
+	# then we are almost certainly inside a '|& tui_pipe' call.
 	[[ ${PROMPT:-CLI} == GUI && ! -t 1 && ! -t 2 ]]
 }
 
 # Check to see if we should use a dialog box
-use_dialog_box() {
+use_tui_box() {
 	[[ ${PROMPT:-CLI} != GUI ]] && return 1
 
 	# TRUE if Ready to start OR already inside one
-	if in_dialog_box || [[ -t 1 && -t 2 ]]; then
+	if in_tui_box || [[ -t 1 && -t 2 ]]; then
 		return 0
 	fi
 	return 1
@@ -182,15 +211,53 @@ dialog_pipe() {
 	echo -n "${S["BS"]}" >&2
 	return ${result}
 }
-# Script Dialog Runner Function
-run_script_dialog() {
+whiptail_pipe() {
+	if [[ -t 1 ]]; then
+		cat
+	else
+		cat > /dev/tty
+	fi
+}
+tui_pipe() {
+	if use_dialog; then
+		dialog_pipe "$@"
+	else
+		whiptail_pipe "$@"
+	fi
+}
+
+tui_pipe_open() {
+	local -n _tpo_fd_="${1}"
+	local -n _tpo_pid_="${2}"
+	local Title="${3:-}" SubTitle="${4:-}" TimeOut="${5:-0}"
+	if use_dialog && use_tui_box; then
+		coproc {
+			dialog_pipe "${Title}" "${SubTitle}" "${TimeOut}"
+		}
+		_tpo_fd_=${COPROC[1]}
+		_tpo_pid_=${COPROC_PID}
+	else
+		_tpo_fd_=1
+		_tpo_pid_=0
+	fi
+}
+tui_pipe_close() {
+	local -n _tpc_fd_="${1}"
+	local -n _tpc_pid_="${2}"
+	if [[ _tpc_fd_ -ne 1 ]]; then
+		local _tpc_fd_val_=${_tpc_fd_}
+		exec {_tpc_fd_val_}<&- &> /dev/null || true
+		wait "${_tpc_pid_}" &> /dev/null || true
+	fi
+}
+
+dialog_run_script() {
 	local Title=${1:-}
 	local SubTitle=${2:-}
 	local TimeOut=${3:-0}
 	local SCRIPTSNAME=${4-}
 	shift 4
-	if use_dialog_box && ! in_dialog_box; then
-		# Using the GUI, pipe output to a dialog box
+	if ! in_tui_box; then
 		coproc {
 			dialog_pipe "${Title}" "${SubTitle}" "${TimeOut}"
 		}
@@ -203,56 +270,128 @@ run_script_dialog() {
 		return ${result}
 	else
 		run_script "${SCRIPTSNAME}" "$@"
-		return
+	fi
+}
+whiptail_run_script() {
+	local Title=${1:-}
+	local SubTitle=${2:-}
+	local TimeOut=${3:-0}
+	local SCRIPTSNAME=${4-}
+	shift 4
+	run_script "${SCRIPTSNAME}" "$@"
+}
+run_script_tui() {
+	if use_dialog && use_tui_box; then
+		dialog_run_script "$@"
+	else
+		whiptail_run_script "$@"
 	fi
 }
 
-# Command Dialog Runner Function
-run_command_dialog() {
+dialog_run_command() {
 	local Title=${1:-}
 	local SubTitle=${2:-}
 	local TimeOut=${3:-0}
 	local CommandName=${4-}
 	shift 4
 	if [[ -n ${CommandName-} ]]; then
-		if use_dialog_box; then
-			# Using the GUI, pipe output to a dialog box
-			"${CommandName}" "$@" |& dialog_pipe "${Title}" "${SubTitle}" "${TimeOut}"
-			return "${PIPESTATUS[0]}"
-		else
-			"${CommandName}" "$@"
-			return
-		fi
+		"${CommandName}" "$@" |& dialog_pipe "${Title}" "${SubTitle}" "${TimeOut}"
+		return "${PIPESTATUS[0]}"
+	fi
+}
+whiptail_run_command() {
+	local Title=${1:-}
+	local SubTitle=${2:-}
+	local TimeOut=${3:-0}
+	local CommandName=${4-}
+	shift 4
+	if [[ -n ${CommandName-} ]]; then
+		"${CommandName}" "$@"
+	fi
+}
+run_command_tui() {
+	if use_dialog && use_tui_box; then
+		dialog_run_command "$@"
+	else
+		whiptail_run_command "$@"
 	fi
 }
 
-# _parse_dialog_options_ DialogOptionsRef MaximizedRef CountRef "$@"
+# _dialog_parse_options_ DialogOptionsRef MaximizedRef CountRef "$@"
 # Parses common --option[:value] flags from positional params into a DialogOptions array.
 # Uses namerefs to modify the caller's DialogOptions and Maximized variables directly.
 # Saves the count of consumed positional args to CountRef — caller must: shift "${CountRef}"
-_parse_dialog_options_() {
-	local -n _pdo_opts_="${1}"
-	local -n _pdo_max_="${2}"
-	local -n _pdo_cnt_="${3}"
-	_pdo_max_=0
-	_pdo_cnt_=0
+# Sets _DIALOG_EXIT_BUTTON_ to 1 if --exit-button was present (caller must remap return codes).
+_dialog_parse_options_() {
+	local -n _dpo_opts_="${1}"
+	local -n _dpo_max_="${2}"
+	local -n _dpo_cnt_="${3}"
+	_dpo_max_=0
+	_dpo_cnt_=0
+	_DIALOG_EXIT_BUTTON_=0
+	local _dpo_exit_btn_=0
+	local _dpo_cancel_label_=""
 	shift 3
 	while [[ ${1-} == --* ]]; do
 		case "${1}" in
-			--maximized) _pdo_max_=1 ;;
-			--timeout:*) _pdo_opts_+=("--timeout" "${1#*:}") ;;
-			--extra-label:*) _pdo_opts_+=("--extra-button" "--extra-label" "${1#*:}") ;;
-			--help-label:*) _pdo_opts_+=("--help-button" "--help-label" "${1#*:}") ;;
-			--ok-label:* | --yes-label:* | --no-label:* | --cancel-label:* | --exit-label:*)
-				_pdo_opts_+=("${1%:*}" "${1#*:}")
+			--maximized) _dpo_max_=1 ;;
+			--timeout:*) _dpo_opts_+=("--timeout" "${1#*:}") ;;
+			--exit-button) _dpo_exit_btn_=1 ;;
+			--extra-label:*) _dpo_opts_+=("--extra-button" "--extra-label" "${1#*:}") ;;
+			--help-label:*) _dpo_opts_+=("--help-button" "--help-label" "${1#*:}") ;;
+			--cancel-label:*) _dpo_cancel_label_="${1#*:}" ;;
+			--ok-label:* | --yes-label:* | --no-label:* | --exit-label:*)
+				_dpo_opts_+=("${1%:*}" "${1#*:}")
 				;;
-			--default-item:*) _pdo_opts_+=("--default-item" "${1#*:}") ;;
-			--item-help) _pdo_opts_+=("${1}") ;;
-			--*) _pdo_opts_+=("${1}") ;;
+			--default-item:*) _dpo_opts_+=("--default-item" "${1#*:}") ;;
+			--item-help) _dpo_opts_+=("${1}") ;;
+			--*) _dpo_opts_+=("${1}") ;;
 			*) break ;;
 		esac
 		shift
-		((_pdo_cnt_++))
+		((_dpo_cnt_++))
+	done
+	if [[ _dpo_exit_btn_ -eq 1 ]]; then
+		_DIALOG_EXIT_BUTTON_=1
+		_dpo_opts_+=("--extra-button" "--extra-label" "${_dpo_cancel_label_:-Cancel}" "--cancel-label" "Exit")
+	elif [[ -n ${_dpo_cancel_label_} ]]; then
+		_dpo_opts_+=("--cancel-label" "${_dpo_cancel_label_}")
+	fi
+}
+
+# _whiptail_parse_options_ WhiptailOptionsRef MaximizedRef CountRef "$@"
+# Parses common --option[:value] flags from positional params into a WhiptailOptions array.
+# Uses namerefs to modify the caller's WhiptailOptions and Maximized variables directly.
+# Saves the count of consumed positional args to CountRef — caller must: shift "${CountRef}"
+_whiptail_parse_options_() {
+	local -n _wpo_opts_="${1}"
+	local -n _wpo_max_="${2}"
+	local -n _wpo_cnt_="${3}"
+	_wpo_max_=0
+	_wpo_cnt_=0
+	shift 3
+	while [[ ${1-} == --* ]]; do
+		case "${1}" in
+			--maximized) _wpo_max_=1 ;;
+			--timeout:*) ;;     # ignore
+			--exit-button) ;;   # ignore — whiptail shows default OK + Cancel
+			--extra-button) ;;  # ignore — no third button in whiptail
+			--extra-label:*) ;; # ignore
+			--help-label:*) ;;  # ignore
+			--no-collapse) ;;   # ignore — dialog-only
+			--no-hot-list) ;;   # ignore — dialog-only
+			--ok-label:*) _wpo_opts_+=("--ok-button" "${1#*:}") ;;
+			--yes-label:*) _wpo_opts_+=("--yes-button" "${1#*:}") ;;
+			--no-label:*) _wpo_opts_+=("--no-button" "${1#*:}") ;;
+			--cancel-label:*) _wpo_opts_+=("--cancel-button" "${1#*:}") ;;
+			--exit-label:*) ;; # ignore
+			--default-item:*) _wpo_opts_+=("--default-item" "${1#*:}") ;;
+			--item-help) _wpo_opts_+=("${1}") ;;
+			--*) _wpo_opts_+=("${1}") ;;
+			*) break ;;
+		esac
+		shift
+		((_wpo_cnt_++))
 	done
 }
 
@@ -288,10 +427,43 @@ _dialog_calc_list_width_() {
 	[[ ${_dclw_req_} -ge ${_dclw_wmax_} ]] && _dclw_w_=${_dclw_wmax_} || _dclw_w_=0
 }
 
+# _whiptail_calc_list_width_ WindowWidthRef Title SubTitle FieldsPerItem Items...
+# Computes WindowWidth for non-maximized list dialogs based on content.
+# Sets width to wmax if content overflows, 0 (auto) otherwise.
+_whiptail_calc_list_width_() {
+	local -n _dclw_w_="${1}"
+	local _dclw_title_="${2}"
+	local _dclw_sub_="${3}"
+	local -i _dclw_fpi_="${4}"
+	shift 4
+	_dclw_w_=0
+}
+
 # _dialog_calc_text_size_ WindowHeightRef WindowWidthRef Message Title Maximized
 # Computes WindowHeight and WindowWidth for text-based dialogs (msgbox, inputbox, form, yesno).
 # Uses namerefs to set the caller's WindowHeight and WindowWidth variables directly.
 _dialog_calc_text_size_() {
+	local -n _dcts_h_="${1}"
+	local -n _dcts_w_="${2}"
+	local _dcts_msg_="${3}"
+	local _dcts_title_="${4}"
+	local -i _dcts_max_="${5:-0}"
+	set_screen_size
+	local -i _dcts_hmax_=$((LINES - D["WindowRowsAdjust"]))
+	local -i _dcts_wmax_=$((COLUMNS - D["WindowColsAdjust"]))
+	if [[ ${_dcts_max_} -eq 1 ]]; then
+		_dcts_h_=${_dcts_hmax_}
+		_dcts_w_=${_dcts_wmax_}
+	else
+		_dcts_h_=0
+		_dcts_w_=0
+	fi
+}
+
+# _whiptail_calc_text_size_ WindowHeightRef WindowWidthRef Message Title Maximized
+# Computes WindowHeight and WindowWidth for text-based dialogs (msgbox, inputbox, form, yesno).
+# Uses namerefs to set the caller's WindowHeight and WindowWidth variables directly.
+_whiptail_calc_text_size_() {
 	local -n _dcts_h_="${1}"
 	local -n _dcts_w_="${2}"
 	local _dcts_msg_="${3}"
@@ -348,6 +520,35 @@ _dialog_calc_list_size_() {
 	fi
 }
 
+# _whiptail_calc_list_size_ WindowHeightRef WindowWidthRef MenuHeightRef SubTitle Maximized ItemCount
+# Computes WindowHeight, WindowWidth, and MenuHeight for list-based dialogs (menu, checklist, radiolist, inputmenu).
+# Uses namerefs to set the caller's WindowHeight, WindowWidth, and MenuHeight variables directly.
+_whiptail_calc_list_size_() {
+	local -n _dcls_h_="${1}"
+	local -n _dcls_w_="${2}"
+	local -n _dcls_m_="${3}"
+	#local _dcls_sub_="${4}"
+	#local -i _dcls_max_="${5:-0}"
+	_dcls_h_=0
+	_dcls_w_=0
+	_dcls_m_=0
+}
+
+# _strip_helptext_in_place_ <ArrayName> [<Interval>]
+# Removes every Nth element from an array, starting from the Nth element.
+_strip_helptext_in_place_() {
+	local -n _shtip_ref_arr=${1}
+	local -i Interval=${2:-3}
+
+	[[ ${#_shtip_ref_arr[@]} -eq 0 ]] && return 0
+
+	local -i ArraySize=${#_shtip_ref_arr[@]}
+	for ((i = Interval - 1; i < ArraySize; i += Interval)); do
+		unset "_shtip_ref_arr[$i]"
+	done
+	_shtip_ref_arr=("${_shtip_ref_arr[@]}")
+}
+
 dialog_info() {
 	local Title="${1-}"
 	shift || true
@@ -355,32 +556,58 @@ dialog_info() {
 	shift || true
 	local -a DialogOptions=()
 	local -i Maximized=0 _n_=0
-	_parse_dialog_options_ DialogOptions Maximized _n_ "$@"
+	local BoxType="--infobox"
+
+	_dialog_parse_options_ DialogOptions Maximized _n_ "$@"
 	shift "${_n_}"
 	local -i result=0
-	_dialog_ "${DialogOptions[@]}" --infobox "${Message}" 0 0 || result=$?
+	_dialog_ "${DialogOptions[@]}" "${BoxType}" "${Message}" 0 0 || result=$?
 	echo -n "${S["BS"]}" >&2
 	return ${result}
 }
-
-dialog_message() {
+whiptail_info() {
 	local Title="${1-}"
 	shift || true
 	local Message="${1-}"
 	shift || true
-	dialog_msgbox "${Title}" "${Message}" "$@"
+	local -a WhiptailOptions=()
+	local -i Maximized=0 _n_=0
+	local BoxType="--infobox"
+
+	_whiptail_parse_options_ WhiptailOptions Maximized _n_ "$@"
+	shift "${_n_}"
+	[[ -n ${Title} ]] && WhiptailOptions+=(--title "${Title}")
+	local -i result=0
+	_whiptail_ "${WhiptailOptions[@]}" "${BoxType}" "${Message}" 0 0 || result=$?
+	echo -n "${S["BS"]}" >&2
+	return ${result}
+}
+tui_info() {
+	if use_dialog; then
+		dialog_info "$@"
+	else
+		whiptail_info "$@"
+	fi
 }
 
-dialog_error() {
-	dialog_message "{{|TitleError|}}${1-}" "${2-}" "--maximized"
+tui_message() {
+	local Title="${1-}"
+	shift || true
+	local Message="${1-}"
+	shift || true
+	tui_msgbox "${Title}" "${Message}" "$@"
 }
 
-dialog_warning() {
-	dialog_message "{{|TitleWarning|}}${1-}" "${2-}" "--maximized"
+tui_error() {
+	tui_msgbox "{{|TitleError|}}${1-}" "${2-}" "--maximized"
 }
 
-dialog_success() {
-	dialog_message "{{|TitleSuccess|}}${1-}" "${2-}" "--maximized"
+tui_warning() {
+	tui_message "{{|TitleWarning|}}${1-}" "${2-}" "--maximized"
+}
+
+tui_success() {
+	tui_message "{{|TitleSuccess|}}${1-}" "${2-}" "--maximized"
 }
 
 dialog_yesno() {
@@ -393,10 +620,9 @@ dialog_yesno() {
 	local BoxType="--yesno"
 
 	local -i _n_=0
-	_parse_dialog_options_ DialogOptions Maximized _n_ "$@"
+	_dialog_parse_options_ DialogOptions Maximized _n_ "$@"
 	shift "${_n_}"
 
-	DialogOptions+=(--output-fd 1)
 	[[ -n ${Title} ]] && DialogOptions+=(--title "{{|TitleQuestion|}}${Title}")
 
 	local -i WindowHeight=0 WindowWidth=0
@@ -407,6 +633,36 @@ dialog_yesno() {
 	echo -n "${S["BS"]}" >&2
 	return ${result}
 }
+whiptail_yesno() {
+	local Title="${1-}"
+	shift || true
+	local Message="${1-}"
+	shift || true
+	local -a WhiptailOptions=()
+	local -i Maximized=0
+	local BoxType="--yesno"
+
+	local -i _n_=0
+	_whiptail_parse_options_ WhiptailOptions Maximized _n_ "$@"
+	shift "${_n_}"
+
+	[[ -n ${Title} ]] && WhiptailOptions+=(--title "${Title}")
+
+	local -i WindowHeight=0 WindowWidth=0
+	_whiptail_calc_text_size_ WindowHeight WindowWidth "${Message}" "${Title}" "${Maximized}"
+
+	local -i result=0
+	_whiptail_ "${WhiptailOptions[@]}" "${BoxType}" "${Message}" "${WindowHeight}" "${WindowWidth}" "$@" || result=$?
+	echo -n "${S["BS"]}" >&2
+	return ${result}
+}
+tui_yesno() {
+	if use_dialog; then
+		dialog_yesno "$@"
+	else
+		whiptail_yesno "$@"
+	fi
+}
 
 dialog_msgbox() {
 	local Title="${1-}"
@@ -415,21 +671,51 @@ dialog_msgbox() {
 	shift || true
 	local -a DialogOptions=()
 	local -i Maximized=0
+	local BoxType="--msgbox"
 
 	local -i _n_=0
-	_parse_dialog_options_ DialogOptions Maximized _n_ "$@"
+	_dialog_parse_options_ DialogOptions Maximized _n_ "$@"
 	shift "${_n_}"
 
-	DialogOptions+=(--output-fd 1)
 	[[ -n ${Title} ]] && DialogOptions+=(--title "{{|Title|}}${Title}")
 
 	local -i WindowHeight=0 WindowWidth=0
 	_dialog_calc_text_size_ WindowHeight WindowWidth "${Message}" "${Title}" "${Maximized}"
 
 	local -i result=0
-	_dialog_ "${DialogOptions[@]}" --msgbox "${Message}" "${WindowHeight}" "${WindowWidth}" "$@" || result=$?
+	_dialog_ "${DialogOptions[@]}" "${BoxType}" "${Message}" "${WindowHeight}" "${WindowWidth}" "$@" || result=$?
 	echo -n "${S["BS"]}" >&2
 	return ${result}
+}
+whiptail_msgbox() {
+	local Title="${1-}"
+	shift || true
+	local Message="${1-}"
+	shift || true
+	local -a WhiptailOptions=()
+	local -i Maximized=0
+	local BoxType="--msgbox"
+
+	local -i _n_=0
+	_whiptail_parse_options_ WhiptailOptions Maximized _n_ "$@"
+	shift "${_n_}"
+
+	[[ -n ${Title} ]] && WhiptailOptions+=(--title "${Title}")
+
+	local -i WindowHeight=0 WindowWidth=0
+	_whiptail_calc_text_size_ WindowHeight WindowWidth "${Message}" "${Title}" "${Maximized}"
+
+	local -i result=0
+	_whiptail_ "${WhiptailOptions[@]}" "${BoxType}" "${Message}" "${WindowHeight}" "${WindowWidth}" "$@" || result=$?
+	echo -n "${S["BS"]}" >&2
+	return ${result}
+}
+tui_msgbox() {
+	if use_dialog; then
+		dialog_msgbox "$@"
+	else
+		whiptail_msgbox "$@"
+	fi
 }
 
 dialog_inputbox() {
@@ -441,10 +727,9 @@ dialog_inputbox() {
 	local -i Maximized=0
 
 	local -i _n_=0
-	_parse_dialog_options_ DialogOptions Maximized _n_ "$@"
+	_dialog_parse_options_ DialogOptions Maximized _n_ "$@"
 	shift "${_n_}"
 
-	DialogOptions+=(--output-fd 1)
 	[[ -n ${Title} ]] && DialogOptions+=(--title "{{|Title|}}${Title}")
 
 	local -i WindowHeight=0 WindowWidth=0
@@ -454,6 +739,35 @@ dialog_inputbox() {
 	_dialog_ "${DialogOptions[@]}" --inputbox "${Message}" "${WindowHeight}" "${WindowWidth}" "$@" || result=$?
 	echo -n "${S["BS"]}" >&2
 	return ${result}
+}
+whiptail_inputbox() {
+	local Title="${1-}"
+	shift || true
+	local Message="${1-}"
+	shift || true
+	local -a DialogOptions=()
+	local -i Maximized=0
+
+	local -i _n_=0
+	_whiptail_parse_options_ WhiptailOptions Maximized _n_ "$@"
+	shift "${_n_}"
+
+	[[ -n ${Title} ]] && WhiptailOptions+=(--title "${Title}")
+
+	local -i WindowHeight=0 WindowWidth=0
+	_whiptail_calc_text_size_ WindowHeight WindowWidth "${Message}" "${Title}" "${Maximized}"
+
+	local -i result=0
+	_whiptail_ "${WhiptailOptions[@]}" --inputbox "${Message}" "${WindowHeight}" "${WindowWidth}" "$@" || result=$?
+	echo -n "${S["BS"]}" >&2
+	return ${result}
+}
+tui_inputbox() {
+	if use_dialog; then
+		dialog_inputbox "$@"
+	else
+		whiptail_inputbox "$@"
+	fi
 }
 
 dialog_form() {
@@ -465,10 +779,10 @@ dialog_form() {
 	local -i Maximized=0
 
 	local -i _n_=0
-	_parse_dialog_options_ DialogOptions Maximized _n_ "$@"
+	local -i _DIALOG_EXIT_BUTTON_=0
+	_dialog_parse_options_ DialogOptions Maximized _n_ "$@"
 	shift "${_n_}"
 
-	DialogOptions+=(--output-fd 1)
 	[[ -n ${Title} ]] && DialogOptions+=(--title "{{|Title|}}${Title}")
 
 	local -i WindowHeight=0 WindowWidth=0
@@ -478,7 +792,39 @@ dialog_form() {
 	# form_height=0 (auto-size) is always appended before the field definitions in "$@"
 	_dialog_ "${DialogOptions[@]}" --form "${Message}" "${WindowHeight}" "${WindowWidth}" 0 "$@" || result=$?
 	echo -n "${S["BS"]}" >&2
+	[[ _DIALOG_EXIT_BUTTON_ -eq 1 && result -eq DIALOG_CANCEL ]] && return ${DIALOG_EXIT}
+	[[ _DIALOG_EXIT_BUTTON_ -eq 1 && result -eq DIALOG_EXTRA ]] && return ${DIALOG_CANCEL}
 	return ${result}
+}
+whiptail_form() {
+	local Title="${1-}"
+	shift || true
+	local Message="${1-}"
+	shift || true
+	local -a WhiptailOptions=()
+	local -i Maximized=0
+
+	local -i _n_=0
+	_whiptail_parse_options_ WhiptailOptions Maximized _n_ "$@"
+	shift "${_n_}"
+
+	[[ -n ${Title} ]] && WhiptailOptions+=(--title "${Title}")
+
+	local -i WindowHeight=0 WindowWidth=0
+	_whiptail_calc_text_size_ WindowHeight WindowWidth "${Message}" "${Title}" "${Maximized}"
+
+	local -i result=0
+	# form_height=0 (auto-size) is always appended before the field definitions in "$@"
+	_whiptail_ "${WhiptailOptions[@]}" --form "${Message}" "${WindowHeight}" "${WindowWidth}" 0 "$@" || result=$?
+	echo -n "${S["BS"]}" >&2
+	return ${result}
+}
+tui_form() {
+	if use_dialog; then
+		dialog_form "$@"
+	else
+		whiptail_form "$@"
+	fi
 }
 
 dialog_menu() {
@@ -490,11 +836,11 @@ dialog_menu() {
 	local -i Maximized=0
 
 	local -i _n_=0
-	_parse_dialog_options_ DialogOptions Maximized _n_ "$@"
+	local -i _DIALOG_EXIT_BUTTON_=0
+	_dialog_parse_options_ DialogOptions Maximized _n_ "$@"
 	shift "${_n_}"
 	local -a Items=("$@")
 
-	DialogOptions+=(--output-fd 1)
 	[[ -n ${Title} ]] && DialogOptions+=(--title "{{|Title|}}${Title}")
 
 	local -i FieldsPerItem=2
@@ -513,7 +859,57 @@ dialog_menu() {
 	local -i result=0
 	_dialog_ "${DialogOptions[@]}" --menu "${StyledSubTitle}" "${WindowHeight}" "${WindowWidth}" "${MenuHeight}" "${Items[@]}" || result=$?
 	echo -n "${S["BS"]}" >&2
+	[[ _DIALOG_EXIT_BUTTON_ -eq 1 && result -eq DIALOG_CANCEL ]] && return ${DIALOG_EXIT}
+	[[ _DIALOG_EXIT_BUTTON_ -eq 1 && result -eq DIALOG_EXTRA ]] && return ${DIALOG_CANCEL}
 	return ${result}
+}
+
+whiptail_menu() {
+	local Title="${1-}"
+	shift || true
+	local SubTitle="${1-}"
+	shift || true
+	local -a WhiptailOptions=()
+	local -i Maximized=0
+
+	local -i _n_=0
+	_whiptail_parse_options_ WhiptailOptions Maximized _n_ "$@"
+	shift "${_n_}"
+	local -a Items=("$@")
+
+	[[ -n ${Title} ]] && WhiptailOptions+=(--title "${Title}")
+
+	local -i FieldsPerItem=2
+	local Option
+	local -a FilteredOptions=()
+	for Option in "${WhiptailOptions[@]}"; do
+		if [[ ${Option} == "--item-help" ]]; then
+			FieldsPerItem=3
+		else
+			FilteredOptions+=("${Option}")
+		fi
+	done
+	WhiptailOptions=("${FilteredOptions[@]}")
+	local -i ItemCount=$((${#Items[@]} / FieldsPerItem))
+	if [[ FieldsPerItem -eq 3 ]]; then
+		_strip_helptext_in_place_ Items 3
+		FieldsPerItem=2
+	fi
+	local -i WindowHeight=0 WindowWidth=0 MenuHeight=0
+	_whiptail_calc_list_size_ WindowHeight WindowWidth MenuHeight "${SubTitle}" "${Maximized}" "${ItemCount}"
+	[[ ${Maximized} -eq 0 ]] && _whiptail_calc_list_width_ WindowWidth "${Title}" "${SubTitle}" "${FieldsPerItem}" "${Items[@]}"
+
+	local -i result=0
+	_whiptail_ "${WhiptailOptions[@]}" --menu "${SubTitle}" "${WindowHeight}" "${WindowWidth}" "${MenuHeight}" "${Items[@]}" || result=$?
+	echo -n "${S["BS"]}" >&2
+	return ${result}
+}
+tui_menu() {
+	if use_dialog; then
+		dialog_menu "$@"
+	else
+		whiptail_menu "$@"
+	fi
 }
 
 dialog_checklist() {
@@ -525,11 +921,11 @@ dialog_checklist() {
 	local -i Maximized=0
 
 	local -i _n_=0
-	_parse_dialog_options_ DialogOptions Maximized _n_ "$@"
+	local -i _DIALOG_EXIT_BUTTON_=0
+	_dialog_parse_options_ DialogOptions Maximized _n_ "$@"
 	shift "${_n_}"
 	local -a Items=("$@")
 
-	DialogOptions+=(--output-fd 1)
 	[[ -n ${Title} ]] && DialogOptions+=(--title "{{|Title|}}${Title}")
 
 	local -i FieldsPerItem=3
@@ -548,7 +944,56 @@ dialog_checklist() {
 	local -i result=0
 	_dialog_ "${DialogOptions[@]}" --checklist "${StyledSubTitle}" "${WindowHeight}" "${WindowWidth}" "${MenuHeight}" "${Items[@]}" || result=$?
 	echo -n "${S["BS"]}" >&2
+	[[ _DIALOG_EXIT_BUTTON_ -eq 1 && result -eq DIALOG_CANCEL ]] && return ${DIALOG_EXIT}
+	[[ _DIALOG_EXIT_BUTTON_ -eq 1 && result -eq DIALOG_EXTRA ]] && return ${DIALOG_CANCEL}
 	return ${result}
+}
+whiptail_checklist() {
+	local Title="${1-}"
+	shift || true
+	local SubTitle="${1-}"
+	shift || true
+	local -a WhiptailOptions=()
+	local -i Maximized=0
+
+	local -i _n_=0
+	_whiptail_parse_options_ WhiptailOptions Maximized _n_ "$@"
+	shift "${_n_}"
+	local -a Items=("$@")
+
+	[[ -n ${Title} ]] && WhiptailOptions+=(--title "${Title}")
+
+	local -i FieldsPerItem=3
+	local Option
+	local -a FilteredOptions=()
+	for Option in "${WhiptailOptions[@]}"; do
+		if [[ ${Option} == "--item-help" ]]; then
+			FieldsPerItem=4
+		else
+			FilteredOptions+=("${Option}")
+		fi
+	done
+	WhiptailOptions=("${FilteredOptions[@]}")
+	local -i ItemCount=$((${#Items[@]} / FieldsPerItem))
+	if [[ FieldsPerItem -eq 4 ]]; then
+		_strip_helptext_in_place_ Items 4
+		FieldsPerItem=3
+	fi
+	local -i WindowHeight=0 WindowWidth=0 MenuHeight=0
+	_whiptail_calc_list_size_ WindowHeight WindowWidth MenuHeight "${SubTitle}" "${Maximized}" "${ItemCount}"
+	[[ ${Maximized} -eq 0 ]] && _whiptail_calc_list_width_ WindowWidth "${Title}" "${SubTitle}" "${FieldsPerItem}" "${Items[@]}"
+
+	local -i result=0
+	_whiptail_ "${WhiptailOptions[@]}" --checklist "${SubTitle}" "${WindowHeight}" "${WindowWidth}" "${MenuHeight}" "${Items[@]}" || result=$?
+	echo -n "${S["BS"]}" >&2
+	return ${result}
+}
+tui_checklist() {
+	if use_dialog; then
+		dialog_checklist "$@"
+	else
+		whiptail_checklist "$@"
+	fi
 }
 
 dialog_radiolist() {
@@ -560,11 +1005,11 @@ dialog_radiolist() {
 	local -i Maximized=0
 
 	local -i _n_=0
-	_parse_dialog_options_ DialogOptions Maximized _n_ "$@"
+	local -i _DIALOG_EXIT_BUTTON_=0
+	_dialog_parse_options_ DialogOptions Maximized _n_ "$@"
 	shift "${_n_}"
 	local -a Items=("$@")
 
-	DialogOptions+=(--output-fd 1)
 	[[ -n ${Title} ]] && DialogOptions+=(--title "{{|Title|}}${Title}")
 
 	local -i FieldsPerItem=3
@@ -583,7 +1028,56 @@ dialog_radiolist() {
 	local -i result=0
 	_dialog_ "${DialogOptions[@]}" --radiolist "${StyledSubTitle}" "${WindowHeight}" "${WindowWidth}" "${MenuHeight}" "${Items[@]}" || result=$?
 	echo -n "${S["BS"]}" >&2
+	[[ _DIALOG_EXIT_BUTTON_ -eq 1 && result -eq DIALOG_CANCEL ]] && return ${DIALOG_EXIT}
+	[[ _DIALOG_EXIT_BUTTON_ -eq 1 && result -eq DIALOG_EXTRA ]] && return ${DIALOG_CANCEL}
 	return ${result}
+}
+whiptail_radiolist() {
+	local Title="${1-}"
+	shift || true
+	local SubTitle="${1-}"
+	shift || true
+	local -a WhiptailOptions=()
+	local -i Maximized=0
+
+	local -i _n_=0
+	_whiptail_parse_options_ WhiptailOptions Maximized _n_ "$@"
+	shift "${_n_}"
+	local -a Items=("$@")
+
+	[[ -n ${Title} ]] && WhiptailOptions+=(--title "${Title}")
+
+	local -i FieldsPerItem=3
+	local Option
+	local -a FilteredOptions=()
+	for Option in "${WhiptailOptions[@]}"; do
+		if [[ ${Option} == "--item-help" ]]; then
+			FieldsPerItem=4
+		else
+			FilteredOptions+=("${Option}")
+		fi
+	done
+	WhiptailOptions=("${FilteredOptions[@]}")
+	local -i ItemCount=$((${#Items[@]} / FieldsPerItem))
+	if [[ FieldsPerItem -eq 4 ]]; then
+		_strip_helptext_in_place_ Items 4
+		FieldsPerItem=3
+	fi
+	local -i WindowHeight=0 WindowWidth=0 MenuHeight=0
+	_whiptail_calc_list_size_ WindowHeight WindowWidth MenuHeight "${SubTitle}" "${Maximized}" "${ItemCount}"
+	[[ ${Maximized} -eq 0 ]] && _whiptail_calc_list_width_ WindowWidth "${Title}" "${SubTitle}" "${FieldsPerItem}" "${Items[@]}"
+
+	local -i result=0
+	_whiptail_ "${WhiptailOptions[@]}" --radiolist "${SubTitle}" "${WindowHeight}" "${WindowWidth}" "${MenuHeight}" "${Items[@]}" || result=$?
+	echo -n "${S["BS"]}" >&2
+	return ${result}
+}
+tui_radiolist() {
+	if use_dialog; then
+		dialog_radiolist "$@"
+	else
+		whiptail_radiolist "$@"
+	fi
 }
 
 dialog_inputmenu() {
@@ -595,11 +1089,10 @@ dialog_inputmenu() {
 	local -i Maximized=0
 
 	local -i _n_=0
-	_parse_dialog_options_ DialogOptions Maximized _n_ "$@"
+	_dialog_parse_options_ DialogOptions Maximized _n_ "$@"
 	shift "${_n_}"
 	local -a Items=("$@")
 
-	DialogOptions+=(--output-fd 1)
 	[[ -n ${Title} ]] && DialogOptions+=(--title "{{|Title|}}${Title}")
 
 	local -i FieldsPerItem=2
@@ -621,7 +1114,7 @@ dialog_inputmenu() {
 	return ${result}
 }
 
-invalid_dialog_button() {
+invalid_tui_button() {
 	local -i DialogButtonNumber=${1}
 	local -l NoticeType=${2:-fatal}
 	local DialogButton="${DIALOG_BUTTONS[DialogButtonNumber]-#${DialogButtonNumber}}"

--- a/includes/usage.sh
+++ b/includes/usage.sh
@@ -117,6 +117,13 @@ EOF
 	Generates the '{{|UsageFile|}}docker-compose.yml{{[-]}} file
 EOF
 			;;&
+		--config-display-engine | --display-engine | "")
+			Found=1
+			cat << EOF
+{{|UsageCommand|}}--config-display-engine{{[-]}} < {{|UsageOption|}}dialog{{[-]}} | {{|UsageOption|}}whiptail{{[-]}} >{{[-]}}
+	Select the display engine used for the TUI.
+EOF
+			;;&
 		--config-pm | --config-pm-auto | "")
 			Found=1
 			cat << EOF
@@ -477,6 +484,8 @@ EOF
 	Load the specified page in the menu.
 {{|UsageCommand|}}-M --menu{{[-]}} < {{|UsageOption|}}options-display{{[-]}} | {{|UsageOption|}}display{{[-]}} >{{[-]}}
 	Load the {{|UsagePage|}}Display Options{{[-]}} page in the menu.
+{{|UsageCommand|}}-M --menu{{[-]}} < {{|UsageOption|}}options-display-engine{{[-]}} | {{|UsageOption|}}display-engine{{[-]}} >{{[-]}}
+	Load the {{|UsagePage|}}Display Engine{{[-]}} page in the menu.
 {{|UsageCommand|}}-M --menu{{[-]}} < {{|UsageOption|}}options-theme{{[-]}} | {{|UsageOption|}}theme{{[-]}} >{{[-]}}
 	Load the {{|UsagePage|}}Theme Chooser{{[-]}} page in the menu.
 {{|UsageCommand|}}-M --menu{{[-]}} < {{|UsageOption|}}config-app-select{{[-]}} | {{|UsageOption|}}app-select{{[-]}} | {{|UsageOption|}}select{{[-]}} >{{[-]}}

--- a/main.sh
+++ b/main.sh
@@ -814,7 +814,7 @@ if declare -F MigrateFilesAndFolders > /dev/null; then
 fi
 [[ -f "${SCRIPTPATH}/includes/pm_variables.sh" ]] && source "${SCRIPTPATH}/includes/pm_variables.sh"
 [[ -f "${SCRIPTPATH}/includes/run_script.sh" ]] && source "${SCRIPTPATH}/includes/run_script.sh"
-[[ -f "${SCRIPTPATH}/includes/dialog_functions.sh" ]] && source "${SCRIPTPATH}/includes/dialog_functions.sh"
+[[ -f "${SCRIPTPATH}/includes/tui_functions.sh" ]] && source "${SCRIPTPATH}/includes/tui_functions.sh"
 [[ -f "${SCRIPTPATH}/includes/ds_functions.sh" ]] && source "${SCRIPTPATH}/includes/ds_functions.sh"
 [[ -f "${SCRIPTPATH}/includes/test_functions.sh" ]] && source "${SCRIPTPATH}/includes/test_functions.sh"
 [[ -f "${SCRIPTPATH}/includes/usage.sh" ]] && source "${SCRIPTPATH}/includes/usage.sh"

--- a/scripts/apply_config.sh
+++ b/scripts/apply_config.sh
@@ -3,10 +3,7 @@ set -Eeuo pipefail
 IFS=$'\n\t'
 
 apply_config() {
-	if [[ ! -f ${APPLICATION_TOML_FILE} ]]; then
-		run_script 'config_create'
-		return
-	fi
+	run_script 'config_create'
 
 	#shellcheck disable=SC2034 # (warning): LITERAL_CONFIG_FOLDER appears unused. Verify use (or export if used externally).
 	run_script 'config_get_into' LITERAL_CONFIG_FOLDER paths.config_folder || true

--- a/scripts/appvars_purge.sh
+++ b/scripts/appvars_purge.sh
@@ -54,8 +54,8 @@ appvars_purge() {
 
 		if [[ -z ${GlobalVarsToRemove[*]-} && -z ${AppEnvVarsToRemove[*]-} ]]; then
 			local WarningText="'{{|Highlight|}}{{|App|}}${AppName}{{[-]}}{{[-]}}' has no variables to remove."
-			if use_dialog_box; then
-				dialog_warning "${Title}" "${WarningText}"
+			if use_tui_box; then
+				tui_warning "${Title}" "${WarningText}"
 				warn "${WarningText}" &> /dev/null
 			else
 				warn "${WarningText}"

--- a/scripts/config_create.sh
+++ b/scripts/config_create.sh
@@ -5,7 +5,19 @@ IFS=$'\n\t'
 config_create() {
 	# Early return if the TOML config already exists
 	if [[ -f ${APPLICATION_TOML_FILE} ]]; then
-		return 0
+		if run_script 'config_toml_key_exists' paths.compose_folder; then
+			return 0
+		fi
+		notice "Detected {{|ApplicationName|}}${APPLICATION_NAME}{{[-]}} config file with no compose folder defined. Detecting compose folder location."
+
+		detect_compose_folder
+		run_script 'apply_config'
+
+		notice ""
+		notice "$(run_script 'config_show')"
+		notice ""
+
+		return
 	fi
 
 	notice "No {{|ApplicationName|}}${APPLICATION_NAME}{{[-]}} config file detected. Performing initial configuration."
@@ -104,7 +116,10 @@ config_create() {
 detect_compose_folder() {
 	# Check for a legacy compose folder and update ComposeFolder if needed
 	local ConfigFolder
-	run_script 'config_get_into' ConfigFolder paths.config_folder || true
+	run_script 'config_get_into' ConfigFolder paths.config_folder ||
+		fatal \
+			"Failed to get config folder." \
+			"Failing command: {{|FailingCommand|}}run_script 'config_get_into' ConfigFolder paths.config_folder"
 
 	local -a ExpandVarList=(
 		ScriptFolder "${SCRIPTPATH}"
@@ -128,8 +143,8 @@ detect_compose_folder() {
 		LegacyHasFiles=true
 	fi
 
-	local DefaultComposeFolder
-	run_script 'config_get_into' DefaultComposeFolder paths.compose_folder || true
+	local DefaultComposeFolder=""
+	run_script 'config_get_into' DefaultComposeFolder paths.compose_folder "${DEFAULT_TOML_FILE}" || true
 	local ExpandedDefaultComposeFolder
 	ExpandedDefaultComposeFolder="$(expand_vars "${DefaultComposeFolder}" "${ExpandVarList[@]}")"
 
@@ -152,8 +167,14 @@ detect_compose_folder() {
 			run_script 'config_set' paths.compose_folder "${DefaultComposeFolder}"
 		fi
 	elif [[ ${LegacyHasFiles} == true ]]; then
-		notice "Detected compose folder at '{{|Folder|}}${ExpandedLegacyComposeFolder}{{[-]}}'."
+		notice "Detected compose folder at legacy location '{{|Folder|}}${ExpandedLegacyComposeFolder}{{[-]}}'."
 		run_script 'config_set' paths.compose_folder "${LegacyComposeFolder}"
+	elif [[ ${DefaultHasFiles} == true ]]; then
+		notice "Detected compose folder at default location '{{|Folder|}}${ExpandedDefaultComposeFolder}{{[-]}}'."
+		run_script 'config_set' paths.compose_folder "${DefaultComposeFolder}"
+	else
+		notice "No compose folder detected. Using default location '{{|Folder|}}${ExpandedDefaultComposeFolder}{{[-]}}'."
+		run_script 'config_set' paths.compose_folder "${DefaultComposeFolder}"
 	fi
 }
 

--- a/scripts/config_display_engine.sh
+++ b/scripts/config_display_engine.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+config_display_engine() {
+	local -l DisplayEngine=${1-dialog}
+
+	if [[ ! -f ${APPLICATION_TOML_FILE} ]]; then
+		run_script 'config_create'
+	fi
+
+	case "${DisplayEngine}" in
+		dialog | whiptail)
+			run_script 'config_set' ui.display_engine "${DisplayEngine}"
+			notice "Display engine set to '{{|UserCommand|}}${DisplayEngine}{{[-]}}'."
+			return 0
+			;;
+	esac
+
+	error \
+		"Selected display engine '{{|UserCommand|}}${DisplayEngine}{{[-]}}' unknown." \
+		"" \
+		"Known display engines are:" \
+		"\tdialog" \
+		"\twhiptail"
+	return 1
+}
+
+test_config_display_engine() {
+	warn "CI does not test config_display_engine."
+}

--- a/scripts/config_get_into.sh
+++ b/scripts/config_get_into.sh
@@ -17,6 +17,13 @@ config_get_into() {
 			if run_script 'config_toml_get_into' _cgi_val_ "${_cgi_section_key_}" "${_cgi_config_file_}"; then
 				_cgi_out_="${_cgi_val_}"
 				return 0
+			elif [[ ${_cgi_config_file_:-} == "${APPLICATION_TOML_FILE}" ]]; then
+				# Load default value if not found in main config file
+				if run_script 'config_toml_get_into' _cgi_val_ "${_cgi_section_key_}" "${DEFAULT_TOML_FILE}"; then
+					run_script 'config_toml_set' "${_cgi_section_key_}" "${_cgi_val_}" "${_cgi_config_file_}"
+					_cgi_out_="${_cgi_val_}"
+					return 0
+				fi
 			fi
 			;;
 		ini)

--- a/scripts/config_show.sh
+++ b/scripts/config_show.sh
@@ -11,22 +11,26 @@ config_show() {
 		"paths.config_folder"
 		"paths.compose_folder"
 		"pm.package_manager"
+		"ui.display_engine"
 		"ui.theme"
 		"ui.borders"
 		"ui.line_characters"
 		"ui.scrollbar"
 		"ui.shadow"
+		"ui.large_buttons"
 	)
 
 	local -A DisplayNames=(
 		["paths.config_folder"]="Config Folder"
 		["paths.compose_folder"]="Compose Folder"
 		["pm.package_manager"]="Package Manager"
+		["ui.display_engine"]="Display Engine"
 		["ui.theme"]="Theme"
 		["ui.borders"]="Borders"
 		["ui.line_characters"]="Line Characters"
 		["ui.scrollbar"]="Scrollbar"
 		["ui.shadow"]="Shadow"
+		["ui.large_buttons"]="Large Buttons"
 	)
 
 	local -a TableArray=()

--- a/scripts/config_theme.sh
+++ b/scripts/config_theme.sh
@@ -102,7 +102,6 @@ config_theme() {
 
 	declare -Agx DC=()
 	declare -Agx D=()
-
 	D+=(
 		["_defined_"]=1
 	)
@@ -136,40 +135,47 @@ config_theme() {
 
 	D["ThemeName"]="$(get_toml_val_string "${ThemeFile}" metadata.name)"
 	local DialogOptions="--colors --output-fd 1 --cr-wrap --no-collapse"
+	local -a WhiptailOptions=()
 
-	local LineCharacters Borders Scrollbar Shadow
-	run_script 'config_get_into' Borders ui.borders || true
-	run_script 'config_get_into' LineCharacters ui.line_characters || true
-	run_script 'config_get_into' Scrollbar ui.scrollbar || true
-	run_script 'config_get_into' Shadow ui.shadow || true
-
-	D+=(
-		["Borders"]="${Borders}"
-		["LineCharacters"]="${LineCharacters}"
-		["Scrollbar"]="${Scrollbar}"
-		["Shadow"]="${Shadow}"
+	local -a UIKeys=(
+		'ui.display_engine'
+		'ui.large_buttons'
+		'ui.line_characters'
+		'ui.borders'
+		'ui.scrollbar'
+		'ui.shadow'
 	)
+	for Key in "${UIKeys[@]}"; do
+		local value=''
+		run_script 'config_get_into' value "${Key}" || true
+		D["${Key}"]="${value}"
+	done
 
-	# Set the dialog options based on the settings in the .toml file
-	if is_true "${Borders}"; then
-		if is_false "${LineCharacters}"; then
+	if is_true "${D["ui.large_buttons"]}"; then
+		WhiptailOptions+=(--fullbuttons)
+	fi
+
+	if is_true "${D["ui.borders"]}"; then
+		if is_false "${D["ui.line_characters"]}"; then
 			DialogOptions+=" --ascii-lines"
 		fi
 	else
 		DialogOptions+=" --no-lines"
 	fi
-	if is_true "${Scrollbar}"; then
+	if is_true "${D["ui.scrollbar"]}"; then
 		DialogOptions+=" --scrollbar"
+		WhiptailOptions+=(--scrolltext)
 	else
 		DialogOptions+=" --no-scrollbar"
 	fi
-	if is_true "${Shadow}"; then
+	if is_true "${D["ui.shadow"]}"; then
 		DialogOptions+=" --shadow"
 		D["WindowColsAdjust"]=$((D["WindowColsAdjust"] + 2))
 		D["WindowRowsAdjust"]=$((D["WindowRowsAdjust"] + 1))
 	else
 		DialogOptions+=" --no-shadow"
 	fi
+	declare -agx WHIPTAIL_OPTIONS=("${WhiptailOptions[@]}")
 	RunAndLog "" "cp:info" \
 		fatal "Failed to save dialog options file." \
 		cp <(printf "%s" "${DialogOptions}") "${DIALOG_OPTIONS_FILE}"

--- a/scripts/config_toml_get_into.sh
+++ b/scripts/config_toml_get_into.sh
@@ -15,6 +15,7 @@ config_toml_get_into() {
 	fi
 
 	local -A _ctgi_Config_booleans_=(
+		["ui.large_buttons"]=1
 		["ui.borders"]=1
 		["ui.line_characters"]=1
 		["ui.scrollbar"]=1

--- a/scripts/config_toml_key_exists.sh
+++ b/scripts/config_toml_key_exists.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+config_toml_key_exists() {
+	# config_toml_key_exists section_key [config_file]
+	local _ctke_val_
+	run_script 'config_toml_get_into' _ctke_val_ "$@"
+}
+
+test_config_toml_key_exists() {
+	warn "CI does not test config_toml_key_exists."
+}

--- a/scripts/docker_compose.sh
+++ b/scripts/docker_compose.sh
@@ -129,34 +129,10 @@ docker_compose() {
 
 	local -i result=0
 	if run_script 'question_prompt' Y "${Question}" "${Title}" "${ASSUMEYES:+Y}"; then
-		if use_dialog_box; then
-			coproc {
-				dialog_pipe "{{|TitleSuccess|}}${Title}" "${YesNotice}{{[-]}}\n{{|CommandLine|}} ${APPLICATION_COMMAND} --compose ${ComposeInput}"
-			}
-			local -i DialogBox_PID=${COPROC_PID}
-			local -i DialogBox_FD="${COPROC[1]}"
-			{
-				[[ -n ${YesNotice-} ]] && notice "${YesNotice}"
-				run_script 'require_docker'
-				if run_script 'yml_merge'; then
-					for index in "${!ComposeCommand[@]}"; do
-						local -a Command=(
-							docker compose --project-directory "${COMPOSE_FOLDER}/"
-						)
-						local -a CommandArgs
-						IFS=' ' read -ra CommandArgs <<< "${ComposeCommand[index]}"
-						if ! RunAndLog notice "" error "Failed to run compose." "${Command[@]}" "${CommandArgs[@]}"; then
-							result=1
-							break
-						fi
-					done
-				else
-					result=1
-				fi
-			} >&${DialogBox_FD} 2>&1 || true
-			exec {DialogBox_FD}<&-
-			wait ${DialogBox_PID}
-		else
+		#shellcheck disable=SC2034 # (warning): PipePID is passed by name to tui_pipe_open/close via nameref and appears unused to shellcheck.
+		local -i PipeFD PipePID
+		tui_pipe_open PipeFD PipePID "{{|TitleSuccess|}}${Title}" "${YesNotice}{{[-]}}\n{{|CommandLine|}} ${APPLICATION_COMMAND} --compose ${ComposeInput}"
+		{
 			[[ -n ${YesNotice-} ]] && notice "${YesNotice}"
 			run_script 'require_docker'
 			if run_script 'yml_merge'; then
@@ -174,13 +150,14 @@ docker_compose() {
 			else
 				result=1
 			fi
-		fi
+		} >&${PipeFD} 2>&1 || true
+		tui_pipe_close PipeFD PipePID
 	else
-		if use_dialog_box; then
-			{ [[ -n ${NoNotice-} ]] && notice "${NoNotice}" || true; } |& dialog_pipe "{{|TitleError|}}${Title}" "${NoNotice}"
-		else
-			[[ -n ${NoNotice-} ]] && notice "${NoNotice}"
-		fi
+		#shellcheck disable=SC2034 # (warning): PipePID is passed by name to tui_pipe_open/close via nameref and appears unused to shellcheck.
+		local -i PipeFD PipePID
+		tui_pipe_open PipeFD PipePID "{{|TitleError|}}${Title}" "${NoNotice}"
+		{ [[ -n ${NoNotice-} ]] && notice "${NoNotice}" || true; } >&${PipeFD} 2>&1
+		tui_pipe_close PipeFD PipePID
 	fi
 	return ${result}
 }

--- a/scripts/docker_prune.sh
+++ b/scripts/docker_prune.sh
@@ -12,27 +12,24 @@ docker_prune() {
 	local CommandText
 	CommandText=$(printf "%q " "${Command[@]}" | xargs)
 	if run_script 'question_prompt' Y "${Question}" "${Title}" "${ASSUMEYES:+Y}"; then
-		if use_dialog_box; then
+		#shellcheck disable=SC2034 # (warning): PipePID is passed by name to tui_pipe_open/close via nameref and appears unused to shellcheck.
+		local -i PipeFD PipePID
+		tui_pipe_open PipeFD PipePID "{{|TitleSuccess|}}${Title}" "${YesNotice}{{[-]}}\n{{|CommandLine|}} ${CommandText}"
+		{
 			{
-				{
-					notice "${YesNotice}"
-					RunAndLog notice "docker:notice" \
-						error "Failed to remove unused docker resources." \
-						"${Command[@]}"
-				} || true
-			} |& dialog_pipe "{{|TitleSuccess|}}${Title}" "${YesNotice}{{[-]}}\n{{|CommandLine|}} ${CommandText}"
-		else
-			notice "${YesNotice}"
-			RunAndLog notice "docker:notice" \
-				error "Failed to remove unused docker resources." \
-				"${Command[@]}"
-		fi
+				notice "${YesNotice}"
+				RunAndLog notice "docker:notice" \
+					error "Failed to remove unused docker resources." \
+					"${Command[@]}"
+			} || true
+		} >&${PipeFD} 2>&1
+		tui_pipe_close PipeFD PipePID
 	else
-		if use_dialog_box; then
-			{ notice "${NoNotice}" || true; } |& dialog_pipe "{{|TitleError|}}${Title}" "${NoNotice}"
-		else
-			notice "${NoNotice}"
-		fi
+		#shellcheck disable=SC2034 # (warning): PipePID is passed by name to tui_pipe_open/close via nameref and appears unused to shellcheck.
+		local -i PipeFD PipePID
+		tui_pipe_open PipeFD PipePID "{{|TitleError|}}${Title}" "${NoNotice}"
+		{ notice "${NoNotice}" || true; } >&${PipeFD} 2>&1
+		tui_pipe_close PipeFD PipePID
 	fi
 }
 

--- a/scripts/get_docker.sh
+++ b/scripts/get_docker.sh
@@ -5,17 +5,16 @@ IFS=$'\n\t'
 get_docker() {
 	Title="Install Docker"
 	if [[ -n ${VERBOSE-} ]]; then
-		if use_dialog_box; then
+		#shellcheck disable=SC2034 # (warning): PipePID is passed by name to tui_pipe_open/close via nameref and appears unused to shellcheck.
+		local -i PipeFD PipePID
+		tui_pipe_open PipeFD PipePID "${Title}" "Installing docker. Please be patient, this can take a while."
+		{
 			{
-				{
-					notice "Installing docker. Please be patient, this can take a while."
-					command_get_docker
-				} || true
-			} |& dialog_pipe "${Title}" "Installing docker. Please be patient, this can take a while."
-		else
-			notice "Installing docker. Please be patient, this can take a while."
-			command_get_docker
-		fi
+				notice "Installing docker. Please be patient, this can take a while."
+				command_get_docker
+			} || true
+		} >&${PipeFD} 2>&1
+		tui_pipe_close PipeFD PipePID
 	else
 		notice "Installing docker. Please be patient, this can take a while."
 		command_get_docker &> /dev/null

--- a/scripts/menu_add_app.sh
+++ b/scripts/menu_add_app.sh
@@ -5,7 +5,6 @@ IFS=$'\n\t'
 menu_add_app() {
 	local Title="Add Application"
 
-	local AppNameMaxLength=256
 	local AppNameNone="{{|Highlight|}}[*NONE*]"
 
 	local AppName=""
@@ -19,23 +18,17 @@ menu_add_app() {
 		local Heading InputValueText
 		run_script 'menu_heading_into' Heading "${AppNameHeading}"
 		InputValueText="${Heading}\n\nWhat application would you like add?\n"
-		local ValueOptions
-		ValueOptions=(
-			"" 1 1
-			"${AppName}" 1 1
-			"${AppNameMaxLength}" "${AppNameMaxLength}"
-		)
 		local -a InputValueDialog=(
 			"${Title}"
 			"${InputValueText}"
 			--maximized
 			--ok-label:Select
-			"--extra-label:Back"
-			--cancel-label:Exit
-			"${ValueOptions[@]}"
+			--cancel-label:Back
+			--exit-button
+			"${AppName}"
 		)
 		local InputValueDialogButtonPressed=0
-		AppName=$(dialog_form "${InputValueDialog[@]}") || InputValueDialogButtonPressed=$?
+		AppName=$(tui_inputbox "${InputValueDialog[@]}") || InputValueDialogButtonPressed=$?
 		case ${DIALOG_BUTTONS[InputValueDialogButtonPressed]-} in
 			OK)
 				# Sanitize the input
@@ -64,7 +57,7 @@ menu_add_app() {
 				fi
 				if [[ -n ${ErrorMessage} ]]; then
 					run_script 'menu_heading_into' Heading "${AppNameHeading}"
-					dialog_error "${Title}" "${Heading}\n\n${ErrorMessage}"
+					tui_error "${Title}" "${Heading}\n\n${ErrorMessage}"
 					continue
 				fi
 				run_script 'menu_heading_into' Heading "${AppNameHeading}"
@@ -74,7 +67,7 @@ menu_add_app() {
 					run_script 'menu_heading_into' Heading "${AppNameHeading}"
 					if run_script 'question_prompt' N "${Heading}\n\n${Question}" "Create Application" "${ASSUMEYES:+Y}" "User Defined" "Back"; then
 						run_script 'menu_heading_into' Heading "${AppNameHeading}"
-						dialog_success "Adding User Defined Application" "${Heading}" "${DIALOGTIMEOUT}"
+						tui_success "Adding User Defined Application" "${Heading}" "${DIALOGTIMEOUT}"
 						run_script 'menu_add_var' "${AppName}"
 						return
 					fi
@@ -92,47 +85,44 @@ menu_add_app() {
 						"--no-label:Back"
 					)
 					local -i YesNoDialogButtonPressed=0
-					dialog_yesno "${YesNoDialog[@]}" || YesNoDialogButtonPressed=$?
+					tui_yesno "${YesNoDialog[@]}" || YesNoDialogButtonPressed=$?
 					case ${DIALOG_BUTTONS[YesNoDialogButtonPressed]-} in
 						OK) # Built In
 							run_script 'menu_heading_into' Heading "${AppNameHeading}"
-							coproc {
-								dialog_pipe "{{|TitleSuccess|}}Adding Built In Application" "${Heading}\n\n{{|Subtitle|}}Adding application:\n{{|CommandLine|}} ${APPLICATION_COMMAND} --add ${AppName}" "${DIALOGTIMEOUT}"
-							}
-							local -i DialogBox_PID=${COPROC_PID}
-							local -i DialogBox_FD="${COPROC[1]}"
+							#shellcheck disable=SC2034 # (warning): PipePID is passed by name to tui_pipe_open/close via nameref and appears unused to shellcheck.
+							local -i PipeFD PipePID
+							tui_pipe_open PipeFD PipePID "{{|TitleSuccess|}}Adding Built In Application" "${Heading}\n\n{{|Subtitle|}}Adding application:\n{{|CommandLine|}} ${APPLICATION_COMMAND} --add ${AppName}" "${DIALOGTIMEOUT}"
 							{
 								run_script 'env_backup'
 								run_script 'appvars_create' "${AppName}"
 								run_script 'env_update'
-							} >&${DialogBox_FD} 2>&1
-							exec {DialogBox_FD}<&-
-							wait ${DialogBox_PID}
+							} >&${PipeFD} 2>&1
+							tui_pipe_close PipeFD PipePID
 							return
 							;;
 						EXTRA) # User Defined
 							run_script 'menu_heading_into' Heading "${AppNameHeading}"
-							dialog_success "{{|TitleSuccess|}}Adding User Defined Application" "${Heading}" "${DIALOGTIMEOUT}"
+							tui_success "{{|TitleSuccess|}}Adding User Defined Application" "${Heading}" "${DIALOGTIMEOUT}"
 							run_script 'menu_add_var' "${AppName}"
 							return
 							;;
 						CANCEL | ESC) # Back
 							;;
 						*)
-							invalid_dialog_button ${YesNoDialogButtonPressed}
+							invalid_tui_button ${YesNoDialogButtonPressed}
 							;;
 					esac
 				fi
 				;;
-			EXTRA)
+			CANCEL | ESC)
 				return
 				;;
-			CANCEL | ESC)
+			EXIT)
 				run_script 'menu_exit'
 				continue
 				;;
 			*)
-				invalid_dialog_button ${InputValueDialogButtonPressed}
+				invalid_tui_button ${InputValueDialogButtonPressed}
 				;;
 		esac
 	done

--- a/scripts/menu_add_var.sh
+++ b/scripts/menu_add_var.sh
@@ -6,6 +6,68 @@ declare -a _dependencies_list=(
 	grep
 )
 
+menu_add_var_select_dialog() {
+	dialog_inputmenu "$@"
+}
+
+menu_add_var_select_whiptail() {
+	local Title="${1-}"
+	shift || true
+	local Message="${1-}"
+	shift || true
+	#shellcheck disable=SC2034 # (warning): ParsedOptions is passed by name to _whiptail_parse_options_ via nameref and appears unused to shellcheck.
+	local -a ParsedOptions=()
+	#shellcheck disable=SC2034 # (warning): Maximized is passed by name to _whiptail_parse_options_ via nameref and appears unused to shellcheck.
+	local -i _n_=0 Maximized=0
+	_whiptail_parse_options_ ParsedOptions Maximized _n_ "$@"
+	shift "${_n_}"
+	local -a Items=("$@")
+	local -a MenuDialog=(
+		"${Title}"
+		"${Message}"
+		--maximized
+		--item-help
+		--ok-label:Select
+		--cancel-label:Done
+		"${Items[@]}"
+	)
+	local -i result=0
+	local Selected
+	Selected=$(tui_menu "${MenuDialog[@]}") || result=$?
+	case ${DIALOG_BUTTONS[result]-} in
+		OK)
+			local StrippedSelected="${Selected// /}"
+			if [[ ${StrippedSelected} == *_ ]]; then
+				local NewValue
+				NewValue=$(tui_inputbox "${Title}" "${Message}" --maximized) || result=$?
+				case ${DIALOG_BUTTONS[result]-} in
+					OK)
+						echo "RENAMED ${Selected} ${NewValue}"
+						return "${DIALOG_EXTRA}"
+						;;
+					*)
+						return ${result}
+						;;
+				esac
+			else
+				echo "${Selected}"
+				return "${DIALOG_OK}"
+			fi
+			;;
+		*)
+			return ${result}
+			;;
+	esac
+}
+
+menu_add_var_select() {
+	if use_dialog; then
+		menu_add_var_select_dialog "$@"
+	else
+		menu_add_var_select_whiptail "$@"
+	fi
+}
+
 menu_add_var() {
 	local APPNAME=${1-}
 	local appname
@@ -14,7 +76,6 @@ menu_add_var() {
 	local VarType
 	local VarName=""
 	local Heading
-	local VarNameMaxLength=256
 	local VarNameHeading
 	local VarNameNone="{{|Highlight|}}[*NONE*]"
 	Heading=""
@@ -188,7 +249,7 @@ menu_add_var() {
 				)
 				local -i SelectValueDialogButtonPressed=0
 				local SelectedOption
-				SelectedOption=$(dialog_inputmenu "${SelectValueDialog[@]}") || SelectValueDialogButtonPressed=$?
+				SelectedOption=$(menu_add_var_select "${SelectValueDialog[@]}") || SelectValueDialogButtonPressed=$?
 				case ${DIALOG_BUTTONS[SelectValueDialogButtonPressed]-} in
 					OK) # SELECT button
 						if [[ ${SelectedOption} == "${OptionClear}" ]]; then
@@ -201,11 +262,9 @@ menu_add_var() {
 							run_script 'menu_heading_into' Heading ":${AppName}"
 							if run_script 'question_prompt' N "${Heading}\n\n${Question}" "Create Stock Variables" "${ASSUMEYES:+Y}" "Create" "Back"; then
 								run_script 'menu_heading_into' Heading ":${AppName}" "${VarNameHeading}"
-								coproc {
-									dialog_pipe "{{|TitleSuccess|}}Creating Stock Variables" "${Heading}"
-								}
-								local -i DialogBox_PID=${COPROC_PID}
-								local -i DialogBox_FD="${COPROC[1]}"
+								#shellcheck disable=SC2034 # (warning): PipePID is passed by name to tui_pipe_open/close via nameref and appears unused to shellcheck.
+								local -i PipeFD PipePID
+								tui_pipe_open PipeFD PipePID "{{|TitleSuccess|}}Creating Stock Variables" "${Heading}"
 								{
 									notice "Adding variables to {{|File|}}${COMPOSE_ENV}{{[-]}}:"
 									for Option in "${ValidStockOptions[@]}"; do
@@ -214,9 +273,8 @@ menu_add_var() {
 										notice "   {{|Var|}}${Option// /}=${DefaultValue}{{[-]}}"
 										run_script 'env_set_literal' "${Option// /}" "${DefaultValue}"
 									done
-								} >&${DialogBox_FD} 2>&1
-								exec {DialogBox_FD}<&-
-								wait ${DialogBox_PID}
+								} >&${PipeFD} 2>&1
+								tui_pipe_close PipeFD PipePID
 							fi
 							continue
 						elif [[ ${SelectedOption} =~ ${APPNAME__ENABLED}|${StockOptionsRegex} ]]; then
@@ -261,7 +319,7 @@ menu_add_var() {
 						fi
 						if [[ -n ${ErrorMessage-} ]]; then
 							run_script 'menu_heading_into' Heading ":${AppName}" "${VarNameHeading}"
-							dialog_error "${Title}" "${Heading}\n\n${ErrorMessage}"
+							tui_error "${Title}" "${Heading}\n\n${ErrorMessage}"
 							continue
 						fi
 						Question="Create variable {{|Highlight|}}${VarName}{{[-]}} for application {{|Highlight|}}${AppName}{{[-]}}?\n"
@@ -269,7 +327,7 @@ menu_add_var() {
 						if run_script 'question_prompt' N "${Heading}\n\n${Question}" "Create Variable" "${ASSUMEYES:+Y}" "Create" "Back"; then
 							run_script 'var_default_value_into' Default "${VarName}"
 							run_script 'menu_heading_into' Heading ":${AppName}" "${VarNameHeading}"
-							run_script_dialog "{{|TitleSuccess|}}Creating Variable" "${Heading}\n\n" "${DIALOGTIMEOUT}" \
+							run_script_tui "{{|TitleSuccess|}}Creating Variable" "${Heading}\n\n" "${DIALOGTIMEOUT}" \
 								'env_set_literal' "${VarName}" "${Default}"
 							run_script 'menu_value_prompt' "${VarName}"
 							return
@@ -296,23 +354,17 @@ menu_add_var() {
 				fi
 				local ErrorMessage=''
 				local DetectedAppName=''
-				local ValueOptions
-				ValueOptions=(
-					"" 1 1
-					"${VarName}" 1 1
-					"${VarNameMaxLength}" "${VarNameMaxLength}"
-				)
 				local -a InputValueDialog=(
 					"${Title}"
 					"${InputValueText}"
 					--maximized
 					--ok-label:Select
-					"--extra-label:Back"
-					--cancel-label:Exit
-					"${ValueOptions[@]}"
+					--cancel-label:Back
+					--exit-button
+					"${VarName}"
 				)
 				local InputValueDialogButtonPressed=0
-				VarName=$(dialog_form "${InputValueDialog[@]}") || InputValueDialogButtonPressed=$?
+				VarName=$(tui_inputbox "${InputValueDialog[@]}") || InputValueDialogButtonPressed=$?
 				case ${DIALOG_BUTTONS[InputValueDialogButtonPressed]-} in
 					OK)
 						local Default
@@ -335,7 +387,7 @@ menu_add_var() {
 						fi
 						if [[ -n ${ErrorMessage} ]]; then
 							run_script 'menu_heading_into' Heading "${AppNameHeading}" "${VarNameHeading}"
-							dialog_error "${Title}" "${Heading}\n\n${ErrorMessage}"
+							tui_error "${Title}" "${Heading}\n\n${ErrorMessage}"
 							continue
 						fi
 						run_script 'menu_heading_into' Heading "${AppNameHeading}" "${VarNameHeading}"
@@ -346,7 +398,7 @@ menu_add_var() {
 							if run_script 'question_prompt' N "${Heading}\n\n${Question}" "Create Variable" "${ASSUMEYES:+Y}" "Create" "Back"; then
 								run_script 'var_default_value_into' Default "${AppName}:${VarName}"
 								run_script 'menu_heading_into' Heading "${AppNameHeading}" "${VarNameHeading}"
-								run_script_dialog "{{|TitleSuccess|}}Creating Variable" "${Heading}\n\n" "${DIALOGTIMEOUT}" \
+								run_script_tui "{{|TitleSuccess|}}Creating Variable" "${Heading}\n\n" "${DIALOGTIMEOUT}" \
 									'env_set_literal' "${appname}:${VarName}" "${Default}"
 								run_script 'menu_value_prompt' "${appname}:${VarName}"
 								return
@@ -357,22 +409,22 @@ menu_add_var() {
 							if run_script 'question_prompt' N "${Heading}\n\n${Question}" "Create Variable" "${ASSUMEYES:+Y}" "Create" "Back"; then
 								run_script 'var_default_value_into' Default "${VarName}"
 								run_script 'menu_heading_into' Heading "${AppNameHeading}" "${VarNameHeading}"
-								run_script_dialog "{{|TitleSuccess|}}Creating Variable" "${Heading}\n\n" "${DIALOGTIMEOUT}" \
+								run_script_tui "{{|TitleSuccess|}}Creating Variable" "${Heading}\n\n" "${DIALOGTIMEOUT}" \
 									'env_set_literal' "${VarName}" "${Default}"
 								run_script 'menu_value_prompt' "${VarName}"
 								return
 							fi
 						fi
 						;;
-					EXTRA)
+					CANCEL | ESC)
 						return
 						;;
-					CANCEL | ESC)
+					EXIT)
 						run_script 'menu_exit'
 						continue
 						;;
 					*)
-						invalid_dialog_button ${InputValueDialogButtonPressed}
+						invalid_tui_button ${InputValueDialogButtonPressed}
 						;;
 				esac
 			done

--- a/scripts/menu_app_select.sh
+++ b/scripts/menu_app_select.sh
@@ -4,7 +4,6 @@ IFS=$'\n\t'
 
 declare -a _dependencies_list=(
 	column
-	dialog
 	sed
 )
 
@@ -25,8 +24,8 @@ declare DialogGaugeText FullDialogGaugeText ExpandedDialogGaugeText
 declare -i ProgressSteps ProgressStepNumber
 
 declare GaugePipe ProgressLog
-declare -i GaugePipe_fd ProgressLog_fd
-declare Dialog_PID
+declare -i GaugePipe_fd ProgressLog_fd=0
+declare -i Dialog_PID=0
 
 menu_app_select() {
 	local -a ProcessInfo
@@ -159,7 +158,7 @@ menu_app_select() {
 			"${AppList[@]}"
 		)
 		SelectedAppsDialogButtonPressed=0
-		SelectedApps=$(dialog_checklist "${SelectedAppsDialog[@]}") || SelectedAppsDialogButtonPressed=$?
+		SelectedApps=$(tui_checklist "${SelectedAppsDialog[@]}") || SelectedAppsDialogButtonPressed=$?
 	fi
 	case ${DIALOG_BUTTONS[SelectedAppsDialogButtonPressed]-} in
 		OK)
@@ -240,15 +239,15 @@ menu_app_select() {
 			return 1
 			;;
 		*)
-			invalid_dialog_button ${SelectedAppsDialogButtonPressed}
+			invalid_tui_button ${SelectedAppsDialogButtonPressed}
 			;;
 	esac
 }
 
-show_gauge() {
+dialog_show_gauge() {
 	local GaugeTitle="${1-${Title}}"
 
-	_dialog_backtitle_
+	_tui_backtitle_
 	local -a GlobalDialogOptions=(
 		--file "${DIALOG_OPTIONS_FILE}"
 		--backtitle "${BACKTITLE}"
@@ -258,7 +257,6 @@ show_gauge() {
 	local -i ScreenRows=${LINES}
 	local -i ScreenCols=${COLUMNS}
 	local -i DialogCols
-	#local -i DialogRows
 
 	local -i GaugeDialogStartRow
 	local -i LogDialogStartRow
@@ -272,7 +270,6 @@ show_gauge() {
 	GaugeDialogStartRow=2
 	DialogStartCol=2
 
-	#DialogRows=$((ScreenRows - D["WindowRowsAdjust"]))
 	DialogCols=$((ScreenCols - D["WindowColsAdjust"]))
 
 	GaugeDialogTextRows=$(wc -l <<< "${FullDialogGaugeText}")
@@ -281,7 +278,6 @@ show_gauge() {
 	LogDialogStartRow="$((GaugeDialogStartRow + GaugeDialogRows + (D["WindowRowsAdjust"] - 3)))"
 	LogDialogRows="$((ScreenRows - LogDialogStartRow - (D["WindowRowsAdjust"] - 3) - 1))"
 
-	# Create the pipes to communicate with the gauge and log dialog windows
 	GaugePipe=$(mktemp -u -t "${APPLICATION_NAME}.${FUNCNAME[0]}.GaugePipe.XXXXXXXXXX")
 	mkfifo "${GaugePipe}"
 	exec {GaugePipe_fd}<> "${GaugePipe}"
@@ -310,7 +306,6 @@ show_gauge() {
 		"${GaugeDialog[@]}"
 	)
 
-	# Start the gauge and progress dialog windows in the background, and get the process id
 	local index
 	for index in "${!DialogOptions[@]}"; do
 		resolve_styles_into DialogOptions["${index}"] DC "${DialogOptions["${index}"]}"
@@ -318,16 +313,36 @@ show_gauge() {
 	"${DIALOG}" "${DialogOptions[@]}" < "${GaugePipe}" &
 	Dialog_PID=$!
 }
+whiptail_show_gauge() {
+	ProgressLog=/dev/tty
+	Dialog_PID=0
+}
+show_gauge() {
+	if use_dialog; then
+		dialog_show_gauge "$@"
+	else
+		whiptail_show_gauge "$@"
+	fi
+}
 
-close_gauge() {
-	# Signal the dialog gauge and progress windows to terminate
+dialog_close_gauge() {
 	kill -SIGTERM "${Dialog_PID}" &> /dev/null || true
 	wait "${Dialog_PID}" &> /dev/null || true
-	# Remove the communication pipes to dialog
 	exec {GaugePipe_fd}>&- &> /dev/null || true
 	rm "${GaugePipe}" &> /dev/null || true
 	exec {ProgressLog_fd}>&- &> /dev/null || true
 	rm "${ProgressLog}" &> /dev/null || true
+}
+whiptail_close_gauge() {
+	true
+}
+
+close_gauge() {
+	if use_dialog; then
+		dialog_close_gauge
+	else
+		whiptail_close_gauge
+	fi
 }
 
 init_gauge_text() {
@@ -478,13 +493,23 @@ update_gauge_percent() {
 	echo "${ProgressPercent}" > "${GaugePipe}"
 }
 
-update_gauge() {
+dialog_update_gauge() {
 	update_gauge_percent_value "${1-0}"
 	shift 1 || true
 	if [[ $# -gt 0 ]]; then
 		update_gauge_text "$@"
 	fi
 	printf 'XXX\n%s\n%s\nXXX\n' "${ProgressPercent}" "${ExpandedDialogGaugeText}" > "${GaugePipe}"
+}
+whiptail_update_gauge() {
+	true
+}
+update_gauge() {
+	if use_dialog; then
+		dialog_update_gauge "$@"
+	else
+		whiptail_update_gauge "$@"
+	fi
 }
 
 test_menu_app_select() {

--- a/scripts/menu_config.sh
+++ b/scripts/menu_config.sh
@@ -10,17 +10,14 @@ menu_config() {
 	local Title="Configuration Menu"
 
 	if run_script 'needs_appvars_create'; then
-		coproc {
-			dialog_pipe "{{|TitleSuccess|}}Creating environment variables for added apps" "Please be patient, this can take a while.\n{{|CommandLine|}} ${APPLICATION_COMMAND} --env" "${DIALOGTIMEOUT}"
-		}
-		local -i DialogBox_PID=${COPROC_PID}
-		local -i DialogBox_FD="${COPROC[1]}"
+		#shellcheck disable=SC2034 # (warning): PipePID is passed by name to tui_pipe_open/close via nameref and appears unused to shellcheck.
+		local -i PipeFD PipePID
+		tui_pipe_open PipeFD PipePID "{{|TitleSuccess|}}Creating environment variables for added apps" "Please be patient, this can take a while.\n{{|CommandLine|}} ${APPLICATION_COMMAND} --env" "${DIALOGTIMEOUT}"
 		{
 			run_script 'env_backup'
 			run_script 'appvars_create_all' || true
-		} >&${DialogBox_FD} 2>&1
-		exec {DialogBox_FD}<&-
-		wait ${DialogBox_PID}
+		} >&${PipeFD} 2>&1
+		tui_pipe_close PipeFD PipePID
 	fi
 
 	local Option_FullSetup="Full Setup"
@@ -47,14 +44,14 @@ menu_config() {
 			"What would you like to do?"
 			--item-help
 			"--ok-label:Select"
-			"--extra-label:Back"
-			"--cancel-label:Exit"
+			--cancel-label:Back
+			--exit-button
 			"--default-item:${LastConfigChoice}"
 			"${ConfigOpts[@]}"
 		)
 		local ConfigChoice
 		local -i ConfigDialogButtonPressed=0
-		ConfigChoice=$(dialog_menu "${ConfigChoiceDialog[@]}") || ConfigDialogButtonPressed=$?
+		ConfigChoice=$(tui_menu "${ConfigChoiceDialog[@]}") || ConfigDialogButtonPressed=$?
 		LastConfigChoice=${ConfigChoice}
 		case ${DIALOG_BUTTONS[ConfigDialogButtonPressed]-} in
 			OK) # Select
@@ -85,26 +82,25 @@ menu_config() {
 							"${Question}{{[-]}}"
 							--maximized
 							--no-collapse
-							--extra-button
 							--yes-label:Stop
 							--extra-label:Down
 							--cancel-label:Cancel
 						)
 						local -i YesNoDialogButtonPressed=0
-						dialog_yesno "${YesNoDialog[@]}" || YesNoDialogButtonPressed=$?
+						tui_yesno "${YesNoDialog[@]}" || YesNoDialogButtonPressed=$?
 						case ${DIALOG_BUTTONS[YesNoDialogButtonPressed]-} in
 							OK) # Stop
-								run_script_dialog "{{|TitleSuccess|}}Docker Compose" "Stopping all running services.\n{{|CommandLine|}} ${APPLICATION_COMMAND} --compose stop" "" \
+								run_script_tui "{{|TitleSuccess|}}Docker Compose" "Stopping all running services.\n{{|CommandLine|}} ${APPLICATION_COMMAND} --compose stop" "" \
 									'docker_compose' "stop"
 								;;
 							EXTRA) # Down
-								run_script_dialog "{{|TitleSuccess|}}Docker Compose" "Stopping and removing all containers, networks, volumes, and images.\n{{|CommandLine|}} ${APPLICATION_COMMAND} --compose down" "" \
+								run_script_tui "{{|TitleSuccess|}}Docker Compose" "Stopping and removing all containers, networks, volumes, and images.\n{{|CommandLine|}} ${APPLICATION_COMMAND} --compose down" "" \
 									'docker_compose' "down"
 								;;
 							CANCEL | ESC) # Cancel
 								;;
 							*)
-								invalid_dialog_button ${YesNoDialogButtonPressed}
+								invalid_tui_button ${YesNoDialogButtonPressed}
 								;;
 						esac
 						;;
@@ -116,14 +112,14 @@ menu_config() {
 						;;
 				esac
 				;;
-			EXTRA | ESC) # Back
+			CANCEL | ESC) # Back
 				return
 				;;
-			CANCEL) # Exit
+			EXIT) # Exit
 				run_script 'menu_exit'
 				;;
 			*)
-				invalid_dialog_button ${ConfigDialogButtonPressed}
+				invalid_tui_button ${ConfigDialogButtonPressed}
 				;;
 		esac
 	done

--- a/scripts/menu_config_apps.sh
+++ b/scripts/menu_config_apps.sh
@@ -26,14 +26,14 @@ menu_config_apps() {
 			"${Title}"
 			"Select the application to configure"
 			--ok-label:Select
-			--extra-label:Back
-			--cancel-label:Exit
+			--cancel-label:Back
+			--exit-button
 			--default-item:"${LastAppChoice}"
 			"${AppOptions[@]}"
 		)
 		local AppChoice
 		local -i AppChoiceButtonPressed=0
-		AppChoice=$(dialog_menu "${AppChoiceDialog[@]}") || AppChoiceButtonPressed=$?
+		AppChoice=$(tui_menu "${AppChoiceDialog[@]}") || AppChoiceButtonPressed=$?
 		LastAppChoice=${AppChoice}
 		case ${DIALOG_BUTTONS[AppChoiceButtonPressed]-} in
 			OK) # Select
@@ -43,14 +43,14 @@ menu_config_apps() {
 					run_script 'menu_config_vars' "${AppChoice}"
 				fi
 				;;
-			EXTRA | ESC) # Back
+			CANCEL | ESC) # Back
 				return
 				;;
-			CANCEL) # Exit
+			EXIT) # Exit
 				run_script 'menu_exit'
 				;;
 			*)
-				invalid_dialog_button ${AppChoiceButtonPressed}
+				invalid_tui_button ${AppChoiceButtonPressed}
 				;;
 		esac
 	done

--- a/scripts/menu_config_vars.sh
+++ b/scripts/menu_config_vars.sh
@@ -167,7 +167,7 @@ menu_config_vars() {
 				"${LineOptions[@]}"
 			)
 			local -i LineDialogButtonPressed=0
-			LineChoice=$(dialog_menu "${LineDialog[@]}") || LineDialogButtonPressed=$?
+			LineChoice=$(tui_menu "${LineDialog[@]}") || LineDialogButtonPressed=$?
 			case ${DIALOG_BUTTONS[LineDialogButtonPressed]-} in
 				OK) # Select
 					LastLineChoice="${LineChoice}"
@@ -199,11 +199,9 @@ menu_config_vars() {
 						local Question="Do you really want to delete {{|Highlight|}}${CleanVarName}{{[-]}}?"
 						if run_script 'question_prompt' N "${DialogHeading}\n\n${Question}\n" "Delete Variable" "${ASSUMEYES:+Y}" "Delete" "Back"; then
 							run_script 'menu_heading_into' DialogHeading "${APPNAME-}" "${VarName}"
-							coproc {
-								dialog_pipe "{{|TitleSuccess|}}Deleting Variable" "${DialogHeading}" "${DIALOGTIMEOUT}"
-							}
-							local -i DialogBox_PID=${COPROC_PID}
-							local -i DialogBox_FD="${COPROC[1]}"
+							#shellcheck disable=SC2034 # (warning): PipePID is passed by name to tui_pipe_open/close via nameref and appears unused to shellcheck.
+							local -i PipeFD PipePID
+							tui_pipe_open PipeFD PipePID "{{|TitleSuccess|}}Deleting Variable" "${DialogHeading}" "${DIALOGTIMEOUT}"
 							{
 								run_script 'env_delete' "${VarName}"
 								if [[ -n ${APPNAME-} ]]; then
@@ -220,9 +218,8 @@ menu_config_vars() {
 									run_script 'env_sanitize'
 									run_script 'env_update'
 								fi
-							} >&${DialogBox_FD} 2>&1
-							exec {DialogBox_FD}<&-
-							wait ${DialogBox_PID}
+							} >&${PipeFD} 2>&1
+							tui_pipe_close PipeFD PipePID
 							break
 						fi
 					fi
@@ -231,7 +228,7 @@ menu_config_vars() {
 					return
 					;;
 				*)
-					invalid_dialog_button ${LineDialogButtonPressed}
+					invalid_tui_button ${LineDialogButtonPressed}
 					;;
 			esac
 		done

--- a/scripts/menu_dialog_example.sh
+++ b/scripts/menu_dialog_example.sh
@@ -78,7 +78,7 @@ menu_dialog_example() {
 		"${DialogOptions[@]}"
 	)
 
-	dialog_menu "${MenuDialog[@]}" > /dev/null || true
+	tui_menu "${MenuDialog[@]}" > /dev/null || true
 }
 
 test_menu_dialog_example() {

--- a/scripts/menu_main.sh
+++ b/scripts/menu_main.sh
@@ -32,7 +32,7 @@ menu_main() {
 		)
 		local MainChoice
 		local -i MainDialogButtonPressed=0
-		MainChoice=$(dialog_menu "${MainChoiceDialog[@]}") || MainDialogButtonPressed=$?
+		MainChoice=$(tui_menu "${MainChoiceDialog[@]}") || MainDialogButtonPressed=$?
 		LastMainChoice=${MainChoice}
 		case ${DIALOG_BUTTONS[MainDialogButtonPressed]-} in
 			OK)
@@ -61,7 +61,7 @@ menu_main() {
 				exit 0
 				;;
 			*)
-				invalid_dialog_button ${MainDialogButtonPressed}
+				invalid_tui_button ${MainDialogButtonPressed}
 				;;
 		esac
 	done

--- a/scripts/menu_options.sh
+++ b/scripts/menu_options.sh
@@ -9,9 +9,11 @@ menu_options() {
 
 	local Title="Options"
 	local Option_Theme="Choose Theme"
+	local Option_Display_Engine="Display Engine"
 	local Option_Display="Display Options"
 	local Option_Package_Manager="Package Manager"
 	local Opts=(
+		"${Option_Display_Engine}" "{{|ListDefault|}}Set display engine for menus" ""
 		"${Option_Theme}" "{{|ListDefault|}}Choose a theme for ${APPLICATION_NAME}" ""
 		"${Option_Display}" "{{|ListDefault|}}Set display options" ""
 		"${Option_Package_Manager}" "{{|ListDefault|}}Choose the package manager to use" ""
@@ -23,19 +25,22 @@ menu_options() {
 			"${Title}"
 			"What would you like to do?"
 			"--ok-label:Select"
-			"--extra-label:Back"
-			"--cancel-label:Exit"
+			--cancel-label:Back
+			--exit-button
 			"--default-item:${LastChoice}"
 			--item-help
 			"${Opts[@]}"
 		)
 		local Choice
 		local -i DialogButtonPressed=0
-		Choice=$(dialog_menu "${ChoiceDialog[@]}") || DialogButtonPressed=$?
+		Choice=$(tui_menu "${ChoiceDialog[@]}") || DialogButtonPressed=$?
 		LastChoice=${Choice}
 		case ${DIALOG_BUTTONS[DialogButtonPressed]-} in
 			OK) # Select
 				case "${Choice}" in
+					"${Option_Display_Engine}")
+						run_script 'menu_options_display_engine' || true
+						;;
 					"${Option_Theme}")
 						run_script 'menu_options_theme' || true
 						;;
@@ -50,14 +55,14 @@ menu_options() {
 						;;
 				esac
 				;;
-			EXTRA | ESC) # Back
+			CANCEL | ESC) # Back
 				return
 				;;
-			CANCEL) # Exit
+			EXIT) # Exit
 				run_script 'menu_exit'
 				;;
 			*)
-				invalid_dialog_button ${DialogButtonPressed}
+				invalid_tui_button ${DialogButtonPressed}
 				;;
 		esac
 	done

--- a/scripts/menu_options_display.sh
+++ b/scripts/menu_options_display.sh
@@ -15,6 +15,7 @@ menu_options_display() {
 	local ShowBordersOption="Show Borders"
 	local ShowScrollbarOption="Show Scrollbars"
 	local ShowShadowOption="Show Shadows"
+	local LargeButtonsOption="Large Buttons"
 
 	local -A OptionDescription OptionVariable
 
@@ -22,18 +23,20 @@ menu_options_display() {
 	OptionDescription["${ShowBordersOption}"]="{{|ListDefault|}}Show borders in dialog boxes"
 	OptionDescription["${ShowScrollbarOption}"]="{{|ListDefault|}}Show a scrollbar in dialog boxes"
 	OptionDescription["${ShowShadowOption}"]="{{|ListDefault|}}Show a shadow under the dialog boxes"
+	OptionDescription["${LargeButtonsOption}"]="{{|ListDefault|}}Use large buttons (Whiptail)"
 
-	OptionVariable["${DrawLineOption}"]="line_characters"
-	OptionVariable["${ShowBordersOption}"]="borders"
-	OptionVariable["${ShowScrollbarOption}"]="scrollbar"
-	OptionVariable["${ShowShadowOption}"]="shadow"
+	OptionVariable["${DrawLineOption}"]="ui.line_characters"
+	OptionVariable["${ShowBordersOption}"]="ui.borders"
+	OptionVariable["${ShowScrollbarOption}"]="ui.scrollbar"
+	OptionVariable["${ShowShadowOption}"]="ui.shadow"
+	OptionVariable["${LargeButtonsOption}"]="ui.large_buttons"
 
 	while true; do
 		local EnabledOptions=()
 		local Opts=()
-		for Option in "${DrawLineOption}" "${ShowBordersOption}" "${ShowScrollbarOption}" "${ShowShadowOption}"; do
+		for Option in "${DrawLineOption}" "${ShowBordersOption}" "${ShowScrollbarOption}" "${ShowShadowOption}" "${LargeButtonsOption}"; do
 			local Value
-			run_script 'config_get_into' Value "ui.${OptionVariable["${Option}"]}" || true
+			run_script 'config_get_into' Value "${OptionVariable["${Option}"]}" || true
 			if is_true "${Value}"; then
 				EnabledOptions+=("${Option}")
 				Opts+=("${Option}" "${OptionDescription["${Option}"]}" ON)
@@ -45,14 +48,14 @@ menu_options_display() {
 			"${Title}"
 			"Choose the options to enable."
 			--ok-label:Select
-			--extra-label:Back
-			--cancel-label:Exit
+			--cancel-label:Back
+			--exit-button
 			--separate-output
 			"${Opts[@]}"
 		)
 		local Choices
 		local -i DialogButtonPressed=0
-		Choices=$(dialog_checklist "${ChoiceDialog[@]}") || DialogButtonPressed=$?
+		Choices=$(tui_checklist "${ChoiceDialog[@]}") || DialogButtonPressed=$?
 		case ${DIALOG_BUTTONS[DialogButtonPressed]-} in
 			OK)
 				local -a ChoicesArray OptionsToTurnOff OptionsToTurnOn
@@ -66,25 +69,25 @@ menu_options_display() {
 				if [[ -n ${OptionsToTurnOff[*]-} || ${OptionsToTurnOn[*]-} ]]; then
 					if [[ -n ${OptionsToTurnOff[*]-} ]]; then
 						for Option in "${OptionsToTurnOff[@]}"; do
-							run_script 'config_set' "ui.${OptionVariable["${Option}"]}" false
+							run_script 'config_set' "${OptionVariable["${Option}"]}" false
 						done
 					fi
 					if [[ -n ${OptionsToTurnOn[*]-} ]]; then
 						for Option in "${OptionsToTurnOn[@]}"; do
-							run_script 'config_set' "ui.${OptionVariable["${Option}"]}" true
+							run_script 'config_set' "${OptionVariable["${Option}"]}" true
 						done
 					fi
 					run_script 'config_theme' &> /dev/null
 				fi
 				;;
-			EXTRA | ESC)
+			CANCEL | ESC)
 				return
 				;;
-			CANCEL)
+			EXIT)
 				run_script 'menu_exit' || true
 				;;
 			*)
-				invalid_dialog_button ${DialogButtonPressed}
+				invalid_tui_button ${DialogButtonPressed}
 				;;
 		esac
 	done

--- a/scripts/menu_options_display_engine.sh
+++ b/scripts/menu_options_display_engine.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+menu_options_display_engine() {
+	if [[ ${CI-} == true ]]; then
+		return
+	fi
+
+	local Title="Choose Display Engine"
+
+	local DialogOption="Dialog"
+	local WhiptailOption="Whiptail"
+
+	local -A OptionDescription=(
+		["${DialogOption}"]="{{|ListDefault|}}Use the modern Dialog command"
+		["${WhiptailOption}"]="{{|ListDefault|}}Use the legacy Whiptail command"
+	)
+	local -A OptionValue=(
+		["${DialogOption}"]="dialog"
+		["${WhiptailOption}"]="whiptail"
+	)
+
+	local CurrentOption
+	run_script 'config_get_into' CurrentOption ui.display_engine || true
+
+	while true; do
+		local -a Opts=()
+		for Tag in "${DialogOption}" "${WhiptailOption}"; do
+			if [[ ${OptionValue["${Tag}"]} == "${CurrentOption}" ]]; then
+				Opts+=("${Tag}" "${OptionDescription["${Tag}"]}" ON "")
+			else
+				Opts+=("${Tag}" "${OptionDescription["${Tag}"]}" OFF "")
+			fi
+		done
+		local -a ChoiceDialog=(
+			"${Title}"
+			"Select the display engine to use."
+			--item-help
+			--ok-label:Select
+			--cancel-label:Back
+			--exit-button
+			--default-item:"${LastChoice}"
+			"${Opts[@]}"
+		)
+		local Choice
+		local -i DialogButtonPressed=0
+		Choice=$(tui_radiolist "${ChoiceDialog[@]}") || DialogButtonPressed=$?
+		LastChoice=${Choice}
+		case ${DIALOG_BUTTONS[DialogButtonPressed]-} in
+			OK)
+				if [[ ${OptionValue["${Choice}"]} != "${CurrentOption}" ]]; then
+					CurrentOption=${OptionValue["${Choice}"]}
+					run_script 'config_display_engine' "${CurrentOption}" &> /dev/null
+				fi
+				;;
+			CANCEL | ESC)
+				return
+				;;
+			EXIT)
+				run_script 'menu_exit' || true
+				;;
+			*)
+				invalid_tui_button ${DialogButtonPressed}
+				;;
+		esac
+	done
+}
+
+test_menu_options_display_engine() {
+	warn "CI does not test menu_options_display_engine."
+}

--- a/scripts/menu_options_package_manager.sh
+++ b/scripts/menu_options_package_manager.sh
@@ -59,14 +59,14 @@ menu_options_package_manager() {
 			"Select the package manager to use. Detected package managers are highlighted."
 			--item-help
 			--ok-label:Select
-			--extra-label:Back
-			--cancel-label:Exit
+			--cancel-label:Back
+			--exit-button
 			--default-item:"${LastChoice}"
 			"${Opts[@]}"
 		)
 		local Choice
 		local -i DialogButtonPressed=0
-		Choice=$(dialog_radiolist "${ChoiceDialog[@]}") || DialogButtonPressed=$?
+		Choice=$(tui_radiolist "${ChoiceDialog[@]}") || DialogButtonPressed=$?
 		LastChoice=${Choice}
 		case ${DIALOG_BUTTONS[DialogButtonPressed]-} in
 			OK)
@@ -75,14 +75,14 @@ menu_options_package_manager() {
 					run_script 'config_package_manager' "${CurrentPackageManager}" &> /dev/null
 				fi
 				;;
-			EXTRA | ESC)
+			CANCEL | ESC)
 				return
 				;;
-			CANCEL)
+			EXIT)
 				run_script 'menu_exit' || true
 				;;
 			*)
-				invalid_dialog_button ${DialogButtonPressed}
+				invalid_tui_button ${DialogButtonPressed}
 				;;
 		esac
 	done

--- a/scripts/menu_options_theme.sh
+++ b/scripts/menu_options_theme.sh
@@ -92,14 +92,14 @@ menu_options_theme() {
 			"${Title}"
 			"Select the theme to apply."
 			--ok-label:Select
-			--extra-label:Back
-			--cancel-label:Exit
+			--cancel-label:Back
+			--exit-button
 			--default-item:"${LastChoice}"
 			"${Opts[@]}"
 		)
 		local Choice
 		local -i DialogButtonPressed=0
-		Choice=$(dialog_radiolist "${ChoiceDialog[@]}") || DialogButtonPressed=$?
+		Choice=$(tui_radiolist "${ChoiceDialog[@]}") || DialogButtonPressed=$?
 		LastChoice=${Choice}
 		case ${DIALOG_BUTTONS[DialogButtonPressed]-} in
 			OK)
@@ -107,17 +107,17 @@ menu_options_theme() {
 				if run_script 'config_theme' "${CurrentTheme}"; then
 					run_script 'menu_dialog_example' "Applied theme ${CurrentTheme}" "${APPLICATION_COMMAND} --theme \"${CurrentTheme}\""
 				else
-					dialog_error "${Title}" "Unable to apply theme ${CurrentTheme}"
+					tui_error "${Title}" "Unable to apply theme ${CurrentTheme}"
 				fi
 				;;
-			EXTRA | ESC)
+			CANCEL | ESC)
 				return
 				;;
-			CANCEL)
+			EXIT)
 				run_script 'menu_exit' || true
 				;;
 			*)
-				invalid_dialog_button ${DialogButtonPressed}
+				invalid_tui_button ${DialogButtonPressed}
 				;;
 		esac
 	done

--- a/scripts/menu_value_prompt.sh
+++ b/scripts/menu_value_prompt.sh
@@ -340,7 +340,7 @@ menu_value_prompt() {
 		)
 		local -i SelectValueDialogButtonPressed=0
 		local SelectedValue
-		SelectedValue=$(dialog_inputmenu "${SelectValueDialog[@]}") || SelectValueDialogButtonPressed=$?
+		SelectedValue=$(menu_value_prompt_select "${SelectValueDialog[@]}") || SelectValueDialogButtonPressed=$?
 
 		case ${DIALOG_BUTTONS[SelectValueDialogButtonPressed]-} in
 			OK) # SELECT button
@@ -383,7 +383,7 @@ menu_value_prompt() {
 									;;
 								*)
 									ValueValid="false"
-									dialog_error "${Title}" "${DialogHeading}\n{{|Highlight|}}${OptionValue["${CurrentValueOption}"]}{{[-]}} is not {{|Highlight|}}true{{[-]}}/{{|Highlight|}}on{{[-]}}/{{|Highlight|}}yes{{[-]}} or {{|Highlight|}}false{{[-]}}/{{|Highlight|}}off{{[-]}}/{{|Highlight|}}no{{[-]}}. Please try setting {{|Highlight|}}${CleanVarName}{{[-]}} again."
+									tui_error "${Title}" "${DialogHeading}\n{{|Highlight|}}${OptionValue["${CurrentValueOption}"]}{{[-]}} is not {{|Highlight|}}true{{[-]}}/{{|Highlight|}}on{{[-]}}/{{|Highlight|}}yes{{[-]}} or {{|Highlight|}}false{{[-]}}/{{|Highlight|}}off{{[-]}}/{{|Highlight|}}no{{[-]}}. Please try setting {{|Highlight|}}${CleanVarName}{{[-]}} again."
 									;;
 							esac
 							;;
@@ -394,7 +394,7 @@ menu_value_prompt() {
 									;;
 								*)
 									ValueValid="false"
-									dialog_error "${Title}" "${DialogHeading}\n\n{{|Highlight|}}${OptionValue["${CurrentValueOption}"]}{{[-]}} is not a valid network mode. Please try setting {{|Highlight|}}${CleanVarName}{{[-]}} again."
+									tui_error "${Title}" "${DialogHeading}\n\n{{|Highlight|}}${OptionValue["${CurrentValueOption}"]}{{[-]}} is not a valid network mode. Please try setting {{|Highlight|}}${CleanVarName}{{[-]}} again."
 									;;
 							esac
 							;;
@@ -405,32 +405,35 @@ menu_value_prompt() {
 									;;
 								*)
 									ValueValid="false"
-									dialog_error "${Title}" "${DialogHeading}\n\n{{|Highlight|}}${OptionValue["${CurrentValueOption}"]}{{[-]}} is not a valid restart value. Please try setting {{|Highlight|}}${CleanVarName}{{[-]}} again."
+									tui_error "${Title}" "${DialogHeading}\n\n{{|Highlight|}}${OptionValue["${CurrentValueOption}"]}{{[-]}} is not a valid restart value. Please try setting {{|Highlight|}}${CleanVarName}{{[-]}} again."
 									;;
 							esac
 							;;
 						"${APPNAME}__VOLUME_"*)
 							if [[ ${StrippedValue} == "/" ]]; then
 								ValueValid="false"
-								dialog_error "${Title}" "${DialogHeading}\n\nCannot use {{|Highlight|}}/{{[-]}} for {{|Highlight|}}${CleanVarName}{{[-]}}. Please select another folder."
+								tui_error "${Title}" "${DialogHeading}\n\nCannot use {{|Highlight|}}/{{[-]}} for {{|Highlight|}}${CleanVarName}{{[-]}}. Please select another folder."
 							elif [[ ${StrippedValue} == *~* ]]; then
 								local CORRECTED_DIR="${OptionValue["${CurrentValueOption}"]//\~/"${DETECTED_HOMEDIR}"}"
 								if run_script 'question_prompt' --maximized Y "${DialogHeading}\n\nCannot use the {{|Highlight|}}~{{[-]}} shortcut in {{|Highlight|}}${CleanVarName}{{[-]}}. Would you like to use {{|Highlight|}}${CORRECTED_DIR}{{[-]}} instead?" "${Title}"; then
 									OptionValue["${CurrentValueOption}"]="${CORRECTED_DIR}"
 									ValueValid="false"
-									dialog_success "${Title}" "Returning to the previous menu to confirm selection."
+									tui_success "${Title}" "Returning to the previous menu to confirm selection."
 								else
 									ValueValid="false"
-									dialog_error "${Title}" "${DialogHeading}\n\nCannot use the {{|Highlight|}}~{{[-]}} shortcut in {{|Highlight|}}${CleanVarName}{{[-]}}. Please select another folder."
+									tui_error "${Title}" "${DialogHeading}\n\nCannot use the {{|Highlight|}}~{{[-]}} shortcut in {{|Highlight|}}${CleanVarName}{{[-]}}. Please select another folder."
 								fi
 							elif [[ -d ${StrippedValue} ]]; then
 								if run_script 'question_prompt' --maximized Y "${DialogHeading}\n\nWould you like to set permissions on ${OptionValue["${CurrentValueOption}"]} ?" "${Title}" "${ASSUMEYES:+Y}"; then
-									run_script_dialog "Setting Permissions" "{{|Heading|}}${StrippedValue}{{[-]}}" "${DIALOGTIMEOUT}" \
+									run_script_tui "Setting Permissions" "{{|Heading|}}${StrippedValue}{{[-]}}" "${DIALOGTIMEOUT}" \
 										'set_permissions' "${StrippedValue}"
 								fi
 								ValueValid="true"
 							else
 								if run_script 'question_prompt' --maximized Y "${DialogHeading}\n\n{{|Highlight|}}${OptionValue["${CurrentValueOption}"]}{{[-]}} is not a valid path. Would you like to attempt to create it?" "${Title}"; then
+									#shellcheck disable=SC2034 # (warning): PipePID is passed by name to tui_pipe_open/close via nameref and appears unused to shellcheck.
+									local -i PipeFD PipePID
+									tui_pipe_open PipeFD PipePID "Creating folder and settings permissions" "${OptionValue["${CurrentValueOption}"]}" "${DIALOGTIMEOUT}"
 									{
 										{
 											mkdir -p "${StrippedValue}" ||
@@ -439,11 +442,12 @@ menu_value_prompt() {
 													"Failing command: {{|FailingCommand|}}mkdir -p \"${StrippedValue}\""
 											run_script 'set_permissions' "${StrippedValue}"
 										} || true
-									} |& dialog_pipe "Creating folder and settings permissions" "${OptionValue["${CurrentValueOption}"]}" "${DIALOGTIMEOUT}"
-									dialog_msgbox "{{|TitleSuccess|}}${Title}" "{{|Highlight|}}${OptionValue["${CurrentValueOption}"]}{{[-]}} folder was created successfully." --maximized
+									} >&${PipeFD} 2>&1
+									tui_pipe_close PipeFD PipePID
+									tui_msgbox "{{|TitleSuccess|}}${Title}" "{{|Highlight|}}${OptionValue["${CurrentValueOption}"]}{{[-]}} folder was created successfully." --maximized
 									ValueValid="true"
 								else
-									dialog_error "${Title}" "${DialogHeading}\n\n{{|Highlight|}}${OptionValue["${CurrentValueOption}"]}{{[-]}} is not a valid path. Please try setting {{|Highlight|}}${CleanVarName}{{[-]}} again."
+									tui_error "${Title}" "${DialogHeading}\n\n{{|Highlight|}}${OptionValue["${CurrentValueOption}"]}{{[-]}} is not a valid path. Please try setting {{|Highlight|}}${CleanVarName}{{[-]}} again."
 									ValueValid="false"
 								fi
 							fi
@@ -460,7 +464,7 @@ menu_value_prompt() {
 									ValueValid="true"
 								fi
 							else
-								dialog_error "${Title}" "${DialogHeading}\n\n{{|Highlight|}}${OptionValue["${CurrentValueOption}"]}{{[-]}} is not a valid ${CleanVarName}. Please try setting {{|Highlight|}}${CleanVarName}{{[-]}} again."
+								tui_error "${Title}" "${DialogHeading}\n\n{{|Highlight|}}${OptionValue["${CurrentValueOption}"]}{{[-]}} is not a valid ${CleanVarName}. Please try setting {{|Highlight|}}${CleanVarName}{{[-]}} again."
 								ValueValid="false"
 							fi
 							;;
@@ -470,7 +474,7 @@ menu_value_prompt() {
 									ValueValid="true"
 								else
 									ValueValid="false"
-									dialog_error "${Title}" "${DialogHeading}\n\n{{|Highlight|}}${OptionValue["${CurrentValueOption}"]}{{[-]}} is not a valid port. Please try setting {{|Highlight|}}${CleanVarName}{{[-]}} again."
+									tui_error "${Title}" "${DialogHeading}\n\n{{|Highlight|}}${OptionValue["${CurrentValueOption}"]}{{[-]}} is not a valid port. Please try setting {{|Highlight|}}${CleanVarName}{{[-]}} again."
 								fi
 							else
 								ValueValid="true"
@@ -482,11 +486,9 @@ menu_value_prompt() {
 					if [[ -z ${OptionValue["${CurrentValueOption}"]-} ]]; then
 						if run_script 'question_prompt' --maximized N "${DialogHeading}\n\nDo you really want to delete {{|Highlight|}}${CleanVarName}{{[-]}}?\n" "Delete Variable" "${ASSUMEYES:+Y}" "Delete" "Back"; then
 							# Value is empty, delete the variable
-							coproc {
-								dialog_pipe "{{|TitleSuccess|}}Deleting Variable" "${DialogHeading}" "${DIALOGTIMEOUT}"
-							}
-							local -i DialogBox_PID=${COPROC_PID}
-							local -i DialogBox_FD="${COPROC[1]}"
+							#shellcheck disable=SC2034 # (warning): PipePID is passed by name to tui_pipe_open/close via nameref and appears unused to shellcheck.
+							local -i PipeFD PipePID
+							tui_pipe_open PipeFD PipePID "{{|TitleSuccess|}}Deleting Variable" "${DialogHeading}" "${DIALOGTIMEOUT}"
 							{
 								run_script 'env_delete' "${VarName}"
 								if [[ -n ${APPNAME-} ]]; then
@@ -502,19 +504,16 @@ menu_value_prompt() {
 									run_script 'env_sanitize'
 									run_script 'env_update'
 								fi
-							} >&${DialogBox_FD} 2>&1 || true
-							exec {DialogBox_FD}<&-
-							wait ${DialogBox_PID}
+							} >&${PipeFD} 2>&1 || true
+							tui_pipe_close PipeFD PipePID
 							return 0
 						fi
 					elif [[ ${OptionValue["${CurrentValueOption}"]-} == "${OptionValue["${OriginalValueOption}"]-}" ]]; then
 						if run_script 'question_prompt' --maximized N "${DialogHeading}\n\nThe value of {{|Highlight|}}${CleanVarName}{{[-]}} has not been changed, exit anyways?\n" "Save Variable" "${ASSUMEYES:+Y}" "Done" "Back"; then
 							# Value has not changed, confirm exiting
-							coproc {
-								dialog_pipe "{{|TitleSuccess|}}Canceling Variable Edit" "${DialogHeading}" "${DIALOGTIMEOUT}"
-							}
-							local -i DialogBox_PID=${COPROC_PID}
-							local -i DialogBox_FD="${COPROC[1]}"
+							#shellcheck disable=SC2034 # (warning): PipePID is passed by name to tui_pipe_open/close via nameref and appears unused to shellcheck.
+							local -i PipeFD PipePID
+							tui_pipe_open PipeFD PipePID "{{|TitleSuccess|}}Canceling Variable Edit" "${DialogHeading}" "${DIALOGTIMEOUT}"
 							{
 								if [[ -n ${APPNAME-} ]]; then
 									if ! run_script 'app_is_user_defined' "${APPNAME}"; then
@@ -529,19 +528,16 @@ menu_value_prompt() {
 									run_script 'env_update'
 									run_script 'env_sanitize'
 								fi
-							} >&${DialogBox_FD} 2>&1 || true
-							exec {DialogBox_FD}<&-
-							wait ${DialogBox_PID}
+							} >&${PipeFD} 2>&1 || true
+							tui_pipe_close PipeFD PipePID
 							return 0
 						fi
 					else
 						if run_script 'question_prompt' --maximized N "${DialogHeading}\n\nWould you like to save {{|Highlight|}}${CleanVarName}{{[-]}}?\n" "Save Variable" "${ASSUMEYES:+Y}" "Save" "Back"; then
 							# Value is valid, save it and exit
-							coproc {
-								dialog_pipe "{{|TitleSuccess|}}Saving Variable" "${DialogHeading}" "${DIALOGTIMEOUT}"
-							}
-							local -i DialogBox_PID=${COPROC_PID}
-							local -i DialogBox_FD="${COPROC[1]}"
+							#shellcheck disable=SC2034 # (warning): PipePID is passed by name to tui_pipe_open/close via nameref and appears unused to shellcheck.
+							local -i PipeFD PipePID
+							tui_pipe_open PipeFD PipePID "{{|TitleSuccess|}}Saving Variable" "${DialogHeading}" "${DIALOGTIMEOUT}"
 							{
 								run_script 'env_set_literal' "${VarName}" "${OptionValue["${CurrentValueOption}"]}"
 								if [[ -n ${APPNAME-} ]]; then
@@ -556,19 +552,91 @@ menu_value_prompt() {
 									run_script 'env_update'
 									run_script 'env_sanitize'
 								fi
-							} >&${DialogBox_FD} 2>&1 || true
-							exec {DialogBox_FD}<&-
-							wait ${DialogBox_PID}
+							} >&${PipeFD} 2>&1 || true
+							tui_pipe_close PipeFD PipePID
 							return 0
 						fi
 					fi
 				fi
 				;;
 			*)
-				invalid_dialog_button ${SelectValueDialogButtonPressed}
+				invalid_tui_button ${SelectValueDialogButtonPressed}
 				;;
 		esac
 	done
+}
+
+menu_value_prompt_select_dialog() {
+	dialog_inputmenu "$@"
+}
+
+menu_value_prompt_select_whiptail() {
+	local Title="${1-}"
+	shift || true
+	local Message="${1-}"
+	shift || true
+	#shellcheck disable=SC2034 # (warning): ParsedOptions is passed by name to _whiptail_parse_options_ via nameref and appears unused to shellcheck.
+	local -a ParsedOptions=()
+	#shellcheck disable=SC2034 # (warning): Maximized is passed by name to _whiptail_parse_options_ via nameref and appears unused to shellcheck.
+	local -i _n_=0 Maximized=0
+	_whiptail_parse_options_ ParsedOptions Maximized _n_ "$@"
+	shift "${_n_}"
+	local -a Items=("$@")
+	local -i OptionsLength=0
+	local -i i
+	for ((i = 0; i < ${#Items[@]}; i += 3)); do
+		if [[ ${#Items[i]} -gt OptionsLength ]]; then
+			OptionsLength=${#Items[i]}
+		fi
+	done
+	local EnterCustom="<CUSTOM VALUE>"
+	local CustomBar
+	CustomBar=$(printf "%$(((OptionsLength - ${#EnterCustom}) / 2))s" '')
+	EnterCustom="${CustomBar}${EnterCustom}${CustomBar}"
+	Items+=("${EnterCustom}" "" "")
+	local -a MenuDialog=(
+		"${Title}"
+		"${Message}"
+		--maximized
+		--item-help
+		--ok-label:Select
+		--cancel-label:Done
+		"${Items[@]}"
+	)
+	local -i result=0
+	local Selected
+	Selected=$(tui_menu "${MenuDialog[@]}") || result=$?
+	case ${DIALOG_BUTTONS[result]-} in
+		OK)
+			if [[ ${Selected} == "${EnterCustom}" ]]; then
+				local NewValue
+				NewValue=$(tui_inputbox "${Title}" "${Message}" --maximized) || result=$?
+				case ${DIALOG_BUTTONS[result]-} in
+					OK)
+						echo "RENAMED Current Value ${NewValue}"
+						return "${DIALOG_EXTRA}"
+						;;
+					*)
+						return ${result}
+						;;
+				esac
+			else
+				echo "${Selected}"
+				return "${DIALOG_OK}"
+			fi
+			;;
+		*)
+			return ${result}
+			;;
+	esac
+}
+
+menu_value_prompt_select() {
+	if use_dialog; then
+		menu_value_prompt_select_dialog "$@"
+	else
+		menu_value_prompt_select_whiptail "$@"
+	fi
 }
 
 test_menu_value_prompt() {

--- a/scripts/pm_apk_install_docker.sh
+++ b/scripts/pm_apk_install_docker.sh
@@ -10,7 +10,7 @@ pm_apk_install_docker() {
 	local REDIRECT='&> /dev/null '
 	if [[ -n ${VERBOSE-} ]]; then
 		#shellcheck disable=SC2016 # (info): Expressions don't expand in single quotes, use double quotes for that.
-		REDIRECT='run_command_dialog "${Title}" "${COMMAND}" "" '
+		REDIRECT='run_command_tui "${Title}" "${COMMAND}" "" '
 	fi
 	eval "${REDIRECT}${COMMAND}" ||
 		fatal \

--- a/scripts/pm_apk_upgrade.sh
+++ b/scripts/pm_apk_upgrade.sh
@@ -11,7 +11,7 @@ pm_apk_upgrade() {
 		local REDIRECT='&> /dev/null '
 		if [[ -n ${VERBOSE-} ]]; then
 			#shellcheck disable=SC2016 # (info): Expressions don't expand in single quotes, use double quotes for that.
-			REDIRECT='run_command_dialog "${Title}" "${COMMAND}" "" '
+			REDIRECT='run_command_tui "${Title}" "${COMMAND}" "" '
 		fi
 		eval "${REDIRECT}${COMMAND}" ||
 			fatal \

--- a/scripts/pm_dnf_upgrade.sh
+++ b/scripts/pm_dnf_upgrade.sh
@@ -11,7 +11,7 @@ pm_dnf_upgrade() {
 		local REDIRECT='&> /dev/null '
 		if [[ -n ${VERBOSE-} ]]; then
 			#shellcheck disable=SC2016 # (info): Expressions don't expand in single quotes, use double quotes for that.
-			REDIRECT='run_command_dialog "${Title}" "${COMMAND}" "" '
+			REDIRECT='run_command_tui "${Title}" "${COMMAND}" "" '
 		fi
 		eval "${REDIRECT}${COMMAND}" ||
 			fatal \

--- a/scripts/pm_pacman_install_docker.sh
+++ b/scripts/pm_pacman_install_docker.sh
@@ -10,7 +10,7 @@ pm_pacman_install_docker() {
 	local REDIRECT='&> /dev/null '
 	if [[ -n ${VERBOSE-} ]]; then
 		#shellcheck disable=SC2016 # (info): Expressions don't expand in single quotes, use double quotes for that.
-		REDIRECT='run_command_dialog "${Title}" "${COMMAND}" "" '
+		REDIRECT='run_command_tui "${Title}" "${COMMAND}" "" '
 	fi
 	eval "${REDIRECT}${COMMAND}" ||
 		fatal \

--- a/scripts/pm_pacman_upgrade.sh
+++ b/scripts/pm_pacman_upgrade.sh
@@ -11,7 +11,7 @@ pm_pacman_upgrade() {
 		local REDIRECT='&> /dev/null '
 		if [[ -n ${VERBOSE-} ]]; then
 			#shellcheck disable=SC2016 # (info): Expressions don't expand in single quotes, use double quotes for that.
-			REDIRECT='run_command_dialog "${Title}" "${COMMAND}" "" '
+			REDIRECT='run_command_tui "${Title}" "${COMMAND}" "" '
 		fi
 		eval "${REDIRECT}${COMMAND}" ||
 			fatal \

--- a/scripts/pm_yum_upgrade.sh
+++ b/scripts/pm_yum_upgrade.sh
@@ -11,7 +11,7 @@ pm_yum_upgrade() {
 		local REDIRECT='&> /dev/null '
 		if [[ -n ${VERBOSE-} ]]; then
 			#shellcheck disable=SC2016 # (info): Expressions don't expand in single quotes, use double quotes for that.
-			REDIRECT='run_command_dialog "${Title}" "${COMMAND}" "" '
+			REDIRECT='run_command_tui "${Title}" "${COMMAND}" "" '
 		fi
 		eval "${REDIRECT}${COMMAND}" ||
 			fatal \

--- a/scripts/pm_zypper_upgrade.sh
+++ b/scripts/pm_zypper_upgrade.sh
@@ -11,7 +11,7 @@ pm_zypper_upgrade() {
 		local REDIRECT='&> /dev/null '
 		if [[ -n ${VERBOSE-} ]]; then
 			#shellcheck disable=SC2016 # (info): Expressions don't expand in single quotes, use double quotes for that.
-			REDIRECT='run_command_dialog "${Title}" "${COMMAND}" "" '
+			REDIRECT='run_command_tui "${Title}" "${COMMAND}" "" '
 		fi
 		eval "${REDIRECT}${COMMAND}" ||
 			fatal \

--- a/scripts/question_prompt.sh
+++ b/scripts/question_prompt.sh
@@ -37,7 +37,7 @@ question_prompt() {
 		YN=${Default:-Y}
 	elif [[ -n ${Override-} ]]; then
 		YN="${Override}"
-	elif use_dialog_box; then
+	elif use_tui_box; then
 		local DIALOG_DEFAULT
 		if [[ ${Default} == "N" ]]; then
 			DIALOG_DEFAULT="--defaultno"
@@ -65,7 +65,7 @@ question_prompt() {
 				${DIALOG_DEFAULT-}
 			)
 			local -i YesNoDialogButtonPressed=0
-			dialog_yesno "${YesNoDialog[@]}" || YesNoDialogButtonPressed=$?
+			tui_yesno "${YesNoDialog[@]}" || YesNoDialogButtonPressed=$?
 			case ${DIALOG_BUTTONS[YesNoDialogButtonPressed]-} in
 				OK)
 					YN="Y"
@@ -78,7 +78,7 @@ question_prompt() {
 					break
 					;;
 				*)
-					invalid_dialog_button ${YesNoDialogButtonPressed}
+					invalid_tui_button ${YesNoDialogButtonPressed}
 					;;
 			esac
 		done

--- a/scripts/run_install.sh
+++ b/scripts/run_install.sh
@@ -9,23 +9,22 @@ run_install() {
 	local YesNotice="Installing or updating all {{|ApplicationName|}}${APPLICATION_NAME}{{[-]}} dependencies."
 	local NoNotice="Not installing or updating all {{|ApplicationName|}}${APPLICATION_NAME}{{[-]}} dependencies."
 	if run_script 'question_prompt' Y "${Question}" "${Title}" "${ASSUMEYES:+Y}"; then
-		if use_dialog_box; then
+		#shellcheck disable=SC2034 # (warning): PipePID is passed by name to tui_pipe_open/close via nameref and appears unused to shellcheck.
+		local -i PipeFD PipePID
+		tui_pipe_open PipeFD PipePID "{{|TitleSuccess|}}${Title}" "${YesNotice}\n{{|CommandLine|}} ${CommandLine}"
+		{
 			{
-				{
-					notice "${YesNotice}"
-					run_install_commands
-				} || true
-			} |& dialog_pipe "{{|TitleSuccess|}}${Title}" "${YesNotice}\n{{|CommandLine|}} ${CommandLine}"
-		else
-			notice "${YesNotice}"
-			run_install_commands
-		fi
+				notice "${YesNotice}"
+				run_install_commands
+			} || true
+		} >&${PipeFD} 2>&1
+		tui_pipe_close PipeFD PipePID
 	else
-		if use_dialog_box; then
-			notice "${NoNotice}" |& dialog_pipe "{{|TitleError|}}${Title}" "${NoNotice}"
-		else
-			notice "${NoNotice}"
-		fi
+		#shellcheck disable=SC2034 # (warning): PipePID is passed by name to tui_pipe_open/close via nameref and appears unused to shellcheck.
+		local -i PipeFD PipePID
+		tui_pipe_open PipeFD PipePID "{{|TitleError|}}${Title}" "${NoNotice}"
+		notice "${NoNotice}" >&${PipeFD} 2>&1
+		tui_pipe_close PipeFD PipePID
 	fi
 }
 

--- a/scripts/update_self.sh
+++ b/scripts/update_self.sh
@@ -44,47 +44,41 @@ update_self() {
 	CommandLineText="$(printf '%q ' "${APPLICATION_COMMAND}" "--update" "$@" | xargs)"
 	if ! ds_branch_exists "${Branch}" && ! ds_tag_exists "${Branch}" && ! ds_commit_exists "${Branch}"; then
 		local ErrorMessage="{{|ApplicationName|}}${APPLICATION_NAME}{{[-]}} ref '{{|Branch|}}${Branch}{{[-]}}' does not exist on origin."
-		if use_dialog_box; then
-			error "${ErrorMessage}" |&
-				dialog_pipe "{{|TitleError|}}${Title}" "{{|CommandLine|}} ${CommandLineText}"
-		else
-			error "${ErrorMessage}"
-		fi
+		#shellcheck disable=SC2034 # (warning): PipePID is passed by name to tui_pipe_open/close via nameref and appears unused to shellcheck.
+		local -i PipeFD PipePID
+		tui_pipe_open PipeFD PipePID "{{|TitleError|}}${Title}" "{{|CommandLine|}} ${CommandLineText}"
+		error "${ErrorMessage}" >&${PipeFD} 2>&1
+		tui_pipe_close PipeFD PipePID
 		return 1
 	fi
 
 	if [[ -z ${FORCE-} && ${CurrentVersion} == "${RemoteVersion}" ]]; then
-		if use_dialog_box; then
-			{
-				{
-					notice \
-						"{{|ApplicationName|}}${APPLICATION_NAME}{{[-]}} is already up to date on branch '{{|Branch|}}${Branch}{{[-]}}'." \
-						"Current version is '{{|Version|}}${CurrentVersion}{{[-]}}'"
-				} || true
-			} |& dialog_pipe "{{|TitleWarning|}}${Title}" "{{|CommandLine|}} ${CommandLineText}"
-		else
+		#shellcheck disable=SC2034 # (warning): PipePID is passed by name to tui_pipe_open/close via nameref and appears unused to shellcheck.
+		local -i PipeFD PipePID
+		tui_pipe_open PipeFD PipePID "{{|TitleWarning|}}${Title}" "{{|CommandLine|}} ${CommandLineText}"
+		{
 			notice \
 				"{{|ApplicationName|}}${APPLICATION_NAME}{{[-]}} is already up to date on branch '{{|Branch|}}${Branch}{{[-]}}'." \
-				"Current version is '{{|Version|}}${CurrentVersion}{{[-]}}'"
-		fi
+				"Current version is '{{|Version|}}${CurrentVersion}{{[-]}}'" || true
+		} >&${PipeFD} 2>&1
+		tui_pipe_close PipeFD PipePID
 		return 0
 	fi
 
 	if ! run_script 'question_prompt' Y "${Question}" "${Title}" "${ASSUMEYES:+Y}"; then
-		if use_dialog_box; then
-			{ notice "${NoNotice}" || true; } |& dialog_pipe "{{|TitleError|}}${Title}" "${NoNotice}"
-		else
-			notice "${NoNotice}"
-		fi
+		#shellcheck disable=SC2034 # (warning): PipePID is passed by name to tui_pipe_open/close via nameref and appears unused to shellcheck.
+		local -i PipeFD PipePID
+		tui_pipe_open PipeFD PipePID "{{|TitleError|}}${Title}" "${NoNotice}"
+		{ notice "${NoNotice}" || true; } >&${PipeFD} 2>&1
+		tui_pipe_close PipeFD PipePID
 		return 1
 	fi
 
-	if use_dialog_box; then
-		{ commands_update_self_logic "${Branch}" "${YesNotice}" "$@" |&
-			dialog_pipe "{{|TitleSuccess|}}${Title}" "${YesNotice}\n{{|CommandLine|}} ${CommandLineText}"; } || true
-	else
-		commands_update_self_logic "${Branch}" "${YesNotice}" "$@"
-	fi
+	#shellcheck disable=SC2034 # (warning): PipePID is passed by name to tui_pipe_open/close via nameref and appears unused to shellcheck.
+	local -i PipeFD PipePID
+	tui_pipe_open PipeFD PipePID "{{|TitleSuccess|}}${Title}" "${YesNotice}\n{{|CommandLine|}} ${CommandLineText}"
+	{ commands_update_self_logic "${Branch}" "${YesNotice}" "$@" || true; } >&${PipeFD} 2>&1
+	tui_pipe_close PipeFD PipePID
 
 	local -a CommandArray
 	if [[ -z $* ]]; then

--- a/scripts/update_templates.sh
+++ b/scripts/update_templates.sh
@@ -39,47 +39,41 @@ update_templates() {
 
 	if ! templates_branch_exists "${Branch}" && ! templates_tag_exists "${Branch}" && ! templates_commit_exists "${Branch}"; then
 		local ErrorMessage="{{|ApplicationName|}}${TargetName}{{[-]}} ref '{{|Branch|}}${Branch}{{[-]}}' does not exist on origin."
-		if use_dialog_box; then
-			error "${ErrorMessage}" |&
-				dialog_pipe "{{|TitleError|}}${Title}" "{{|CommandLine|}} ${APPLICATION_COMMAND} --update $*"
-		else
-			error "${ErrorMessage}"
-		fi
+		#shellcheck disable=SC2034 # (warning): PipePID is passed by name to tui_pipe_open/close via nameref and appears unused to shellcheck.
+		local -i PipeFD PipePID
+		tui_pipe_open PipeFD PipePID "{{|TitleError|}}${Title}" "{{|CommandLine|}} ${APPLICATION_COMMAND} --update $*"
+		error "${ErrorMessage}" >&${PipeFD} 2>&1
+		tui_pipe_close PipeFD PipePID
 		return 1
 	fi
 
 	if [[ -z ${FORCE-} && ${CurrentVersion} == "${RemoteVersion}" ]]; then
-		if use_dialog_box; then
-			{
-				{
-					notice \
-						"{{|ApplicationName|}}${TargetName}{{[-]}} is already up to date on branch '{{|Branch|}}${Branch}{{[-]}}'." \
-						"Current version is '{{|Version|}}${CurrentVersion}{{[-]}}'"
-				} || true
-			} |& dialog_pipe "{{|TitleWarning|}}${Title}" "{{|CommandLine|}} ${APPLICATION_COMMAND} --update-templates $*"
-		else
+		#shellcheck disable=SC2034 # (warning): PipePID is passed by name to tui_pipe_open/close via nameref and appears unused to shellcheck.
+		local -i PipeFD PipePID
+		tui_pipe_open PipeFD PipePID "{{|TitleWarning|}}${Title}" "{{|CommandLine|}} ${APPLICATION_COMMAND} --update-templates $*"
+		{
 			notice \
 				"{{|ApplicationName|}}${TargetName}{{[-]}} is already up to date on branch '{{|Branch|}}${Branch}{{[-]}}'." \
-				"Current version is '{{|Version|}}${CurrentVersion}{{[-]}}'"
-		fi
+				"Current version is '{{|Version|}}${CurrentVersion}{{[-]}}'" || true
+		} >&${PipeFD} 2>&1
+		tui_pipe_close PipeFD PipePID
 		return 0
 	fi
 
 	if ! run_script 'question_prompt' Y "${Question}" "${Title}" "${ASSUMEYES:+Y}"; then
-		if use_dialog_box; then
-			{ notice "${NoNotice}" || true; } |& dialog_pipe "{{|TitleError|}}${Title}" "${NoNotice}"
-		else
-			notice "${NoNotice}"
-		fi
+		#shellcheck disable=SC2034 # (warning): PipePID is passed by name to tui_pipe_open/close via nameref and appears unused to shellcheck.
+		local -i PipeFD PipePID
+		tui_pipe_open PipeFD PipePID "{{|TitleError|}}${Title}" "${NoNotice}"
+		{ notice "${NoNotice}" || true; } >&${PipeFD} 2>&1
+		tui_pipe_close PipeFD PipePID
 		return 1
 	fi
 
-	if use_dialog_box; then
-		{ commands_update_templates "${Branch}" "${YesNotice}" "$@" || true; } |&
-			dialog_pipe "{{|TitleSuccess|}}${Title}" "${YesNotice}\n{{|CommandLine|}} ${APPLICATION_COMMAND} --update $*"
-	else
-		commands_update_templates "${Branch}" "${YesNotice}" "$@"
-	fi
+	#shellcheck disable=SC2034 # (warning): PipePID is passed by name to tui_pipe_open/close via nameref and appears unused to shellcheck.
+	local -i PipeFD PipePID
+	tui_pipe_open PipeFD PipePID "{{|TitleSuccess|}}${Title}" "${YesNotice}\n{{|CommandLine|}} ${APPLICATION_COMMAND} --update $*"
+	{ commands_update_templates "${Branch}" "${YesNotice}" "$@" || true; } >&${PipeFD} 2>&1
+	tui_pipe_close PipeFD PipePID
 }
 
 commands_update_templates() {


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Introduce a generic TUI layer that supports both dialog and whiptail as display engines, and wire it through the CLI and configuration system.

New Features:
- Allow selecting between dialog and whiptail as the TUI display engine via config and CLI.
- Add a Display Engine options menu and associated configuration commands.
- Support whiptail-based implementations of existing dialog interactions, including menus, forms, gauges, and prompts.

Enhancements:
- Refactor dialog-specific functions into generic TUI helpers and unify GUI piping and progress handling.
- Extend UI configuration options (including large buttons) and ensure defaults are populated from the bundled TOML.
- Improve automatic detection and setup of compose folders and ensure config is created/applied consistently.
- Update dependency checks, usage text, and config display output to reflect the new TUI capabilities.

Tests:
- Add no-op CI test stubs for new configuration and menu scripts related to display engine selection.