### PR TITLE
fix(env): trim trailing empty elements and fix unbound printf array e…

### DIFF
--- a/scripts/env_format_lines.sh
+++ b/scripts/env_format_lines.sh
@@ -111,12 +111,16 @@ env_format_lines() {
 		FormattedEnvLines+=("")
 	fi
 
-	# Remove last element if it is an empty string to avoid extra newline from printf
+	# Remove all trailing empty strings to avoid extra newlines from printf
 	# This ensures parity with Go's strings.Join which doesn't add a trailing delimiter.
-	if [[ ${FormattedEnvLines[${#FormattedEnvLines[@]} - 1]-} == "" ]]; then
-		unset 'FormattedEnvLines[${#FormattedEnvLines[@]}-1]'
-	fi
-	printf "%s\n" "${FormattedEnvLines[@]-}"
+	while true; do
+		if [[ ${#FormattedEnvLines[@]} -gt 0 && -z ${FormattedEnvLines[-1]-} ]]; then
+			FormattedEnvLines=("${FormattedEnvLines[@]:0:${#FormattedEnvLines[@]}-1}")
+		else
+			break
+		fi
+	done
+	printf "%s\n" "${FormattedEnvLines[@]+"${FormattedEnvLines[@]}"}"
 }
 
 _build_var_index() {


### PR DESCRIPTION
…xpansion

# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Adjust environment line formatting to avoid extraneous newlines and handle empty arrays safely.

Bug Fixes:
- Trim all trailing empty environment lines before printing to prevent extra newlines in output.
- Guard printf array expansion to avoid issues when the formatted environment line array is empty.