### PR TITLE
Restrict default-branch self/template updates to tagged releases

### DIFF
--- a/includes/ds_functions.sh
+++ b/includes/ds_functions.sh
@@ -121,13 +121,20 @@ git_version() {
 
 git_resolve_update_target_into() {
 	# Resolves the branch/tag name that should actually be checked out for
-	# an update, applying a release policy when the caller auto-detected
-	# (didn't explicitly request) the default branch: CI (e.g. renovate)
-	# commits land on the default branch between releases, so its literal
-	# tip is frequently not the commit anyone actually meant to update to.
-	# Restrict to the latest tag reachable from the default branch's
-	# history instead. Falls back to the default branch's tip if no
-	# reachable tag exists yet (e.g. before any release).
+	# an update, applying a release policy whenever the resolved branch is
+	# the default branch: CI (e.g. renovate) commits land on the default
+	# branch between releases, so its literal tip is frequently not the
+	# commit anyone actually meant to update to. Restrict to the latest tag
+	# reachable from the default branch's history instead. Falls back to
+	# the default branch's tip if no reachable tag exists yet (e.g. before
+	# any release).
+	#
+	# This applies whether RequestedBranch reached "the default branch"
+	# via auto-detection or because the caller typed the branch name
+	# explicitly (e.g. `ds -u "" main`) -- naming the branch is "pick which
+	# branch to track", not "opt out of the release policy". Only an
+	# explicit literal tag name or commit hash bypasses this, and those
+	# naturally never equal DefaultBranch's name.
 	#
 	# Everything downstream (git_version_into, git checkout) already treats
 	# a tag name exactly like a branch name, so callers just use this
@@ -142,18 +149,14 @@ git_resolve_update_target_into() {
 	# skipped when switching branches (CurrentBranch != RequestedBranch):
 	# a different branch happening to descend from the default branch's
 	# latest tag must never block the switch itself.
-	#
-	# Only an explicit tag/commit request (WasExplicit=true) bypasses this
-	# policy entirely and is returned unchanged.
 	local -n _grti_out_="${1}"
 	assert_nameref_is_string "${1}"
 	local GitPath=${2}
 	local DefaultBranch=${3}
 	local RequestedBranch=${4}
 	local CurrentBranch=${5-}
-	local WasExplicit=${6-false}
 
-	if $WasExplicit || [[ ${RequestedBranch} != "${DefaultBranch}" ]]; then
+	if [[ ${RequestedBranch} != "${DefaultBranch}" ]]; then
 		_grti_out_="${RequestedBranch}"
 		return
 	fi

--- a/includes/ds_functions.sh
+++ b/includes/ds_functions.sh
@@ -161,8 +161,13 @@ git_resolve_update_target_into() {
 		return
 	fi
 
+	# Sort by actual tag creation date (--sort=-creatordate), not the tag
+	# name string (sort -V): this repo has switched tag-naming schemes over
+	# time (e.g. v2026.01.19-1 -> v1.20260628.1), and comparing differently-
+	# shaped version strings against each other picks the wrong "latest" --
+	# creation date is immune to that since it doesn't depend on the name.
 	local LatestTag
-	LatestTag=$(git -C "${GitPath}" tag --merged "origin/${DefaultBranch}" 2> /dev/null | sort -V | tail -1) || true
+	LatestTag=$(git -C "${GitPath}" tag --merged "origin/${DefaultBranch}" --sort=-creatordate 2> /dev/null | head -1) || true
 
 	if [[ -z ${LatestTag} ]]; then
 		# No reachable tag yet -- fall back to the default branch's tip.

--- a/includes/ds_functions.sh
+++ b/includes/ds_functions.sh
@@ -119,6 +119,71 @@ git_version() {
 	echo "${result}"
 }
 
+git_resolve_update_target_into() {
+	# Resolves the branch/tag name that should actually be checked out for
+	# an update, applying a release policy when the caller auto-detected
+	# (didn't explicitly request) the default branch: CI (e.g. renovate)
+	# commits land on the default branch between releases, so its literal
+	# tip is frequently not the commit anyone actually meant to update to.
+	# Restrict to the latest tag reachable from the default branch's
+	# history instead. Falls back to the default branch's tip if no
+	# reachable tag exists yet (e.g. before any release).
+	#
+	# Everything downstream (git_version_into, git checkout) already treats
+	# a tag name exactly like a branch name, so callers just use this
+	# function's output as "Branch" for the rest of their update flow --
+	# no other logic needs to change.
+	#
+	# If CurrentBranch (the branch actually checked out right now) equals
+	# the resolved default-branch target, and the latest reachable tag is
+	# an ancestor of (or equal to) current HEAD, this returns CurrentBranch
+	# unchanged instead of the tag -- i.e. "no update available" rather than
+	# incorrectly offering to move backward to an older tag. This check is
+	# skipped when switching branches (CurrentBranch != RequestedBranch):
+	# a different branch happening to descend from the default branch's
+	# latest tag must never block the switch itself.
+	#
+	# Only an explicit tag/commit request (WasExplicit=true) bypasses this
+	# policy entirely and is returned unchanged.
+	local -n _grti_out_="${1}"
+	assert_nameref_is_string "${1}"
+	local GitPath=${2}
+	local DefaultBranch=${3}
+	local RequestedBranch=${4}
+	local CurrentBranch=${5-}
+	local WasExplicit=${6-false}
+
+	if $WasExplicit || [[ ${RequestedBranch} != "${DefaultBranch}" ]]; then
+		_grti_out_="${RequestedBranch}"
+		return
+	fi
+
+	local LatestTag
+	LatestTag=$(git -C "${GitPath}" tag --merged "origin/${DefaultBranch}" 2> /dev/null | sort -V | tail -1) || true
+
+	if [[ -z ${LatestTag} ]]; then
+		# No reachable tag yet -- fall back to the default branch's tip.
+		_grti_out_="${RequestedBranch}"
+		return
+	fi
+
+	if [[ ${CurrentBranch} == "${RequestedBranch}" ]] && git -C "${GitPath}" merge-base --is-ancestor "${LatestTag}" HEAD 2> /dev/null; then
+		# Current HEAD is already at or ahead of the latest tag and we're
+		# staying on the same branch -- report no update by returning the
+		# current branch name unchanged.
+		_grti_out_="${CurrentBranch}"
+		return
+	fi
+
+	_grti_out_="${LatestTag}"
+}
+
+git_resolve_update_target() {
+	local result
+	git_resolve_update_target_into result "$@"
+	echo "${result}"
+}
+
 git_update_available() {
 	local GitPath=${1}
 	local CurrentRef=${2-}

--- a/scripts/update_self.sh
+++ b/scripts/update_self.sh
@@ -131,7 +131,7 @@ commands_update_self_logic() {
 			info "Pulling recent changes from git."
 			RunAndLog info "git:info" \
 				fatal "Failed to pull recent changes from git." \
-				git -C "${SCRIPTPATH}" pull
+				git -C "${SCRIPTPATH}" pull origin "${Branch}"
 		fi
 	fi
 	info "Cleaning up unnecessary files and optimizing the local repository."

--- a/scripts/update_self.sh
+++ b/scripts/update_self.sh
@@ -5,6 +5,8 @@ IFS=$'\n\t'
 update_self() {
 	local Branch CurrentVersion RemoteVersion
 	Branch=${1-}
+	local WasExplicit=true
+	[[ -z ${Branch} ]] && WasExplicit=false
 	shift || true
 	ds_fetch true
 	if [[ ${Branch-} == "${APPLICATION_LEGACY_BRANCH}" ]] && ds_branch_exists "${APPLICATION_DEFAULT_BRANCH}"; then
@@ -15,8 +17,11 @@ update_self() {
 	local Title="Update ${APPLICATION_NAME}"
 	local Question YesNotice NoNotice
 
+	local CurrentBranch
+	ds_branch_into CurrentBranch
+
 	if [[ -z ${Branch-} ]]; then
-		ds_branch_into Branch
+		Branch="${CurrentBranch}"
 		if ds_tag_exists "${Branch-}"; then
 			ds_best_branch_into Branch
 		fi
@@ -25,6 +30,13 @@ update_self() {
 			return 1
 		fi
 	fi
+
+	# On the default branch (unless a specific tag/commit was explicitly
+	# requested), restrict to the latest tagged release instead of the
+	# branch's literal tip -- see git_resolve_update_target_into's doc
+	# comment for why. Downstream logic (version lookup, checkout) is
+	# unchanged: it already treats a tag name exactly like a branch name.
+	git_resolve_update_target_into Branch "${SCRIPTPATH}" "${APPLICATION_DEFAULT_BRANCH}" "${Branch}" "${CurrentBranch}" "${WasExplicit}"
 
 	ds_version_into CurrentVersion
 	ds_version_into RemoteVersion "${Branch}"

--- a/scripts/update_self.sh
+++ b/scripts/update_self.sh
@@ -5,8 +5,6 @@ IFS=$'\n\t'
 update_self() {
 	local Branch CurrentVersion RemoteVersion
 	Branch=${1-}
-	local WasExplicit=true
-	[[ -z ${Branch} ]] && WasExplicit=false
 	shift || true
 	ds_fetch true
 	if [[ ${Branch-} == "${APPLICATION_LEGACY_BRANCH}" ]] && ds_branch_exists "${APPLICATION_DEFAULT_BRANCH}"; then
@@ -31,12 +29,11 @@ update_self() {
 		fi
 	fi
 
-	# On the default branch (unless a specific tag/commit was explicitly
-	# requested), restrict to the latest tagged release instead of the
-	# branch's literal tip -- see git_resolve_update_target_into's doc
-	# comment for why. Downstream logic (version lookup, checkout) is
+	# On the default branch, restrict to the latest tagged release instead
+	# of the branch's literal tip -- see git_resolve_update_target_into's
+	# doc comment for why. Downstream logic (version lookup, checkout) is
 	# unchanged: it already treats a tag name exactly like a branch name.
-	git_resolve_update_target_into Branch "${SCRIPTPATH}" "${APPLICATION_DEFAULT_BRANCH}" "${Branch}" "${CurrentBranch}" "${WasExplicit}"
+	git_resolve_update_target_into Branch "${SCRIPTPATH}" "${APPLICATION_DEFAULT_BRANCH}" "${Branch}" "${CurrentBranch}"
 
 	ds_version_into CurrentVersion
 	ds_version_into RemoteVersion "${Branch}"

--- a/scripts/update_templates.sh
+++ b/scripts/update_templates.sh
@@ -7,8 +7,6 @@ declare TargetName="${TEMPLATES_NAME}"
 update_templates() {
 	local Branch CurrentVersion RemoteVersion
 	Branch=${1-}
-	local WasExplicit=true
-	[[ -z ${Branch} ]] && WasExplicit=false
 	shift || true
 	local Title="Update ${TargetName}"
 	local Question YesNotice NoNotice
@@ -29,12 +27,11 @@ update_templates() {
 		fi
 	fi
 
-	# On the default branch (unless a specific tag/commit was explicitly
-	# requested), restrict to the latest tagged release instead of the
-	# branch's literal tip -- see git_resolve_update_target_into's doc
-	# comment for why. Downstream logic (version lookup, checkout) is
+	# On the default branch, restrict to the latest tagged release instead
+	# of the branch's literal tip -- see git_resolve_update_target_into's
+	# doc comment for why. Downstream logic (version lookup, checkout) is
 	# unchanged: it already treats a tag name exactly like a branch name.
-	git_resolve_update_target_into Branch "${TEMPLATES_PARENT_FOLDER}" "${TEMPLATES_DEFAULT_BRANCH}" "${Branch}" "${CurrentBranch}" "${WasExplicit}"
+	git_resolve_update_target_into Branch "${TEMPLATES_PARENT_FOLDER}" "${TEMPLATES_DEFAULT_BRANCH}" "${Branch}" "${CurrentBranch}"
 
 	templates_version_into CurrentVersion
 	templates_version_into RemoteVersion "${Branch}"

--- a/scripts/update_templates.sh
+++ b/scripts/update_templates.sh
@@ -7,13 +7,19 @@ declare TargetName="${TEMPLATES_NAME}"
 update_templates() {
 	local Branch CurrentVersion RemoteVersion
 	Branch=${1-}
+	local WasExplicit=true
+	[[ -z ${Branch} ]] && WasExplicit=false
 	shift || true
 	local Title="Update ${TargetName}"
 	local Question YesNotice NoNotice
 
 	templates_fetch true
+
+	local CurrentBranch
+	templates_branch_into CurrentBranch
+
 	if [[ -z ${Branch-} ]]; then
-		templates_branch_into Branch
+		Branch="${CurrentBranch}"
 		if templates_tag_exists "${Branch-}"; then
 			templates_best_branch_into Branch
 		fi
@@ -22,6 +28,13 @@ update_templates() {
 			return 1
 		fi
 	fi
+
+	# On the default branch (unless a specific tag/commit was explicitly
+	# requested), restrict to the latest tagged release instead of the
+	# branch's literal tip -- see git_resolve_update_target_into's doc
+	# comment for why. Downstream logic (version lookup, checkout) is
+	# unchanged: it already treats a tag name exactly like a branch name.
+	git_resolve_update_target_into Branch "${TEMPLATES_PARENT_FOLDER}" "${TEMPLATES_DEFAULT_BRANCH}" "${Branch}" "${CurrentBranch}" "${WasExplicit}"
 
 	templates_version_into CurrentVersion
 	templates_version_into RemoteVersion "${Branch}"

--- a/scripts/update_templates.sh
+++ b/scripts/update_templates.sh
@@ -114,7 +114,7 @@ commands_update_templates() {
 			info "Pulling recent changes from git."
 			RunAndLog info "git:info" \
 				fatal "Failed to pull recent changes from git." \
-				git -C "${TEMPLATES_PARENT_FOLDER}" pull
+				git -C "${TEMPLATES_PARENT_FOLDER}" pull origin "${Branch}"
 		fi
 	fi
 	info "Cleaning up unnecessary files and optimizing the local repository."


### PR DESCRIPTION
## Summary
- On the default branch (\`main\`), self-update and template-update now resolve to the latest tag reachable from that branch's history instead of the branch's literal tip -- CI/renovate commits land on `main` between releases, so the tip is frequently not the commit anyone actually meant to update to. Falls back to the branch's tip if no reachable tag exists yet.
- Applies whether the default branch is auto-detected or named explicitly (e.g. `ds -u "" main`) -- only a literal tag/commit request bypasses the policy.
- If already on the target branch and current HEAD is at or ahead of the latest tag, reports "no update available" instead of offering to move backward to an older tag -- but only when staying on the same branch, so switching to `main` from a branch that happens to descend from `main`'s latest tag is never blocked.
- Implemented via one shared `git_resolve_update_target_into` helper in `ds_functions.sh`, used by both `update_self.sh` and `update_templates.sh`.

## Fixes found while testing
- `git pull` (bare) after `git checkout --force <branch>` could fail when the current branch had no upstream tracking configured -- most visibly after the new policy left HEAD detached on a tag. Switched to `git pull origin "${Branch}"`, matching the explicit `origin/"${Branch}"` already used for the preceding reset.
- Latest-tag selection compared tag names via `sort -V`, which picked the wrong "latest" tag after this repo's tag-naming scheme changed (`v2026.01.19-1` -> `v1.20260628.1`) -- `v1.*` sorts before `v2026.*` lexicographically despite being chronologically much newer. Switched to `git tag --sort=-creatordate`, which compares actual tag creation time and is immune to naming-scheme changes.

## Test plan
- [x] Manually tested on a VM: `ds -u "" main` / `ds -u Updates main` correctly resolve to the latest tagged release instead of `main`'s tip.
- [x] Confirmed "already up to date" is reported correctly when staying on `main` at/ahead of the latest tag.
- [x] Confirmed switching from a different branch (e.g. `DoplarrRS`) back to `main` is never blocked by the ahead-of-tag check.
- [x] Confirmed the previous `git pull` crash after a detached-HEAD tag checkout is fixed.
- [x] Confirmed latest-tag selection now correctly picks the actual newest release across the tag-naming-scheme change.

## Summary by Sourcery

Restrict default-branch self/template updates to track the latest tagged release instead of the branch tip and harden git update behavior around tags and branches.

New Features:
- Route self-update and template-update on the default branch through a shared helper that resolves the effective update target (branch vs latest reachable tag).

Bug Fixes:
- Fix git pull after a detached-HEAD tag checkout by always pulling from origin for the selected branch.
- Ensure latest release selection uses tag creation time instead of tag name ordering so the newest tag is chosen correctly across naming-scheme changes.

Enhancements:
- Prevent default-branch updates from downgrading when the current HEAD is already at or ahead of the latest tag.
- Unify default-branch update handling for self and templates so both consistently honor the tagged-release policy.