### PR TITLE
Add a tab before `git:`, `docker:`, etc in the logs

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -744,7 +744,7 @@ RunAndLog() {
 	if [[ ${OutputNoticeType} == *:* ]]; then
 		Prefix="${OutputNoticeType%%:*}:"
 		OutputNoticeType=${OutputNoticeType#"${Prefix}"}
-		Prefix="{{|RunningCommand|}}${Prefix}{{[-]}} "
+		Prefix="\t{{|RunningCommand|}}${Prefix}{{[-]}} "
 	fi
 
 	local OutputFile


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Enhancements:
- Add a leading tab before prefixed commands (e.g., git:, docker:) in RunAndLog output to visually separate them in logs.