### PR TITLE
Refactor to remove usage of `xargs` and subshells

### DIFF
--- a/includes/cmdline.sh
+++ b/includes/cmdline.sh
@@ -334,8 +334,10 @@ parse_arguments() {
 				-\?)
 					# Unknown '-o'
 					local PreviousArgsString
-					PreviousArgsString="${APPLICATION_COMMAND} $(xargs <<< "${ParsedArgs[@]-}")"
-					PreviousArgsString="$(xargs <<< "${PreviousArgsString}")"
+					local -a ArgsList
+					IFS=' ' read -ra ArgsList <<< "${APPLICATION_COMMAND} ${ParsedArgs[*]-}"
+					printf -v PreviousArgsString '%s ' "${ArgsList[@]}"
+					PreviousArgsString="${PreviousArgsString% }"
 					cmdline_error \
 						"" \
 						"Invalid option %o" \
@@ -356,8 +358,10 @@ parse_arguments() {
 		if [[ OPTIND -eq 1 && ${OPTIND} -le $# ]]; then
 			# Unknown 'option'
 			local PreviousArgsString
-			PreviousArgsString="${APPLICATION_COMMAND} $(xargs <<< "${ParsedArgs[@]-}")"
-			PreviousArgsString="$(xargs <<< "${PreviousArgsString}")"
+			local -a ArgsList
+			IFS=' ' read -ra ArgsList <<< "${APPLICATION_COMMAND} ${ParsedArgs[*]-}"
+			printf -v PreviousArgsString '%s ' "${ArgsList[@]}"
+			PreviousArgsString="${PreviousArgsString% }"
 			cmdline_error \
 				"" \
 				"Invalid option %o" \
@@ -738,17 +742,23 @@ run_command() {
 						"{{|ApplicationName|}}${APPLICATION_NAME}{{[-]}} ref '{{|Branch|}}${AppBranch}{{[-]}}' does not exist."
 					exit 1
 				fi
-				resolve_strings C "{{|ApplicationName|}}${APPLICATION_NAME}{{[-]}} [{{|Version|}}$(ds_version "${AppBranch}"){{[-]}}]"
+				local AppVersion
+				ds_version_into AppVersion "${AppBranch}"
+				resolve_strings C "{{|ApplicationName|}}${APPLICATION_NAME}{{[-]}} [{{|Version|}}${AppVersion}{{[-]}}]"
 			fi
 			if [[ -z ${TemplatesBranch} ]]; then
-				resolve_strings C "{{|ApplicationName|}}${TEMPLATES_NAME}{{[-]}} [{{|Version|}}$(templates_version){{[-]}}]"
+				local TempVersion
+				templates_version_into TempVersion
+				resolve_strings C "{{|ApplicationName|}}${TEMPLATES_NAME}{{[-]}} [{{|Version|}}${TempVersion}{{[-]}}]"
 			else
 				if ! templates_ref_exists "${TemplatesBranch}"; then
 					error \
 						"{{|ApplicationName|}}${TEMPLATES_NAME}{{[-]}} ref '{{|Branch|}}${TemplatesBranch}{{[-]}}' does not exist."
 					exit 1
 				fi
-				resolve_strings C "{{|ApplicationName|}}${TEMPLATES_NAME}{{[-]}} [{{|Version|}}$(templates_version "${TemplatesBranch}"){{[-]}}]"
+				local TempVersion
+				templates_version_into TempVersion "${TemplatesBranch}"
+				resolve_strings C "{{|ApplicationName|}}${TEMPLATES_NAME}{{[-]}} [{{|Version|}}${TempVersion}{{[-]}}]"
 			fi
 			;;
 
@@ -955,7 +965,9 @@ run_command() {
 			#shellcheck disable=SC2034 # (warning): PipePID is passed by name to tui_pipe_open/close via nameref and appears unused to shellcheck.
 			local -i PipeFD PipePID
 			tui_pipe_open PipeFD PipePID "${Title}" "${SubTitle}" ""
-			for AppName in $(xargs -n1 <<< "${ParamsArray[0]}"); do
+			local -a AppList
+			IFS=$' \t\n\r' read -d '' -ra AppList <<< "${ParamsArray[0]}" || true
+			for AppName in "${AppList[@]}"; do
 				run_script "${Script}" "${AppName}"
 			done >&${PipeFD} 2>&1 || result=$?
 			tui_pipe_close PipeFD PipePID

--- a/includes/ds_functions.sh
+++ b/includes/ds_functions.sh
@@ -12,12 +12,25 @@ git_fetch() {
 	fi
 }
 
-git_branch() {
-	local GitPath=${1}
-	local DefaultBranch=${2-}
-	local LegacyBranch=${3-}
+git_branch_into() {
+	local -n _gbi_out_="${1}"
+	assert_nameref_is_string "${1}"
+	local GitPath=${2}
+	local DefaultBranch=${3-}
+	local LegacyBranch=${4-}
 	git_fetch "${GitPath}"
-	git -C "${GitPath}" symbolic-ref --short HEAD 2> /dev/null || git -C "${GitPath}" describe --tags --exact-match 2> /dev/null || git_best_branch "${GitPath}" "${DefaultBranch-}" "${LegacyBranch-}"
+	local _gbi_val_
+	_gbi_val_=$(git -C "${GitPath}" symbolic-ref --short HEAD 2> /dev/null || git -C "${GitPath}" describe --tags --exact-match 2> /dev/null) || true
+	if [[ -z ${_gbi_val_} ]]; then
+		git_best_branch_into _gbi_val_ "${GitPath}" "${DefaultBranch-}" "${LegacyBranch-}"
+	fi
+	_gbi_out_="${_gbi_val_}"
+}
+
+git_branch() {
+	local result
+	git_branch_into result "$@"
+	echo "${result}"
 }
 
 git_branch_exists() {
@@ -45,10 +58,12 @@ git_commit_exists() {
 	return ${result}
 }
 
-git_version() {
-	local GitPath=${1}
-	local CheckBranch=${2-}
-	local commitish Branch result
+git_version_into() {
+	local -n _gvi_out_="${1}"
+	assert_nameref_is_string "${1}"
+	local GitPath=${2}
+	local CheckBranch=${3-}
+	local commitish Branch
 
 	if [[ -n ${CheckBranch-} ]]; then
 		if git -C "${GitPath}" show-ref --quiet --tags "${CheckBranch}" &> /dev/null; then
@@ -59,8 +74,7 @@ git_version() {
 			Branch="${CheckBranch}"
 		elif git -C "${GitPath}" rev-parse --quiet --verify "${CheckBranch}^{commit}" &> /dev/null; then
 			commitish="${CheckBranch}"
-			# Try to find a branch name if we were given a SHA
-			Branch="$(git_best_branch "${GitPath}")"
+			git_best_branch_into Branch "${GitPath}"
 			if [[ -z ${Branch-} ]]; then
 				Branch="${CheckBranch}"
 			fi
@@ -70,19 +84,17 @@ git_version() {
 		fi
 	else
 		commitish='HEAD'
-		# We need to know which repo we're in to pass the right defaults to git_branch
 		if [[ ${GitPath} == "${SCRIPTPATH}" ]]; then
-			Branch="$(ds_branch)"
+			ds_branch_into Branch
 		elif [[ ${GitPath} == "${TEMPLATES_PARENT_FOLDER}" ]]; then
-			Branch="$(templates_branch)"
+			templates_branch_into Branch
 		else
-			Branch="$(git_branch "${GitPath}")"
+			git_branch_into Branch "${GitPath}"
 		fi
 	fi
 
+	local VersionString=''
 	if [[ -z ${CheckBranch-} ]] || git_branch_exists "${GitPath}" "${Branch}" || git_tag_exists "${GitPath}" "${Branch}" || git_commit_exists "${GitPath}" "${Branch}"; then
-		# Get the current tag. If no tag, use the commit instead.
-		local VersionString
 		VersionString="$(git -C "${GitPath}" describe --tags --exact-match "${commitish}" 2> /dev/null || true)"
 		if [[ -n ${VersionString-} ]]; then
 			if [[ ${VersionString} != "${Branch}" ]] && [[ ${Branch} != "main" || ${VersionString} == "main" ]]; then
@@ -97,10 +109,14 @@ git_version() {
 				VersionString="${Branch} commit ${CommitHash}"
 			fi
 		fi
-	else
-		VersionString=''
 	fi
-	echo "${VersionString}"
+	_gvi_out_="${VersionString}"
+}
+
+git_version() {
+	local result
+	git_version_into result "$@"
+	echo "${result}"
 }
 
 git_update_available() {
@@ -142,29 +158,51 @@ ds_fetch() {
 	local ForceRefresh=${1-false}
 	git_fetch "${SCRIPTPATH}" "${ForceRefresh}"
 }
-ds_branch() {
-	git_branch "${SCRIPTPATH}" "${APPLICATION_DEFAULT_BRANCH-}" "${APPLICATION_LEGACY_BRANCH-}"
+
+ds_branch_into() {
+	local -n _dbi_out_="${1}"
+	assert_nameref_is_string "${1}"
+	git_branch_into _dbi_out_ "${SCRIPTPATH}" "${APPLICATION_DEFAULT_BRANCH-}" "${APPLICATION_LEGACY_BRANCH-}"
 }
+
+ds_branch() {
+	local result
+	ds_branch_into result "$@"
+	echo "${result}"
+}
+
 ds_branch_exists() {
 	local Branch=${1-}
 	git_branch_exists "${SCRIPTPATH}" "${Branch-}"
 }
+
 ds_tag_exists() {
 	local Tag=${1-}
 	git_tag_exists "${SCRIPTPATH}" "${Tag-}"
 }
+
 ds_commit_exists() {
 	local Commit=${1-}
 	git_commit_exists "${SCRIPTPATH}" "${Commit-}"
 }
+
 ds_ref_exists() {
 	local Ref=${1-}
 	ds_branch_exists "${Ref}" || ds_tag_exists "${Ref}" || ds_commit_exists "${Ref}"
 }
-ds_version() {
-	local Branch=${1-}
-	git_version "${SCRIPTPATH}" "${Branch-}"
+
+ds_version_into() {
+	local -n _dvi_out_="${1}"
+	assert_nameref_is_string "${1}"
+	git_version_into _dvi_out_ "${SCRIPTPATH}" "${2-}"
 }
+
+ds_version() {
+	local result
+	ds_version_into result "$@"
+	echo "${result}"
+}
+
 ds_update_available() {
 	local CurrentRef=${1-}
 	local TargetRef=${2-}
@@ -175,29 +213,51 @@ templates_fetch() {
 	local ForceRefresh=${1-false}
 	git_fetch "${TEMPLATES_PARENT_FOLDER}" "${ForceRefresh}"
 }
-templates_branch() {
-	git_branch "${TEMPLATES_PARENT_FOLDER}" "${TEMPLATES_DEFAULT_BRANCH-}"
+
+templates_branch_into() {
+	local -n _tbi_out_="${1}"
+	assert_nameref_is_string "${1}"
+	git_branch_into _tbi_out_ "${TEMPLATES_PARENT_FOLDER}" "${TEMPLATES_DEFAULT_BRANCH-}"
 }
+
+templates_branch() {
+	local result
+	templates_branch_into result "$@"
+	echo "${result}"
+}
+
 templates_branch_exists() {
 	local Branch=${1-}
 	git_branch_exists "${TEMPLATES_PARENT_FOLDER}" "${Branch-}"
 }
+
 templates_tag_exists() {
 	local Tag=${1-}
 	git_tag_exists "${TEMPLATES_PARENT_FOLDER}" "${Tag-}"
 }
+
 templates_commit_exists() {
 	local Commit=${1-}
 	git_commit_exists "${TEMPLATES_PARENT_FOLDER}" "${Commit-}"
 }
+
 templates_ref_exists() {
 	local Ref=${1-}
 	templates_branch_exists "${Ref}" || templates_tag_exists "${Ref}" || templates_commit_exists "${Ref}"
 }
-templates_version() {
-	local Branch=${1-}
-	git_version "${TEMPLATES_PARENT_FOLDER}" "${Branch-}"
+
+templates_version_into() {
+	local -n _tvi_out_="${1}"
+	assert_nameref_is_string "${1}"
+	git_version_into _tvi_out_ "${TEMPLATES_PARENT_FOLDER}" "${2-}"
 }
+
+templates_version() {
+	local result
+	templates_version_into result "$@"
+	echo "${result}"
+}
+
 templates_update_available() {
 	local CurrentRef=${1-}
 	local TargetRef=${2-}
@@ -206,7 +266,7 @@ templates_update_available() {
 
 ds_switch_branch() {
 	local CurrentBranch
-	CurrentBranch="$(ds_branch)"
+	ds_branch_into CurrentBranch
 	if [[ ${CurrentBranch} == "${APPLICATION_LEGACY_BRANCH}" ]] && ds_branch_exists "${APPLICATION_DEFAULT_BRANCH}"; then
 		export FORCE=true
 		export PROMPT="CLI"
@@ -217,12 +277,13 @@ ds_switch_branch() {
 	fi
 }
 
-git_best_branch() {
-	local GitPath=${1}
-	local DefaultBranch=${2-}
-	local LegacyBranch=${3-}
+git_best_branch_into() {
+	local -n _gbbi_out_="${1}"
+	assert_nameref_is_string "${1}"
+	local GitPath=${2}
+	local DefaultBranch=${3-}
+	local LegacyBranch=${4-}
 	local -a Branches=()
-	# Get remote branches containing current HEAD
 	readarray -t Branches < <(git -C "${GitPath}" branch -r --contains HEAD 2> /dev/null | sed 's/^[[:space:]]*origin\///' | grep -v 'HEAD ->')
 	local BestBranch=""
 	if [[ ${#Branches[@]} -gt 0 ]]; then
@@ -259,13 +320,35 @@ git_best_branch() {
 	if [[ -z ${BestBranch} ]]; then
 		BestBranch="${DefaultBranch}"
 	fi
-	echo "${BestBranch}"
+	_gbbi_out_="${BestBranch}"
+}
+
+git_best_branch() {
+	local result
+	git_best_branch_into result "$@"
+	echo "${result}"
+}
+
+ds_best_branch_into() {
+	local -n _dbbi_out_="${1}"
+	assert_nameref_is_string "${1}"
+	git_best_branch_into _dbbi_out_ "${SCRIPTPATH}" "${APPLICATION_DEFAULT_BRANCH-}" "${APPLICATION_LEGACY_BRANCH-}"
 }
 
 ds_best_branch() {
-	git_best_branch "${SCRIPTPATH}" "${APPLICATION_DEFAULT_BRANCH-}" "${APPLICATION_LEGACY_BRANCH-}"
+	local result
+	ds_best_branch_into result "$@"
+	echo "${result}"
+}
+
+templates_best_branch_into() {
+	local -n _tbbi_out_="${1}"
+	assert_nameref_is_string "${1}"
+	git_best_branch_into _tbbi_out_ "${TEMPLATES_PARENT_FOLDER}" "${TEMPLATES_DEFAULT_BRANCH-}"
 }
 
 templates_best_branch() {
-	git_best_branch "${TEMPLATES_PARENT_FOLDER}" "${TEMPLATES_DEFAULT_BRANCH-}"
+	local result
+	templates_best_branch_into result "$@"
+	echo "${result}"
 }

--- a/includes/misc_functions.sh
+++ b/includes/misc_functions.sh
@@ -30,9 +30,14 @@ strip_dialog_colors() {
 
 # Take whitespace and newline delimited words and output a single line highlighted list for dialog
 highlighted_list() {
-	local List
-	List=$(xargs <<< "$*")
-	if [[ -n ${List-} ]]; then
+	local -a ListArray
+	IFS=$' \t\n\r' read -d '' -ra ListArray <<< "$*" || true
+	if [[ ${#ListArray[@]} -gt 0 ]]; then
+		local List
+		local old_IFS="${IFS}"
+		IFS=' '
+		List="${ListArray[*]}"
+		IFS="${old_IFS}"
 		echo "{{|Subtitle|}}${List// /{{[-]}} {{|Subtitle|}}}{{[-]}}"
 	fi
 }

--- a/includes/tui_functions.sh
+++ b/includes/tui_functions.sh
@@ -91,14 +91,18 @@ _tui_backtitle_() {
 	local TemplatesVersionColor="{{|ApplicationVersion|}}"
 
 	local CurrentVersion
-	CurrentVersion="$(ds_version)"
+	ds_version_into CurrentVersion
 	if [[ -z ${CurrentVersion} ]]; then
-		CurrentVersion="$(ds_branch) Unknown Version"
+		local _ds_br_
+		ds_branch_into _ds_br_
+		CurrentVersion="${_ds_br_} Unknown Version"
 	fi
 	local CurrentTemplatesVersion
-	CurrentTemplatesVersion="$(templates_version)"
+	templates_version_into CurrentTemplatesVersion
 	if [[ -z ${CurrentTemplatesVersion} ]]; then
-		CurrentTemplatesVersion="$(templates_branch) Unknown Version"
+		local _temp_br_
+		templates_branch_into _temp_br_
+		CurrentTemplatesVersion="${_temp_br_} Unknown Version"
 	fi
 	if ds_update_available; then
 		ApplicationUpdateFlag=${UpdateFlag}
@@ -178,11 +182,18 @@ _whiptail_() {
 	${WHIPTAIL} "${WHIPTAIL_OPTIONS[@]}" --backtitle "${BACKTITLE}" "${WhiptailOptions[@]}" 3>&1 1>&2 2>&3
 }
 
+tui_box_enter() {
+	declare -gx TUI_IN_BOX=$((${TUI_IN_BOX:-0} + 1))
+}
+tui_box_exit() {
+	declare -gx TUI_IN_BOX=$((${TUI_IN_BOX:-0} - 1))
+	if [[ ${TUI_IN_BOX:-0} -le 0 ]]; then
+		unset TUI_IN_BOX
+	fi
+}
 # Check to see if we are already inside a dialog box
 in_tui_box() {
-	# If we are in GUI mode, AND stdout is redirected, AND stderr is ALSO redirected
-	# then we are almost certainly inside a '|& tui_pipe' call.
-	[[ ${PROMPT:-CLI} == GUI && ! -t 1 && ! -t 2 ]]
+	[[ ${TUI_IN_BOX:-0} -gt 0 || ${TUI_IN_BOX-} == true ]]
 }
 
 # Check to see if we should use a dialog box
@@ -236,6 +247,7 @@ tui_pipe_open() {
 		}
 		_tpo_fd_=${COPROC[1]}
 		_tpo_pid_=${COPROC_PID}
+		tui_box_enter
 	else
 		_tpo_fd_=1
 		_tpo_pid_=0
@@ -248,6 +260,7 @@ tui_pipe_close() {
 		local _tpc_fd_val_=${_tpc_fd_}
 		exec {_tpc_fd_val_}<&- &> /dev/null || true
 		wait "${_tpc_pid_}" &> /dev/null || true
+		tui_box_exit
 	fi
 }
 
@@ -264,7 +277,9 @@ dialog_run_script() {
 		local -i DialogBox_PID=${COPROC_PID}
 		local -i DialogBox_FD="${COPROC[1]}"
 		local -i result=0
+		tui_box_enter
 		run_script "${SCRIPTSNAME}" "$@" >&${DialogBox_FD} 2>&1 || result=$?
+		tui_box_exit
 		exec {DialogBox_FD}<&- &> /dev/null || true
 		wait ${DialogBox_PID} &> /dev/null || true
 		return ${result}
@@ -295,7 +310,7 @@ dialog_run_command() {
 	local CommandName=${4-}
 	shift 4
 	if [[ -n ${CommandName-} ]]; then
-		"${CommandName}" "$@" |& dialog_pipe "${Title}" "${SubTitle}" "${TimeOut}"
+		TUI_IN_BOX=1 "${CommandName}" "$@" |& dialog_pipe "${Title}" "${SubTitle}" "${TimeOut}"
 		return "${PIPESTATUS[0]}"
 	fi
 }
@@ -762,13 +777,6 @@ whiptail_inputbox() {
 	echo -n "${S["BS"]}" >&2
 	return ${result}
 }
-tui_inputbox() {
-	if use_dialog; then
-		dialog_inputbox "$@"
-	else
-		whiptail_inputbox "$@"
-	fi
-}
 
 dialog_form() {
 	local Title="${1-}"
@@ -904,13 +912,6 @@ whiptail_menu() {
 	echo -n "${S["BS"]}" >&2
 	return ${result}
 }
-tui_menu() {
-	if use_dialog; then
-		dialog_menu "$@"
-	else
-		whiptail_menu "$@"
-	fi
-}
 
 dialog_checklist() {
 	local Title="${1-}"
@@ -987,13 +988,6 @@ whiptail_checklist() {
 	_whiptail_ "${WhiptailOptions[@]}" --checklist "${SubTitle}" "${WindowHeight}" "${WindowWidth}" "${MenuHeight}" "${Items[@]}" || result=$?
 	echo -n "${S["BS"]}" >&2
 	return ${result}
-}
-tui_checklist() {
-	if use_dialog; then
-		dialog_checklist "$@"
-	else
-		whiptail_checklist "$@"
-	fi
 }
 
 dialog_radiolist() {
@@ -1072,13 +1066,6 @@ whiptail_radiolist() {
 	echo -n "${S["BS"]}" >&2
 	return ${result}
 }
-tui_radiolist() {
-	if use_dialog; then
-		dialog_radiolist "$@"
-	else
-		whiptail_radiolist "$@"
-	fi
-}
 
 dialog_inputmenu() {
 	local Title="${1-}"
@@ -1119,4 +1106,68 @@ invalid_tui_button() {
 	local -l NoticeType=${2:-fatal}
 	local DialogButton="${DIALOG_BUTTONS[DialogButtonNumber]-#${DialogButtonNumber}}"
 	${NoticeType} "Unexpected dialog button '{{|ButtonName|}}${DialogButton}{{[-]}}' pressed."
+}
+
+tui_inputbox_into() {
+	local -n _tibi_out_="${1}"
+	assert_nameref_is_string "${1}"
+	shift
+	local -i result=0
+	local temp_file="${TEMP_FOLDER}/${APPLICATION_NAME,,}.${FUNCNAME[0]}.$$.tmp"
+	if use_dialog; then
+		dialog_inputbox "$@" > "${temp_file}" || result=$?
+	else
+		whiptail_inputbox "$@" > "${temp_file}" || result=$?
+	fi
+	read -r _tibi_out_ < "${temp_file}" || true
+	rm -f "${temp_file}"
+	return ${result}
+}
+
+tui_menu_into() {
+	local -n _tbmi_out_="${1}"
+	assert_nameref_is_string "${1}"
+	shift
+	local -i result=0
+	local temp_file="${TEMP_FOLDER}/${APPLICATION_NAME,,}.${FUNCNAME[0]}.$$.tmp"
+	if use_dialog; then
+		dialog_menu "$@" > "${temp_file}" || result=$?
+	else
+		whiptail_menu "$@" > "${temp_file}" || result=$?
+	fi
+	read -r _tbmi_out_ < "${temp_file}" || true
+	rm -f "${temp_file}"
+	return ${result}
+}
+
+tui_checklist_into_array() {
+	local -n _tcia_out_="${1}"
+	assert_nameref_is_array "${1}"
+	shift
+	local -i result=0
+	local temp_file="${TEMP_FOLDER}/${APPLICATION_NAME,,}.${FUNCNAME[0]}.$$.tmp"
+	if use_dialog; then
+		dialog_checklist "$@" > "${temp_file}" || result=$?
+	else
+		whiptail_checklist "$@" > "${temp_file}" || result=$?
+	fi
+	readarray -t _tcia_out_ < "${temp_file}"
+	rm -f "${temp_file}"
+	return ${result}
+}
+
+tui_radiolist_into() {
+	local -n _tbri_out_="${1}"
+	assert_nameref_is_string "${1}"
+	shift
+	local -i result=0
+	local temp_file="${TEMP_FOLDER}/${APPLICATION_NAME,,}.${FUNCNAME[0]}.$$.tmp"
+	if use_dialog; then
+		dialog_radiolist "$@" > "${temp_file}" || result=$?
+	else
+		whiptail_radiolist "$@" > "${temp_file}" || result=$?
+	fi
+	read -r _tbri_out_ < "${temp_file}" || true
+	rm -f "${temp_file}"
+	return ${result}
 }

--- a/main.sh
+++ b/main.sh
@@ -937,15 +937,19 @@ declare -gx APPLICATION_VERSION="Unknown Version"
 declare -gx TEMPLATES_VERSION="Unknown Version"
 if check_repo; then
 	if declare -F ds_version > /dev/null; then
-		APPLICATION_VERSION="$(ds_version)"
+		ds_version_into APPLICATION_VERSION
 		if [[ -z ${APPLICATION_VERSION} ]]; then
-			APPLICATION_VERSION="$(ds_branch) Unknown Version"
+			declare _ds_br_
+			ds_branch_into _ds_br_
+			APPLICATION_VERSION="${_ds_br_} Unknown Version"
 		fi
 	fi
 	if declare -F templates_version > /dev/null; then
-		TEMPLATES_VERSION="$(templates_version)"
+		templates_version_into TEMPLATES_VERSION
 		if [[ -z ${TEMPLATES_VERSION} ]]; then
-			TEMPLATES_VERSION="$(templates_branch) Unknown Version"
+			declare _temp_br_
+			templates_branch_into _temp_br_
+			TEMPLATES_VERSION="${_temp_br_} Unknown Version"
 		fi
 	fi
 fi
@@ -1029,17 +1033,19 @@ init_check_update() {
 	# Only check for updates once per 24 hours, as it can be quite slow.
 	[ -n "$(find "${APPLICATION_UPDATE_RECORD}" -mtime -1 2> /dev/null)" ] && return
 	local Branch
-	Branch="$(ds_branch)"
+	ds_branch_into Branch
 	local TargetBranch="${Branch}"
 	if ds_tag_exists "${Branch}"; then
-		TargetBranch="$(ds_best_branch)"
+		ds_best_branch_into TargetBranch
 	fi
 	if ds_ref_exists "${Branch}"; then
 		if ds_update_available "${Branch}" "${TargetBranch}"; then
+			local TargetVersion
+			ds_version_into TargetVersion "${TargetBranch}"
 			warn \
 				"{{|ApplicationName|}}${APPLICATION_NAME}{{[-]}} [{{|Version|}}${APPLICATION_VERSION}{{[-]}}]" \
 				"An update to {{|ApplicationName|}}${APPLICATION_NAME}{{[-]}} is available." \
-				"Run '{{|UserCommand|}}${APPLICATION_COMMAND} -u{{[-]}}' to update to version '{{|Version|}}$(ds_version "${TargetBranch}"){{[-]}}'."
+				"Run '{{|UserCommand|}}${APPLICATION_COMMAND} -u{{[-]}}' to update to version '{{|Version|}}${TargetVersion}{{[-]}}'."
 		else
 			info \
 				"{{|ApplicationName|}}${APPLICATION_NAME}{{[-]}} [{{|Version|}}${APPLICATION_VERSION}{{[-]}}]"
@@ -1049,43 +1055,53 @@ init_check_update() {
 		if ! ds_branch_exists "${MainBranch}"; then
 			MainBranch="${APPLICATION_LEGACY_BRANCH}"
 		fi
+		local CurrentVersion
+		ds_version_into CurrentVersion
 		warn \
 			"{{|ApplicationName|}}${APPLICATION_NAME}{{[-]}} branch '{{|Branch|}}${Branch}{{[-]}}' appears to no longer exist." \
-			"{{|ApplicationName|}}${APPLICATION_NAME}{{[-]}} is currently on version '{{|Version|}}$(ds_version){{[-]}}'."
+			"{{|ApplicationName|}}${APPLICATION_NAME}{{[-]}} is currently on version '{{|Version|}}${CurrentVersion}{{[-]}}'."
 		if ! ds_branch_exists "${MainBranch}"; then
 			error \
 				"{{|ApplicationName|}}${APPLICATION_NAME}{{[-]}} does not appear to have a '{{|Branch|}}${APPLICATION_DEFAULT_BRANCH}{{[-]}}' or '{{|Branch|}}${APPLICATION_LEGACY_BRANCH}{{[-]}}' branch."
 		else
+			local MainVersion
+			ds_version_into MainVersion "${MainBranch}"
 			warn \
-				"Run '{{|UserCommand|}}${APPLICATION_COMMAND} -u ${MainBranch}{{[-]}}' to update to the latest stable release '{{|Version|}}$(ds_version "${MainBranch}"){{[-]}}'."
+				"Run '{{|UserCommand|}}${APPLICATION_COMMAND} -u ${MainBranch}{{[-]}}' to update to the latest stable release '{{|Version|}}${MainVersion}{{[-]}}'."
 		fi
 	fi
-	Branch="$(templates_branch)"
+	templates_branch_into Branch
 	local TargetBranch="${Branch}"
 	if templates_tag_exists "${Branch}"; then
-		TargetBranch="$(templates_best_branch)"
+		templates_best_branch_into TargetBranch
 	fi
 	if templates_ref_exists "${Branch}"; then
 		if templates_update_available "${Branch}" "${TargetBranch}"; then
+			local TargetVersion
+			templates_version_into TargetVersion "${TargetBranch}"
 			warn \
 				"{{|ApplicationName|}}${TEMPLATES_NAME}{{[-]}} [{{|Version|}}${TEMPLATES_VERSION}{{[-]}}]" \
 				"An update to {{|ApplicationName|}}${TEMPLATES_NAME}{{[-]}} is available." \
-				"Run '{{|UserCommand|}}${APPLICATION_COMMAND} -u{{[-]}}' to update to version '{{|Version|}}$(templates_version "${TargetBranch}"){{[-]}}'."
+				"Run '{{|UserCommand|}}${APPLICATION_COMMAND} -u{{[-]}}' to update to version '{{|Version|}}${TargetVersion}{{[-]}}'."
 		else
 			info \
 				"{{|ApplicationName|}}${TEMPLATES_NAME}{{[-]}} [{{|Version|}}${TEMPLATES_VERSION}{{[-]}}]"
 		fi
 	else
 		Branch="${TEMPLATES_DEFAULT_BRANCH}"
+		local CurrentVersion
+		templates_version_into CurrentVersion
 		warn \
 			"{{|ApplicationName|}}${TEMPLATES_NAME}{{[-]}} branch '{{|Branch|}}${Branch}{{[-]}}' appears to no longer exist." \
-			"{{|ApplicationName|}}${TEMPLATES_NAME}{{[-]}} is currently on version '{{|Version|}}$(templates_version){{[-]}}'."
+			"{{|ApplicationName|}}${TEMPLATES_NAME}{{[-]}} is currently on version '{{|Version|}}${CurrentVersion}{{[-]}}'."
 		if ! templates_branch_exists "${Branch}"; then
 			error \
 				"{{|ApplicationName|}}${TEMPLATES_NAME}{{[-]}} does not appear to have a '{{|Branch|}}${TEMPLATES_DEFAULT_BRANCH}{{[-]}}' branch."
 		else
+			local StableVersion
+			templates_version_into StableVersion "${Branch}"
 			warn \
-				"Run '{{|UserCommand|}}${APPLICATION_COMMAND} -u ${Branch}{{[-]}}' to update to the latest stable release '{{|Version|}}$(templates_version "${Branch}"){{[-]}}'."
+				"Run '{{|UserCommand|}}${APPLICATION_COMMAND} -u ${Branch}{{[-]}}' to update to the latest stable release '{{|Version|}}${StableVersion}{{[-]}}'."
 		fi
 	fi
 	touch "${APPLICATION_UPDATE_RECORD}"

--- a/scripts/app_filter_runnable.sh
+++ b/scripts/app_filter_runnable.sh
@@ -3,9 +3,9 @@ set -Eeuo pipefail
 IFS=$'\n\t'
 
 app_filter_runnable() {
-	local AppList
-	AppList="$(xargs -n 1 <<< "$*")"
-	for AppName in ${AppList}; do
+	local -a AppList
+	IFS=$' \t\n\r' read -d '' -ra AppList <<< "$*" || true
+	for AppName in "${AppList[@]}"; do
 		local -l basename
 		run_script 'appname_to_baseappname_into' basename "${AppName}"
 		local main_yml="${TEMPLATES_FOLDER}/${basename}/${basename}.yml"

--- a/scripts/app_filter_runnable_into_array.sh
+++ b/scripts/app_filter_runnable_into_array.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+declare -a _dependencies_list=()
+
+app_filter_runnable_into_array() {
+	local -n _afri_out_="${1}"
+	assert_nameref_is_array "${1}"
+	shift
+	_afri_out_=()
+	for _afri_app_ in "$@"; do
+		local -l _afri_base_
+		run_script 'appname_to_baseappname_into' _afri_base_ "${_afri_app_}"
+		local _afri_main_yml_="${TEMPLATES_FOLDER}/${_afri_base_}/${_afri_base_}.yml"
+		local _afri_arch_yml_="${TEMPLATES_FOLDER}/${_afri_base_}/${_afri_base_}.${ARCH}.yml"
+		if [[ -f ${_afri_main_yml_} && -f ${_afri_arch_yml_} ]]; then
+			_afri_out_+=("${_afri_app_}")
+		fi
+	done
+}
+
+test_app_filter_runnable_into_array() {
+	warn "CI does not test app_filter_runnable_into_array."
+}

--- a/scripts/app_nicename.sh
+++ b/scripts/app_nicename.sh
@@ -4,9 +4,9 @@ IFS=$'\n\t'
 
 app_nicename() {
 	# Return the "NiceName" of the appname(s) passed. If there is no "NiceName", return the "Title__Case" of "appname"
-	local AppList
-	AppList="$(xargs -n 1 <<< "$*")"
-	for APPNAME in ${AppList}; do
+	local -a AppList
+	IFS=$' \t\n\r' read -d '' -ra AppList <<< "$*" || true
+	for APPNAME in "${AppList[@]}"; do
 		local result
 		run_script 'app_nicename_into' result "${APPNAME}"
 		echo "${result}"

--- a/scripts/app_nicename_from_template.sh
+++ b/scripts/app_nicename_from_template.sh
@@ -6,9 +6,9 @@ declare -a _dependencies_list=()
 
 app_nicename_from_template() {
 	# Return the "NiceName" of the appname(s) passed. If there is no "NiceName", return the "Title__Case" of "appname"
-	local AppList
-	AppList="$(xargs -n 1 <<< "$*")"
-	for APPNAME in ${AppList}; do
+	local -a AppList
+	IFS=$' \t\n\r' read -d '' -ra AppList <<< "$*" || true
+	for APPNAME in "${AppList[@]}"; do
 		local result
 		run_script 'app_nicename_from_template_into' result "${APPNAME}"
 		echo "${result}"

--- a/scripts/app_nicename_into.sh
+++ b/scripts/app_nicename_into.sh
@@ -5,29 +5,39 @@ IFS=$'\n\t'
 declare -a _dependencies_list=()
 
 app_nicename_into() {
-	# Return the "NiceName" of a single appname. If there is no "NiceName", return the "Title__Case" of "appname"
+	# Return the "NiceName" of the appname(s) passed. If there is no "NiceName", return the "Title__Case" of "appname"
 	local -n _ani_out_="${1}"
 	assert_nameref_is_string "${1}"
 	local _ani_AppName_="${2-}"
-	_ani_AppName_="${_ani_AppName_%:*}"
-	if ! run_script 'app_is_user_defined' "${_ani_AppName_}"; then
-		run_script 'app_nicename_from_template_into' _ani_out_ "${_ani_AppName_}"
-		return
-	fi
 
-	local -l _ani_baseapp_ _ani_instance_
-	local _ani_BaseApp_ _ani_Instance_
-	run_script 'appname_to_baseappname_into' _ani_baseapp_ "${_ani_AppName_}"
-	_ani_BaseApp_="${_ani_baseapp_^}"
-	run_script 'appname_to_instancename_into' _ani_instance_ "${_ani_AppName_}"
-	_ani_Instance_=""
-	if [[ -n ${_ani_instance_} ]]; then
-		local _ani_cap_prefix_ _ani_cap_rest_
-		_ani_cap_prefix_="${_ani_instance_%%[a-zA-Z]*}"
-		_ani_cap_rest_="${_ani_instance_#"${_ani_cap_prefix_}"}"
-		_ani_Instance_="__${_ani_cap_prefix_}${_ani_cap_rest_^}"
-	fi
-	_ani_out_="${_ani_BaseApp_}${_ani_Instance_}"
+	local -a _ani_AppList_
+	IFS=$' \t\n\r' read -d '' -ra _ani_AppList_ <<< "${_ani_AppName_}" || true
+
+	local _ani_Result_=""
+	local _ani_App_
+	for _ani_App_ in "${_ani_AppList_[@]}"; do
+		local _ani_SingleNice_
+		_ani_App_="${_ani_App_%:*}"
+		if ! run_script 'app_is_user_defined' "${_ani_App_}"; then
+			run_script 'app_nicename_from_template_into' _ani_SingleNice_ "${_ani_App_}"
+		else
+			local -l _ani_baseapp_ _ani_instance_
+			local _ani_BaseApp_ _ani_Instance_
+			run_script 'appname_to_baseappname_into' _ani_baseapp_ "${_ani_App_}"
+			_ani_BaseApp_="${_ani_baseapp_^}"
+			run_script 'appname_to_instancename_into' _ani_instance_ "${_ani_App_}"
+			_ani_Instance_=""
+			if [[ -n ${_ani_instance_} ]]; then
+				local _ani_cap_prefix_ _ani_cap_rest_
+				_ani_cap_prefix_="${_ani_instance_%%[a-zA-Z]*}"
+				_ani_cap_rest_="${_ani_instance_#"${_ani_cap_prefix_}"}"
+				_ani_Instance_="__${_ani_cap_prefix_}${_ani_cap_rest_^}"
+			fi
+			_ani_SingleNice_="${_ani_BaseApp_}${_ani_Instance_}"
+		fi
+		_ani_Result_+="${_ani_SingleNice_} "
+	done
+	_ani_out_="${_ani_Result_% }"
 }
 
 test_app_nicename_into() {

--- a/scripts/app_nicename_into_array.sh
+++ b/scripts/app_nicename_into_array.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+declare -a _dependencies_list=()
+
+app_nicename_into_array() {
+	local -n _ania_out_="${1}"
+	assert_nameref_is_array "${1}"
+	shift
+	_ania_out_=()
+	local _ania_name_
+	for _ania_app_ in "$@"; do
+		run_script 'app_nicename_into' _ania_name_ "${_ania_app_}"
+		_ania_out_+=("${_ania_name_}")
+	done
+}
+
+test_app_nicename_into_array() {
+	warn "CI does not test app_nicename_into_array."
+}

--- a/scripts/app_status.sh
+++ b/scripts/app_status.sh
@@ -4,9 +4,9 @@ IFS=$'\n\t'
 
 app_status() {
 	# Enable the status of apps given.  Apps will be seperate arguments and/or seperated by spaces
-	local AppList
-	AppList="$(xargs -n 1 <<< "$*")"
-	for APPNAME in ${AppList}; do
+	local -a AppList
+	IFS=$' \t\n\r' read -d '' -ra AppList <<< "$*" || true
+	for APPNAME in "${AppList[@]}"; do
 		local AppName
 		run_script 'app_nicename_into' AppName "${APPNAME}"
 		if run_script 'app_is_referenced' "${AppName}"; then

--- a/scripts/appvars_create.sh
+++ b/scripts/appvars_create.sh
@@ -3,9 +3,9 @@ set -Eeuo pipefail
 IFS=$'\n\t'
 
 appvars_create() {
-	local AppList
-	AppList="$(xargs -n 1 <<< "$*")"
-	for APPNAME in ${AppList^^}; do
+	local -a AppList
+	IFS=$' \t\n\r' read -d '' -ra AppList <<< "${*^^}" || true
+	for APPNAME in "${AppList[@]}"; do
 		local -l appname=${APPNAME}
 		local AppName
 		run_script 'app_nicename_into' AppName "${APPNAME}"

--- a/scripts/appvars_purge.sh
+++ b/scripts/appvars_purge.sh
@@ -9,9 +9,9 @@ declare -a _dependencies_list=(
 
 appvars_purge() {
 	local Title="Purge Variables"
-	local -l applist
-	applist="$(xargs -n 1 <<< "$*")"
-	for appname in ${applist}; do
+	local -a applist
+	IFS=$' \t\n\r' read -d '' -ra applist <<< "${*,,}" || true
+	for appname in "${applist[@]}"; do
 		local AppName
 		run_script 'app_nicename_into' AppName "${appname}"
 
@@ -24,7 +24,9 @@ appvars_purge() {
 
 		run_script 'appvars_list_into_array' CurrentGlobalVars "${appname}"
 		if [[ -n ${CurrentGlobalVars-} ]]; then
-			readarray -t DefaultGlobalVars <<< "$(run_script 'env_list_app_global_defaults' "${appname}")"
+			local AppDefaultGlobalEnvFile
+			run_script 'app_instance_file_into' AppDefaultGlobalEnvFile "${appname}" ".env"
+			run_script 'env_var_list_into_array' DefaultGlobalVars "${AppDefaultGlobalEnvFile}"
 			# Get the list of current variables also in the default list
 			readarray -t GlobalVarsToRemove <<< "$(
 				printf '%s\n' "${CurrentGlobalVars[@]-}" "${DefaultGlobalVars[@]-}" |
@@ -39,7 +41,9 @@ appvars_purge() {
 
 		run_script 'appvars_list_into_array' CurrentAppEnvVars "${appname}:"
 		if [[ -n ${CurrentAppEnvVars-} ]]; then
-			readarray -t DefaultAppEnvVars <<< "$(run_script 'env_list_app_env_defaults' "${appname}")"
+			local AppDefaultAppEnvFile
+			run_script 'app_instance_file_into' AppDefaultAppEnvFile "${appname}" ".env.app.*"
+			run_script 'env_var_list_into_array' DefaultAppEnvVars "${AppDefaultAppEnvFile}"
 			# Get the list of current variables also in the default list
 			readarray -t AppEnvVarsToRemove <<< "$(
 				printf '%s\n' "${CurrentAppEnvVars[@]-}" "${DefaultAppEnvVars[@]-}" |

--- a/scripts/disable_app.sh
+++ b/scripts/disable_app.sh
@@ -4,9 +4,9 @@ IFS=$'\n\t'
 
 disable_app() {
 	# Disable the list of apps given.  Apps will be seperate arguments and/or seperated by spaces
-	local AppList
-	AppList="$(xargs -n 1 <<< "$*")"
-	for APPNAME in ${AppList^^}; do
+	local -a AppList
+	IFS=$' \t\n\r' read -d '' -ra AppList <<< "${*^^}" || true
+	for APPNAME in "${AppList[@]}"; do
 		local AppName
 		run_script 'app_nicename_into' AppName "${APPNAME}"
 		if run_script 'app_is_builtin' "${APPNAME}"; then

--- a/scripts/docker_compose.sh
+++ b/scripts/docker_compose.sh
@@ -3,14 +3,20 @@ set -Eeuo pipefail
 IFS=$'\n\t'
 
 docker_compose() {
+	local -a InputList
+	IFS=$' \t\n\r' read -d '' -ra InputList <<< "$*" || true
 	local ComposeInput
-	ComposeInput="$(xargs <<< "$@")"
+	printf -v ComposeInput '%s ' "${InputList[@]}"
+	ComposeInput="${ComposeInput% }"
 	local Command=${ComposeInput%% *}
 	local APPNAME AppName
 	if [[ ${ComposeInput} == *" "* ]]; then
 		APPNAME=${ComposeInput#* }
-		run_script 'app_nicename_into' AppName "${APPNAME}"
-		AppName="${AppName// /, }"
+		local -a AppList AppNameArray
+		IFS=$' \t\n\r' read -d '' -ra AppList <<< "${APPNAME}" || true
+		run_script 'app_nicename_into_array' AppNameArray "${AppList[@]}"
+		printf -v AppName '%s, ' "${AppNameArray[@]}"
+		AppName="${AppName%, }"
 	fi
 
 	local Title="Docker Compose"

--- a/scripts/enable_app.sh
+++ b/scripts/enable_app.sh
@@ -4,9 +4,9 @@ IFS=$'\n\t'
 
 enable_app() {
 	# Enable the list of apps given.  Apps will be seperate arguments and/or seperated by spaces
-	local AppList
-	AppList="$(xargs -n 1 <<< "$*")"
-	for APPNAME in ${AppList^^}; do
+	local -a AppList
+	IFS=$' \t\n\r' read -d '' -ra AppList <<< "${*^^}" || true
+	for APPNAME in "${AppList[@]}"; do
 		local AppName
 		run_script 'app_nicename_into' AppName "${APPNAME}"
 		if run_script 'app_is_builtin' "${APPNAME}"; then

--- a/scripts/menu_add_app.sh
+++ b/scripts/menu_add_app.sh
@@ -28,7 +28,7 @@ menu_add_app() {
 			"${AppName}"
 		)
 		local InputValueDialogButtonPressed=0
-		AppName=$(tui_inputbox "${InputValueDialog[@]}") || InputValueDialogButtonPressed=$?
+		tui_inputbox_into AppName "${InputValueDialog[@]}" || InputValueDialogButtonPressed=$?
 		case ${DIALOG_BUTTONS[InputValueDialogButtonPressed]-} in
 			OK)
 				# Sanitize the input

--- a/scripts/menu_add_var.sh
+++ b/scripts/menu_add_var.sh
@@ -6,11 +6,10 @@ declare -a _dependencies_list=(
 	grep
 )
 
-menu_add_var_select_dialog() {
-	dialog_inputmenu "$@"
-}
-
-menu_add_var_select_whiptail() {
+menu_add_var_select_whiptail_into() {
+	local -n _mavswi_out_="${1}"
+	assert_nameref_is_string "${1}"
+	shift
 	local Title="${1-}"
 	shift || true
 	local Message="${1-}"
@@ -33,16 +32,16 @@ menu_add_var_select_whiptail() {
 	)
 	local -i result=0
 	local Selected
-	Selected=$(tui_menu "${MenuDialog[@]}") || result=$?
+	tui_menu_into Selected "${MenuDialog[@]}" || result=$?
 	case ${DIALOG_BUTTONS[result]-} in
 		OK)
 			local StrippedSelected="${Selected// /}"
 			if [[ ${StrippedSelected} == *_ ]]; then
 				local NewValue
-				NewValue=$(tui_inputbox "${Title}" "${Message}" --maximized) || result=$?
+				tui_inputbox_into NewValue "${Title}" "${Message}" --maximized || result=$?
 				case ${DIALOG_BUTTONS[result]-} in
 					OK)
-						echo "RENAMED ${Selected} ${NewValue}"
+						_mavswi_out_="RENAMED ${Selected} ${NewValue}"
 						return "${DIALOG_EXTRA}"
 						;;
 					*)
@@ -50,7 +49,7 @@ menu_add_var_select_whiptail() {
 						;;
 				esac
 			else
-				echo "${Selected}"
+				_mavswi_out_="${Selected}"
 				return "${DIALOG_OK}"
 			fi
 			;;
@@ -60,11 +59,20 @@ menu_add_var_select_whiptail() {
 	esac
 }
 
-menu_add_var_select() {
+menu_add_var_select_into() {
+	local -n _mavsi_out_="${1}"
+	assert_nameref_is_string "${1}"
+	shift
+	local -i result=0
+	local temp_file="${TEMP_FOLDER}/${APPLICATION_NAME,,}.${FUNCNAME[0]}.$$.tmp"
 	if use_dialog; then
-		menu_add_var_select_dialog "$@"
+		dialog_inputmenu "$@" > "${temp_file}" || result=$?
+		read -r _mavsi_out_ < "${temp_file}" || true
+		rm -f "${temp_file}"
+		return ${result}
 	else
-		menu_add_var_select_whiptail "$@"
+		menu_add_var_select_whiptail_into _mavsi_out_ "$@" || result=$?
+		return ${result}
 	fi
 }
 
@@ -249,7 +257,7 @@ menu_add_var() {
 				)
 				local -i SelectValueDialogButtonPressed=0
 				local SelectedOption
-				SelectedOption=$(menu_add_var_select "${SelectValueDialog[@]}") || SelectValueDialogButtonPressed=$?
+				menu_add_var_select_into SelectedOption "${SelectValueDialog[@]}" || SelectValueDialogButtonPressed=$?
 				case ${DIALOG_BUTTONS[SelectValueDialogButtonPressed]-} in
 					OK) # SELECT button
 						if [[ ${SelectedOption} == "${OptionClear}" ]]; then
@@ -364,7 +372,7 @@ menu_add_var() {
 					"${VarName}"
 				)
 				local InputValueDialogButtonPressed=0
-				VarName=$(tui_inputbox "${InputValueDialog[@]}") || InputValueDialogButtonPressed=$?
+				tui_inputbox_into VarName "${InputValueDialog[@]}" || InputValueDialogButtonPressed=$?
 				case ${DIALOG_BUTTONS[InputValueDialogButtonPressed]-} in
 					OK)
 						local Default

--- a/scripts/menu_app_select.sh
+++ b/scripts/menu_app_select.sh
@@ -55,7 +55,7 @@ menu_app_select() {
 		run_script 'app_list_added_into_array' AddedApps
 		update_gauge 1
 
-		readarray -t AddedApps < <(run_script 'app_filter_runnable' "${AddedApps[@]-}" | sort -f -u)
+		run_script 'app_filter_runnable_into_array' AddedApps "${AddedApps[@]-}"
 		update_gauge 1
 
 		run_script 'app_nicename_from_template_into_array' AddedApps "${AddedApps[@]-}"
@@ -93,7 +93,7 @@ menu_app_select() {
 		run_script 'app_list_nondeprecated_into_array' BuiltinApps
 		update_gauge 1
 
-		readarray -t BuiltinApps < <(run_script 'app_filter_runnable' "${BuiltinApps[@]}")
+		run_script 'app_filter_runnable_into_array' BuiltinApps "${BuiltinApps[@]}"
 		update_gauge 1
 
 		run_script 'app_nicename_from_template_into_array' BuiltinApps "${BuiltinApps[@]}"
@@ -142,7 +142,7 @@ menu_app_select() {
 	close_gauge
 
 	local -i SelectedAppsDialogButtonPressed
-	local SelectedApps
+	local -a SelectedApps=()
 	if [[ ${CI-} == true ]]; then
 		SelectedAppsDialogButtonPressed=${DIALOG_CANCEL}
 	else
@@ -158,7 +158,7 @@ menu_app_select() {
 			"${AppList[@]}"
 		)
 		SelectedAppsDialogButtonPressed=0
-		SelectedApps=$(tui_checklist "${SelectedAppsDialog[@]}") || SelectedAppsDialogButtonPressed=$?
+		tui_checklist_into_array SelectedApps "${SelectedAppsDialog[@]}" || SelectedAppsDialogButtonPressed=$?
 	fi
 	case ${DIALOG_BUTTONS[SelectedAppsDialogButtonPressed]-} in
 		OK)
@@ -343,6 +343,7 @@ close_gauge() {
 	else
 		whiptail_close_gauge
 	fi
+	tui_box_exit
 }
 
 init_gauge_text() {
@@ -419,6 +420,7 @@ init_gauge() {
 	shift || true
 	init_gauge_text "$@"
 	show_gauge "${Title}"
+	tui_box_enter
 }
 
 update_gauge_text() {

--- a/scripts/menu_config.sh
+++ b/scripts/menu_config.sh
@@ -51,7 +51,7 @@ menu_config() {
 		)
 		local ConfigChoice
 		local -i ConfigDialogButtonPressed=0
-		ConfigChoice=$(tui_menu "${ConfigChoiceDialog[@]}") || ConfigDialogButtonPressed=$?
+		tui_menu_into ConfigChoice "${ConfigChoiceDialog[@]}" || ConfigDialogButtonPressed=$?
 		LastConfigChoice=${ConfigChoice}
 		case ${DIALOG_BUTTONS[ConfigDialogButtonPressed]-} in
 			OK) # Select

--- a/scripts/menu_config_apps.sh
+++ b/scripts/menu_config_apps.sh
@@ -9,10 +9,11 @@ menu_config_apps() {
 
 	local LastAppChoice=""
 	while true; do
-		local AddedApps
-		AddedApps="$(run_script 'app_list_referenced' | run_script 'app_nicename_pipe')"
+		local -a ReferencedApps AddedApps
+		run_script 'app_list_referenced_into_array' ReferencedApps
+		run_script 'app_nicename_into_array' AddedApps "${ReferencedApps[@]}"
 		local -a AppOptions=()
-		for AppName in ${AddedApps}; do
+		for AppName in "${AddedApps[@]}"; do
 			local AppDescription
 			run_script 'app_description_into' AppDescription "${AppName}"
 			if run_script 'app_is_user_defined' "${AppName}"; then
@@ -33,7 +34,7 @@ menu_config_apps() {
 		)
 		local AppChoice
 		local -i AppChoiceButtonPressed=0
-		AppChoice=$(tui_menu "${AppChoiceDialog[@]}") || AppChoiceButtonPressed=$?
+		tui_menu_into AppChoice "${AppChoiceDialog[@]}" || AppChoiceButtonPressed=$?
 		LastAppChoice=${AppChoice}
 		case ${DIALOG_BUTTONS[AppChoiceButtonPressed]-} in
 			OK) # Select

--- a/scripts/menu_config_vars.sh
+++ b/scripts/menu_config_vars.sh
@@ -153,7 +153,7 @@ menu_config_vars() {
 			LastLineChoice="$(printf "%0${PadSize}d" "${TotalLines}")"
 		fi
 		while true; do
-			local DialogHeading
+			local DialogHeading LineChoice=""
 			run_script 'menu_heading_into' DialogHeading "${APPNAME-}"
 			local -a LineDialog=(
 				"${Title}"
@@ -167,7 +167,7 @@ menu_config_vars() {
 				"${LineOptions[@]}"
 			)
 			local -i LineDialogButtonPressed=0
-			LineChoice=$(tui_menu "${LineDialog[@]}") || LineDialogButtonPressed=$?
+			tui_menu_into LineChoice "${LineDialog[@]}" || LineDialogButtonPressed=$?
 			case ${DIALOG_BUTTONS[LineDialogButtonPressed]-} in
 				OK) # Select
 					LastLineChoice="${LineChoice}"

--- a/scripts/menu_dialog_example.sh
+++ b/scripts/menu_dialog_example.sh
@@ -78,7 +78,9 @@ menu_dialog_example() {
 		"${DialogOptions[@]}"
 	)
 
-	tui_menu "${MenuDialog[@]}" > /dev/null || true
+	#shellcheck disable=SC2034 # (warning): SelectedChoice is populated by example TUI call but is intentionally unused.
+	local SelectedChoice
+	tui_menu_into SelectedChoice "${MenuDialog[@]}" || true
 }
 
 test_menu_dialog_example() {

--- a/scripts/menu_main.sh
+++ b/scripts/menu_main.sh
@@ -32,7 +32,7 @@ menu_main() {
 		)
 		local MainChoice
 		local -i MainDialogButtonPressed=0
-		MainChoice=$(tui_menu "${MainChoiceDialog[@]}") || MainDialogButtonPressed=$?
+		tui_menu_into MainChoice "${MainChoiceDialog[@]}" || MainDialogButtonPressed=$?
 		LastMainChoice=${MainChoice}
 		case ${DIALOG_BUTTONS[MainDialogButtonPressed]-} in
 			OK)

--- a/scripts/menu_options.sh
+++ b/scripts/menu_options.sh
@@ -33,7 +33,7 @@ menu_options() {
 		)
 		local Choice
 		local -i DialogButtonPressed=0
-		Choice=$(tui_menu "${ChoiceDialog[@]}") || DialogButtonPressed=$?
+		tui_menu_into Choice "${ChoiceDialog[@]}" || DialogButtonPressed=$?
 		LastChoice=${Choice}
 		case ${DIALOG_BUTTONS[DialogButtonPressed]-} in
 			OK) # Select

--- a/scripts/menu_options_display.sh
+++ b/scripts/menu_options_display.sh
@@ -53,13 +53,12 @@ menu_options_display() {
 			--separate-output
 			"${Opts[@]}"
 		)
-		local Choices
+		local -a ChoicesArray=()
 		local -i DialogButtonPressed=0
-		Choices=$(tui_checklist "${ChoiceDialog[@]}") || DialogButtonPressed=$?
+		tui_checklist_into_array ChoicesArray "${ChoiceDialog[@]}" || DialogButtonPressed=$?
 		case ${DIALOG_BUTTONS[DialogButtonPressed]-} in
 			OK)
-				local -a ChoicesArray OptionsToTurnOff OptionsToTurnOn
-				readarray -t ChoicesArray <<< "${Choices}"
+				local -a OptionsToTurnOff OptionsToTurnOn
 				readarray -t OptionsToTurnOff < <(
 					printf '%s\n' "${EnabledOptions[@]}" "${ChoicesArray[@]}" "${ChoicesArray[@]}" | sort -f | uniq -u
 				)

--- a/scripts/menu_options_display_engine.sh
+++ b/scripts/menu_options_display_engine.sh
@@ -45,7 +45,7 @@ menu_options_display_engine() {
 		)
 		local Choice
 		local -i DialogButtonPressed=0
-		Choice=$(tui_radiolist "${ChoiceDialog[@]}") || DialogButtonPressed=$?
+		tui_radiolist_into Choice "${ChoiceDialog[@]}" || DialogButtonPressed=$?
 		LastChoice=${Choice}
 		case ${DIALOG_BUTTONS[DialogButtonPressed]-} in
 			OK)

--- a/scripts/menu_options_package_manager.sh
+++ b/scripts/menu_options_package_manager.sh
@@ -66,7 +66,7 @@ menu_options_package_manager() {
 		)
 		local Choice
 		local -i DialogButtonPressed=0
-		Choice=$(tui_radiolist "${ChoiceDialog[@]}") || DialogButtonPressed=$?
+		tui_radiolist_into Choice "${ChoiceDialog[@]}" || DialogButtonPressed=$?
 		LastChoice=${Choice}
 		case ${DIALOG_BUTTONS[DialogButtonPressed]-} in
 			OK)

--- a/scripts/menu_options_theme.sh
+++ b/scripts/menu_options_theme.sh
@@ -99,7 +99,7 @@ menu_options_theme() {
 		)
 		local Choice
 		local -i DialogButtonPressed=0
-		Choice=$(tui_radiolist "${ChoiceDialog[@]}") || DialogButtonPressed=$?
+		tui_radiolist_into Choice "${ChoiceDialog[@]}" || DialogButtonPressed=$?
 		LastChoice=${Choice}
 		case ${DIALOG_BUTTONS[DialogButtonPressed]-} in
 			OK)

--- a/scripts/menu_value_prompt.sh
+++ b/scripts/menu_value_prompt.sh
@@ -340,7 +340,7 @@ menu_value_prompt() {
 		)
 		local -i SelectValueDialogButtonPressed=0
 		local SelectedValue
-		SelectedValue=$(menu_value_prompt_select "${SelectValueDialog[@]}") || SelectValueDialogButtonPressed=$?
+		menu_value_prompt_select_into SelectedValue "${SelectValueDialog[@]}" || SelectValueDialogButtonPressed=$?
 
 		case ${DIALOG_BUTTONS[SelectValueDialogButtonPressed]-} in
 			OK) # SELECT button
@@ -566,11 +566,10 @@ menu_value_prompt() {
 	done
 }
 
-menu_value_prompt_select_dialog() {
-	dialog_inputmenu "$@"
-}
-
-menu_value_prompt_select_whiptail() {
+menu_value_prompt_select_whiptail_into() {
+	local -n _mvpswi_out_="${1}"
+	assert_nameref_is_string "${1}"
+	shift
 	local Title="${1-}"
 	shift || true
 	local Message="${1-}"
@@ -605,15 +604,15 @@ menu_value_prompt_select_whiptail() {
 	)
 	local -i result=0
 	local Selected
-	Selected=$(tui_menu "${MenuDialog[@]}") || result=$?
+	tui_menu_into Selected "${MenuDialog[@]}" || result=$?
 	case ${DIALOG_BUTTONS[result]-} in
 		OK)
 			if [[ ${Selected} == "${EnterCustom}" ]]; then
 				local NewValue
-				NewValue=$(tui_inputbox "${Title}" "${Message}" --maximized) || result=$?
+				tui_inputbox_into NewValue "${Title}" "${Message}" --maximized || result=$?
 				case ${DIALOG_BUTTONS[result]-} in
 					OK)
-						echo "RENAMED Current Value ${NewValue}"
+						_mvpswi_out_="RENAMED Current Value ${NewValue}"
 						return "${DIALOG_EXTRA}"
 						;;
 					*)
@@ -621,7 +620,7 @@ menu_value_prompt_select_whiptail() {
 						;;
 				esac
 			else
-				echo "${Selected}"
+				_mvpswi_out_="${Selected}"
 				return "${DIALOG_OK}"
 			fi
 			;;
@@ -631,11 +630,20 @@ menu_value_prompt_select_whiptail() {
 	esac
 }
 
-menu_value_prompt_select() {
+menu_value_prompt_select_into() {
+	local -n _mvpsi_out_="${1}"
+	assert_nameref_is_string "${1}"
+	shift
+	local -i result=0
+	local temp_file="${TEMP_FOLDER}/${APPLICATION_NAME,,}.${FUNCNAME[0]}.$$.tmp"
 	if use_dialog; then
-		menu_value_prompt_select_dialog "$@"
+		dialog_inputmenu "$@" > "${temp_file}" || result=$?
+		read -r _mvpsi_out_ < "${temp_file}" || true
+		rm -f "${temp_file}"
+		return ${result}
 	else
-		menu_value_prompt_select_whiptail "$@"
+		menu_value_prompt_select_whiptail_into _mvpsi_out_ "$@" || result=$?
+		return ${result}
 	fi
 }
 

--- a/scripts/pm_dnf_install.sh
+++ b/scripts/pm_dnf_install.sh
@@ -49,7 +49,7 @@ detect_packages() {
 	local Command="dnf rq ${DepsSearch} --qf '%{name} '"
 	notice "Running: {{|RunningCommand|}}${Command}{{[-]}}"
 	local -a Packages
-	read -ra Packages <<< "$(eval "${Command}" 2> /dev/null)"
+	IFS=$' \t\n\r' read -d '' -ra Packages <<< "$(eval "${Command}" 2> /dev/null)" || true
 	for Package in "${Packages[@]-}"; do
 		if [[ ! ${Package} =~ ${RegEx_Package_Blacklist} ]]; then
 			echo "${Package}"

--- a/scripts/question_prompt.sh
+++ b/scripts/question_prompt.sh
@@ -37,6 +37,8 @@ question_prompt() {
 		YN=${Default:-Y}
 	elif [[ -n ${Override-} ]]; then
 		YN="${Override}"
+	elif in_tui_box; then
+		YN=${Default:-Y}
 	elif use_tui_box; then
 		local DIALOG_DEFAULT
 		if [[ ${Default} == "N" ]]; then

--- a/scripts/update_self.sh
+++ b/scripts/update_self.sh
@@ -16,9 +16,9 @@ update_self() {
 	local Question YesNotice NoNotice
 
 	if [[ -z ${Branch-} ]]; then
-		Branch="$(ds_branch)"
+		ds_branch_into Branch
 		if ds_tag_exists "${Branch-}"; then
-			Branch="$(ds_best_branch)"
+			ds_best_branch_into Branch
 		fi
 		if [[ -z ${Branch-} ]]; then
 			error "You need to specify a branch to update to."
@@ -26,8 +26,8 @@ update_self() {
 		fi
 	fi
 
-	CurrentVersion="$(ds_version)"
-	RemoteVersion="$(ds_version "${Branch}")"
+	ds_version_into CurrentVersion
+	ds_version_into RemoteVersion "${Branch}"
 	if [[ ${CurrentVersion-} == "${RemoteVersion-}" ]]; then
 		if [[ -n ${FORCE-} ]]; then
 			Question="Would you like to forcefully re-apply {{|ApplicationName|}}${APPLICATION_NAME}{{[-]}} update '{{|Version|}}${CurrentVersion}{{[-]}}'?"
@@ -133,8 +133,10 @@ commands_update_self_logic() {
 	git -C "${SCRIPTPATH}" ls-tree -rt --name-only "${Branch}" | xargs sudo chown "${DETECTED_PUID}":"${DETECTED_PGID}" &> /dev/null || true
 	sudo chown -R "${DETECTED_PUID}":"${DETECTED_PGID}" "${SCRIPTPATH}/.git" &> /dev/null || true
 	sudo chown "${DETECTED_PUID}":"${DETECTED_PGID}" "${SCRIPTPATH}" &> /dev/null || true
+	local UpdatedVersion
+	ds_version_into UpdatedVersion
 	notice \
-		"Updated ${APPLICATION_NAME} to '{{|Version|}}$(ds_version){{[-]}}'"
+		"Updated ${APPLICATION_NAME} to '{{|Version|}}${UpdatedVersion}{{[-]}}'"
 
 	# run_script 'reset_needs' # Add script lines in-line below
 	if [[ -d ${TIMESTAMPS_FOLDER:?} ]]; then

--- a/scripts/update_templates.sh
+++ b/scripts/update_templates.sh
@@ -13,9 +13,9 @@ update_templates() {
 
 	templates_fetch true
 	if [[ -z ${Branch-} ]]; then
-		Branch="$(templates_branch)"
+		templates_branch_into Branch
 		if templates_tag_exists "${Branch-}"; then
-			Branch="$(templates_best_branch)"
+			templates_best_branch_into Branch
 		fi
 		if [[ -z ${Branch-} ]]; then
 			error "You need to specify a branch to update to."
@@ -23,8 +23,8 @@ update_templates() {
 		fi
 	fi
 
-	CurrentVersion="$(templates_version)"
-	RemoteVersion="$(templates_version "${Branch}")"
+	templates_version_into CurrentVersion
+	templates_version_into RemoteVersion "${Branch}"
 	if [[ ${CurrentVersion-} == "${RemoteVersion-}" ]]; then
 		if [[ -n ${FORCE-} ]]; then
 			Question="Would you like to forcefully re-apply {{|ApplicationName|}}${TargetName}{{[-]}} update '{{|Version|}}${CurrentVersion}{{[-]}}'?"
@@ -115,7 +115,9 @@ commands_update_templates() {
 	git -C "${TEMPLATES_PARENT_FOLDER}" ls-tree -rt --name-only "${Branch}" | xargs sudo chown "${DETECTED_PUID}":"${DETECTED_PGID}" &> /dev/null || true
 	sudo chown -R "${DETECTED_PUID}":"${DETECTED_PGID}" "${TEMPLATES_PARENT_FOLDER}/.git" &> /dev/null || true
 	sudo chown "${DETECTED_PUID}":"${DETECTED_PGID}" "${TEMPLATES_PARENT_FOLDER}" &> /dev/null || true
-	notice "Updated ${TargetName} to '{{|Version|}}$(templates_version){{[-]}}'"
+	local UpdatedVersion
+	templates_version_into UpdatedVersion
+	notice "Updated ${TargetName} to '{{|Version|}}${UpdatedVersion}{{[-]}}'"
 
 	# run_script 'reset_needs' (DELETED in favor of granular detection)
 }


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Refactor shell utilities and TUI helpers to avoid subshells and xargs by introducing in-place output functions and array-based helpers, while tightening dialog state tracking and improving version and app-name handling.

New Features:
- Add *_into and *_into_array helper functions for git metadata, TUI dialogs, app nicenames, and runnable-app filtering to write results directly into variables or arrays.
- Track dialog / TUI box nesting explicitly via TUI_IN_BOX with dedicated enter/exit helpers to better detect dialog context.

Bug Fixes:
- Make question prompts respect the default answer when running inside a TUI box to avoid hanging on non-interactive dialog calls.
- Ensure previous-arguments strings and highlighted lists are constructed safely without relying on xargs, preventing mis-formatting with special whitespace.

Enhancements:
- Replace xargs and subshell-heavy patterns with explicit array parsing and variable assignment to improve performance, readability, and portability of shell scripts.
- Standardize version and branch retrieval across the application and templates using *_into helpers, reducing repeated git calls and inline command substitutions.
- Rework menu and checklist APIs to use *_into variants, simplifying callers and clarifying ownership of temporary files used to capture dialog output.
- Improve app nicename handling to support multiple input app names in a single call and to propagate nicenames as arrays where appropriate.
- Update variable purge and env-listing logic to use generic env_var_list_into_array helpers instead of template-specific listing functions.