### PR TITLE
Fix template updates not being applied to existing user files

### DIFF
--- a/scripts/needs_env_update.sh
+++ b/scripts/needs_env_update.sh
@@ -38,9 +38,27 @@ needs_env_update() {
 	fi
 	local filename
 	filename="$(basename "${VarFile}")"
+
+	local -u APPNAME
+	run_script 'varfile_to_appname_into' APPNAME "${VarFile}"
+
+	# Check if the app's template default file changed (e.g. an
+	# --update-templates edited its .env.app.* defaults/ordering/comments).
+	# Without this, editing an app's template was never picked up by a
+	# plain templates update -- only a fresh .env.app.* file (no marker
+	# yet) or a full reset_needs (which wipes every marker) would trigger a
+	# resync. app_instance_file_into already detects template drift and
+	# regenerates the instance file to match; we just need to also notice
+	# when it did.
+	if [[ -n ${APPNAME} ]] && ! run_script 'app_is_user_defined' "${APPNAME}"; then
+		local AppDefaultFile
+		run_script 'app_instance_file_into' AppDefaultFile "${APPNAME}" ".env.app.*"
+		if [[ -n ${AppDefaultFile} ]] && file_changed "${AppDefaultFile}" "${filename}_template"; then
+			return 0
+		fi
+	fi
+
 	if file_changed "${COMPOSE_ENV}" "${filename}_$(basename "${COMPOSE_ENV}")"; then
-		local -u APPNAME
-		run_script 'varfile_to_appname_into' APPNAME "${VarFile}"
 		local AppEnabledFile
 		AppEnabledFile="${timestamps_folder:?}/${filename}_${APPNAME}__ENABLED"
 		local EnabledLine

--- a/scripts/unset_needs_env_update.sh
+++ b/scripts/unset_needs_env_update.sh
@@ -50,6 +50,15 @@ unset_needs_env_update() {
 		echo "${EnabledLine}" > "${AppEnabledFile}"
 		# Record the state of the global .env for this specific app
 		cp -a "${COMPOSE_ENV}" "${timestamps_folder}/${filename}_$(basename "${COMPOSE_ENV}")"
+
+		# Record the app's template-default dependency (see needs_env_update).
+		if ! run_script 'app_is_user_defined' "${APPNAME}"; then
+			local AppDefaultFile
+			run_script 'app_instance_file_into' AppDefaultFile "${APPNAME}" ".env.app.*"
+			if [[ -n ${AppDefaultFile} && -f ${AppDefaultFile} ]]; then
+				cp -a "${AppDefaultFile}" "${timestamps_folder}/${filename}_template"
+			fi
+		fi
 	fi
 }
 

--- a/scripts/update_templates.sh
+++ b/scripts/update_templates.sh
@@ -129,7 +129,13 @@ commands_update_templates() {
 	templates_version_into UpdatedVersion
 	notice "Updated ${TargetName} to '{{|Version|}}${UpdatedVersion}{{[-]}}'"
 
-	# run_script 'reset_needs' (DELETED in favor of granular detection)
+	# Resync per-app env files against the (possibly changed) templates.
+	# needs_env_update's template-dependency check makes this a no-op for
+	# apps whose template didn't actually change -- without this call,
+	# though, nothing ever re-checks after a templates update, so an
+	# edited default/comment/ordering would sit unnoticed until the user
+	# happened to trigger env_update some other way (or reset_needs).
+	run_script 'env_update' || true
 }
 
 test_update_templates() {


### PR DESCRIPTION
## Summary
- \`needs_env_update\` compared each app's generated \`.env.app.*\` file only against its own prior snapshot, never against the template it's built from -- so editing an existing variable's comments/ordering/newly-declared defaults in the templates repo was silently ignored by a plain \`--update-templates\` run, only a full \`--reset\` (which wipes every marker) picked it up.
- Added a template-dependency check (mirroring the existing \`ENABLED\`-dependency check) that resolves the app's template-default file via \`app_instance_file_into\` and compares it with a new \`${filename}_template\` marker, recorded by \`unset_needs_env_update\`.
- \`update_templates.sh\` now calls \`env_update\` at the end instead of leaving a dead comment where a blunt \`reset_needs\` call used to live -- cheap and correct now that the check above makes it a no-op when nothing changed, instead of nuking every marker.
- Existing variable **values** are correctly left untouched either way (never broken) -- this only fixes structural drift: new variables, comment headers, and ordering.
- Same root cause and fix already applied and merged in DockSTARTer2 (Go rewrite), which shares this file's logic almost line-for-line.

## Test plan
- [x] \`bash -n\` syntax check on all three modified files
- [x] Verified live on dstest.lan (\`Updates\` branch checked out at \`~/.dockstarter\`): reordered a variable in the real DS1-shared template, ran \`ds -a doplarr\`, confirmed the live \`.env.app.doplarr\` picked up the new order with no \`--reset\`/\`reset_needs\` needed
- [x] Reverted the template edit and confirmed the live file resynced back correctly
- [x] Broader regression pass across other apps/flows welcome before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure per-app env files are updated when their template defaults change and automatically resync envs after template updates.

Bug Fixes:
- Detect changes in app env template default files and mark corresponding env files as needing update.
- Persist template dependency snapshots alongside existing markers so future runs can spot structural template drift.

Enhancements:
- Invoke env_update at the end of template updates so apps resync against updated templates without requiring a full reset.