### PR TITLE
feat(compose): add create, kill, rm, start subcommands to -c

### DIFF
--- a/includes/cmdline.sh
+++ b/includes/cmdline.sh
@@ -306,14 +306,14 @@ parse_arguments() {
 					break
 					;;
 
-				# --compose [ [down|pull|stop|restart|update|up] [param ...] ]
+				# --compose [ [create|down|kill|pause|pull|rm|start|stop|restart|unpause|update|up] [param ...] ]
 				-c | --compose)
 					CurrentCommand+=("${OPTION}")
 					if [[ -n ${!OPTIND-} && ${!OPTIND} != "-"* ]]; then
 						case ${!OPTIND} in
 							generate | merge) ;&
-							down | pause | pull | stop | restart | unpause | update | up) ;&
-							"down "* | "pause "* | "pull "* | "stop "* | "restart "* | "unpause "* | "update "* | "up "*)
+							create | down | kill | pause | pull | rm | start | stop | restart | unpause | update | up) ;&
+							"create "* | "down "* | "kill "* | "pause "* | "pull "* | "rm "* | "start "* | "stop "* | "restart "* | "unpause "* | "update "* | "up "*)
 								until [[ ${OPTIND} -gt $# || ${!OPTIND} == "-"* ]]; do
 									CurrentCommand+=("${!OPTIND}")
 									OPTIND+=1

--- a/includes/usage.sh
+++ b/includes/usage.sh
@@ -110,7 +110,7 @@ EOF
 		-c | --compose | "")
 			Found=1
 			cat << EOF
-{{|UsageCommand|}}-c --compose{{[-]}} < {{|UsageOption|}}pull{{[-]}} | {{|UsageOption|}}up{{[-]}} | {{|UsageOption|}}down{{[-]}} | {{|UsageOption|}}stop{{[-]}} | {{|UsageOption|}}restart{{[-]}} | {{|UsageOption|}}pause{{[-]}} | {{|UsageOption|}}unpause{{[-]}} | {{|UsageOption|}}update{{[-]}} > [{{|UsageApp|}}<app>{{[-]}} ...]{{[-]}}
+{{|UsageCommand|}}-c --compose{{[-]}} < {{|UsageOption|}}pull{{[-]}} | {{|UsageOption|}}up{{[-]}} | {{|UsageOption|}}down{{[-]}} | {{|UsageOption|}}stop{{[-]}} | {{|UsageOption|}}start{{[-]}} | {{|UsageOption|}}restart{{[-]}} | {{|UsageOption|}}create{{[-]}} | {{|UsageOption|}}rm{{[-]}} | {{|UsageOption|}}kill{{[-]}} | {{|UsageOption|}}pause{{[-]}} | {{|UsageOption|}}unpause{{[-]}} | {{|UsageOption|}}update{{[-]}} > [{{|UsageApp|}}<app>{{[-]}} ...]{{[-]}}
 	Run docker compose commands. If no command is given, it does an '{{|UsageOption|}}update{{[-]}}'.
 	The '{{|UsageOption|}}update{{[-]}}' command is the same as a '{{|UsageOption|}}pull{{[-]}}' followed by an '{{|UsageOption|}}up{{[-]}}'
 {{|UsageCommand|}}-c --compose{{[-]}} < {{|UsageOption|}}generate{{[-]}} | {{|UsageOption|}}merge{{[-]}} >{{[-]}}

--- a/scripts/docker_compose.sh
+++ b/scripts/docker_compose.sh
@@ -29,6 +29,18 @@ docker_compose() {
 			NoNotice="Not merging enabled app templates to '{{|File|}}docker-compose.yml{{[-]}}'."
 			YesNotice="Merging enabled app templates to '{{|File|}}docker-compose.yml{{[-]}}'."
 			;;
+		create)
+			if [[ -n ${AppName-} ]]; then
+				Question="Create containers for: {{|App|}}${AppName}{{[-]}}?"
+				NoNotice="Not creating containers for: {{|App|}}${AppName}{{[-]}}."
+				YesNotice="Creating containers for: {{|App|}}${AppName}{{[-]}}."
+			else
+				Question="Create containers for all enabled services?"
+				NoNotice="Not creating containers for all enabled services."
+				YesNotice="Creating containers for all enabled services."
+			fi
+			ComposeCommand[0]="create --remove-orphans ${APPNAME-}"
+			;;
 		down)
 			if [[ -n ${AppName-} ]]; then
 				Question="Stop and remove: ${AppName}?"
@@ -40,6 +52,18 @@ docker_compose() {
 				YesNotice="Stopping and removing containers, networks, volumes, and images created by {{|ApplicationName|}}${APPLICATION_NAME}."
 			fi
 			ComposeCommand[0]="down --remove-orphans ${APPNAME-}"
+			;;
+		kill)
+			if [[ -n ${AppName-} ]]; then
+				Question="Force stop: {{|App|}}${AppName}{{[-]}}?"
+				NoNotice="Not force stopping: {{|App|}}${AppName}{{[-]}}."
+				YesNotice="Force stopping: {{|App|}}${AppName}{{[-]}}."
+			else
+				Question="Force stop all running containers?"
+				NoNotice="Not force stopping all running containers."
+				YesNotice="Force stopping all running containers."
+			fi
+			ComposeCommand[0]="kill ${APPNAME-}"
 			;;
 		pause)
 			if [[ -n ${AppName-} ]]; then
@@ -65,6 +89,18 @@ docker_compose() {
 			fi
 			ComposeCommand[0]="pull --include-deps ${APPNAME-}"
 			;;
+		rm)
+			if [[ -n ${AppName-} ]]; then
+				Question="Remove stopped containers for: {{|App|}}${AppName}{{[-]}}?"
+				NoNotice="Not removing stopped containers for: {{|App|}}${AppName}{{[-]}}."
+				YesNotice="Removing stopped containers for: {{|App|}}${AppName}{{[-]}}."
+			else
+				Question="Remove stopped containers?"
+				NoNotice="Not removing stopped containers."
+				YesNotice="Removing stopped containers."
+			fi
+			ComposeCommand[0]="rm ${APPNAME-}"
+			;;
 		restart)
 			if [[ -n ${AppName-} ]]; then
 				Question="Restart: {{|App|}}${AppName}{{[-]}}?"
@@ -76,6 +112,18 @@ docker_compose() {
 				YesNotice="Restarting all stopped and running containers."
 			fi
 			ComposeCommand[0]="restart ${APPNAME-}"
+			;;
+		start)
+			if [[ -n ${AppName-} ]]; then
+				Question="Start: {{|App|}}${AppName}{{[-]}}?"
+				NoNotice="Not starting: {{|App|}}${AppName}{{[-]}}."
+				YesNotice="Starting: {{|App|}}${AppName}{{[-]}}."
+			else
+				Question="Start all stopped containers?"
+				NoNotice="Not starting all stopped containers."
+				YesNotice="Starting all stopped containers."
+			fi
+			ComposeCommand[0]="start ${APPNAME-}"
 			;;
 		stop)
 			if [[ -n ${AppName-} ]]; then


### PR DESCRIPTION
Matches the subcommands now supported by DockSTARTer2.

# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Extend docker compose CLI integration to support additional subcommands for container lifecycle management via the -c/--compose flag.

New Features:
- Add support for docker compose create, kill, rm, and start subcommands when using the -c/--compose command.
- Provide interactive confirmation prompts for create, kill, rm, and start operations, applicable to a specific app or all relevant services.

Documentation:
- Update -c/--compose usage help text to document the new create, kill, rm, and start subcommands alongside existing compose operations.