### PR TITLE
Fix reference to old "LineCharacters" display option

### DIFF
--- a/includes/misc_functions.sh
+++ b/includes/misc_functions.sh
@@ -287,7 +287,7 @@ table_pipe() {
 	readarray -t ColWidths < <(longest_columns "${Cols}" "${VisibleData[@]}")
 
 	local -A CharSet
-	if is_false "${D["ui.LineCharacters"]-}" || in_tui_box; then
+	if is_false "${D["ui.line_characters"]-}" || in_tui_box; then
 		CharSet=(
 			["TopLeft"]="+"
 			["TopRight"]="+"


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Bug Fixes:
- Fix use of deprecated ui.LineCharacters setting by switching to the correct ui.line_characters option when determining table character set.