### PR TITLE
Change initial cloning and update behavior

### DIFF
--- a/includes/ds_functions.sh
+++ b/includes/ds_functions.sh
@@ -5,11 +5,34 @@ IFS=$'\n\t'
 git_fetch() {
 	local GitPath=${1}
 	local ForceRefresh=${2-false}
-	# Git touches FETCH_HEAD after each `git fetch`, so we use it to
-	# limit fetches to 1 per day per repo (unless forced).
-	if [[ -n ${FORCE-} ]] || $ForceRefresh || [ -z "$(find "${GitPath}/.git/FETCH_HEAD" -mtime -1 2> /dev/null)" ]; then
+
+	if [[ -n ${FORCE-} ]] || $ForceRefresh; then
 		git -C "${GitPath}" fetch --quiet --tags &> /dev/null || true
+		return
 	fi
+
+	# Cheap pre-check: compare the current branch's remote-tracking hash and
+	# the remote's tag count against what's already local, and skip the full
+	# fetch only when both match. Tags need their own check because a new
+	# tag can point at a commit that's already the local tip -- a branch-
+	# hash-only comparison would miss that release entirely.
+	local CurrentBranch
+	CurrentBranch=$(git -C "${GitPath}" symbolic-ref --short HEAD 2> /dev/null) || true
+	if [[ -n ${CurrentBranch} ]]; then
+		local RemoteHash LocalHash
+		RemoteHash=$(git -C "${GitPath}" ls-remote --quiet origin "refs/heads/${CurrentBranch}" 2> /dev/null | cut -f1) || true
+		LocalHash=$(git -C "${GitPath}" rev-parse --quiet --verify "refs/remotes/origin/${CurrentBranch}" 2> /dev/null) || true
+		if [[ -n ${RemoteHash} && ${RemoteHash} == "${LocalHash}" ]]; then
+			local RemoteTagCount LocalTagCount
+			RemoteTagCount=$(git -C "${GitPath}" ls-remote --quiet --tags origin 2> /dev/null | grep -vc '\^{}') || true
+			LocalTagCount=$(git -C "${GitPath}" tag 2> /dev/null | wc -l) || true
+			if [[ ${RemoteTagCount} == "${LocalTagCount}" ]]; then
+				return
+			fi
+		fi
+	fi
+
+	git -C "${GitPath}" fetch --quiet --tags &> /dev/null || true
 }
 
 git_branch_into() {
@@ -119,6 +142,30 @@ git_version() {
 	echo "${result}"
 }
 
+git_latest_reachable_tag_into() {
+	# Returns the most recently created tag (by tag creation date, not tag
+	# name string) reachable from DefaultBranch's history on origin. Empty
+	# if no tag is reachable yet.
+	#
+	# Sort by actual tag creation date (--sort=-creatordate), not the tag
+	# name string (sort -V): this repo has switched tag-naming schemes over
+	# time (e.g. v2026.01.19-1 -> v1.20260628.1), and comparing differently-
+	# shaped version strings against each other picks the wrong "latest" --
+	# creation date is immune to that since it doesn't depend on the name.
+	local -n _glrti_out_="${1}"
+	assert_nameref_is_string "${1}"
+	local GitPath=${2}
+	local DefaultBranch=${3}
+
+	_glrti_out_=$(git -C "${GitPath}" tag --merged "origin/${DefaultBranch}" --sort=-creatordate 2> /dev/null | head -1) || true
+}
+
+git_latest_reachable_tag() {
+	local result
+	git_latest_reachable_tag_into result "$@"
+	echo "${result}"
+}
+
 git_resolve_update_target_into() {
 	# Resolves the branch/tag name that should actually be checked out for
 	# an update, applying a release policy whenever the resolved branch is
@@ -161,13 +208,8 @@ git_resolve_update_target_into() {
 		return
 	fi
 
-	# Sort by actual tag creation date (--sort=-creatordate), not the tag
-	# name string (sort -V): this repo has switched tag-naming schemes over
-	# time (e.g. v2026.01.19-1 -> v1.20260628.1), and comparing differently-
-	# shaped version strings against each other picks the wrong "latest" --
-	# creation date is immune to that since it doesn't depend on the name.
 	local LatestTag
-	LatestTag=$(git -C "${GitPath}" tag --merged "origin/${DefaultBranch}" --sort=-creatordate 2> /dev/null | head -1) || true
+	git_latest_reachable_tag_into LatestTag "${GitPath}" "${DefaultBranch}"
 
 	if [[ -z ${LatestTag} ]]; then
 		# No reachable tag yet -- fall back to the default branch's tip.
@@ -335,6 +377,45 @@ templates_update_available() {
 	local CurrentRef=${1-}
 	local TargetRef=${2-}
 	git_update_available "${TEMPLATES_PARENT_FOLDER}" "${CurrentRef-}" "${TargetRef-}"
+}
+
+git_checkout_latest_release_after_clone() {
+	# Called only right after a fresh clone whose tip is on DefaultBranch and
+	# therefore always at or ahead of the latest tag -- git_resolve_update_
+	# target_into's "no update" ancestor check would always fire here, so
+	# this resolves the latest reachable tag directly instead, bypassing
+	# that check, and skips entirely (no checkout, no logging) when the
+	# cloned tip already is that release.
+	local GitPath=${1}
+	local DefaultBranch=${2}
+	local TargetName=${3}
+
+	local LatestTag
+	git_latest_reachable_tag_into LatestTag "${GitPath}" "${DefaultBranch}"
+	if [[ -z ${LatestTag} ]]; then
+		# No tagged release reachable yet -- the default branch's tip stands.
+		return 0
+	fi
+	if git -C "${GitPath}" merge-base --is-ancestor "${LatestTag}" HEAD 2> /dev/null; then
+		# The cloned tip already is the latest release -- nothing to check out.
+		return 0
+	fi
+
+	notice "Checking out {{|ApplicationName|}}${TargetName}{{[-]}} release '{{|Version|}}${LatestTag}{{[-]}}'"
+	RunAndLog info "git:info" \
+		fatal "Failed to switch to github ref '{{|Branch|}}${LatestTag}{{[-]}}'." \
+		git -C "${GitPath}" checkout --force "${LatestTag}"
+	info "Cleaning up unnecessary files and optimizing the local repository."
+	RunAndLog info "git:info" \
+		"" "" \
+		git -C "${GitPath}" gc || true
+	local UpdatedVersion
+	git_version_into UpdatedVersion "${GitPath}"
+	notice "Updated ${TargetName} to '{{|Version|}}${UpdatedVersion}{{[-]}}'"
+}
+
+templates_checkout_latest_release_after_clone() {
+	git_checkout_latest_release_after_clone "${TEMPLATES_PARENT_FOLDER}" "${TEMPLATES_DEFAULT_BRANCH}" "${TEMPLATES_NAME}"
 }
 
 ds_switch_branch() {

--- a/main.sh
+++ b/main.sh
@@ -873,6 +873,26 @@ clone_repo() {
 	RunAndLog notice "git:notice" \
 		fatal "Failed to clone {{|ApplicationName|}}${APPLICATION_NAME}{{[-]}} repo." \
 		git clone -b "${APPLICATION_DEFAULT_BRANCH}" "${APPLICATION_REPO}" "${DETECTED_HOMEDIR}/${APPLICATION_FOLDER_NAME_DEFAULT}"
+
+	# This bootstrap copy runs from outside the cloned repo, so
+	# includes/ds_functions.sh isn't sourced yet -- use plain git directly.
+	local ClonedGitPath="${DETECTED_HOMEDIR}/${APPLICATION_FOLDER_NAME_DEFAULT}"
+	local ClonedVersion
+	ClonedVersion="$(git -C "${ClonedGitPath}" describe --tags --exact-match 2> /dev/null || true)"
+	if [[ -z ${ClonedVersion} ]]; then
+		ClonedVersion="${APPLICATION_DEFAULT_BRANCH} commit $(git -C "${ClonedGitPath}" rev-parse --short HEAD 2> /dev/null)"
+	fi
+	notice "Cloned {{|ApplicationName|}}${APPLICATION_NAME}{{[-]}} at '{{|Version|}}${ClonedVersion}{{[-]}}'."
+
+	local LatestTag
+	LatestTag="$(git -C "${ClonedGitPath}" tag --merged "origin/${APPLICATION_DEFAULT_BRANCH}" --sort=-creatordate 2> /dev/null | head -1)" || true
+	if [[ -n ${LatestTag} ]] && ! git -C "${ClonedGitPath}" merge-base --is-ancestor "${LatestTag}" HEAD 2> /dev/null; then
+		notice "Checking out {{|ApplicationName|}}${APPLICATION_NAME}{{[-]}} release '{{|Version|}}${LatestTag}{{[-]}}'"
+		RunAndLog info "git:info" \
+			fatal "Failed to switch to github ref '{{|Branch|}}${LatestTag}{{[-]}}'." \
+			git -C "${ClonedGitPath}" checkout --force "${LatestTag}"
+	fi
+
 	if [[ ${#ARGS[@]} -eq 0 ]]; then
 		notice \
 			"Performing first run install."
@@ -893,6 +913,12 @@ clone_templates_repo() {
 	RunAndLog notice "git:notice" \
 		fatal "Failed to clone {{|ApplicationName|}}${TEMPLATES_NAME}{{[-]}} repo." \
 		git clone -b "${TEMPLATES_DEFAULT_BRANCH}" "${TEMPLATES_REPO}" "${TEMPLATES_PARENT_FOLDER}"
+
+	local ClonedVersion
+	templates_version_into ClonedVersion
+	notice "Cloned {{|ApplicationName|}}${TEMPLATES_NAME}{{[-]}} at '{{|Version|}}${ClonedVersion}{{[-]}}'."
+
+	templates_checkout_latest_release_after_clone
 }
 
 # Cleanup Function
@@ -1030,8 +1056,8 @@ init_check_symlink() {
 }
 
 init_check_update() {
-	# Only check for updates once per 24 hours, as it can be quite slow.
-	[ -n "$(find "${APPLICATION_UPDATE_RECORD}" -mtime -1 2> /dev/null)" ] && return
+	# Only check for updates once every 15 minutes.
+	[ -n "$(find "${APPLICATION_UPDATE_RECORD}" -mmin -15 2> /dev/null)" ] && return
 	local Branch
 	ds_branch_into Branch
 	local TargetBranch="${Branch}"

--- a/scripts/update_self.sh
+++ b/scripts/update_self.sh
@@ -124,7 +124,7 @@ commands_update_self_logic() {
 			git -C "${SCRIPTPATH}" checkout --force "${Branch}"
 
 		# If it's a branch (not a tag or SHA), perform reset and pull
-		if git -C "${SCRIPTPATH}" ls-remote --exit-code --heads origin "${Branch}" &> /dev/null; then
+		if ds_branch_exists "${Branch}"; then
 			RunAndLog info "git:info" \
 				fatal "Failed to reset to branch '{{|Branch|}}origin/${Branch}{{[-]}}'." \
 				git -C "${SCRIPTPATH}" reset --hard origin/"${Branch}"

--- a/scripts/update_templates.sh
+++ b/scripts/update_templates.sh
@@ -107,7 +107,7 @@ commands_update_templates() {
 			git -C "${TEMPLATES_PARENT_FOLDER}" checkout --force "${Branch}"
 
 		# If it's a branch (not a tag or SHA), perform reset and pull
-		if git -C "${TEMPLATES_PARENT_FOLDER}" ls-remote --exit-code --heads origin "${Branch}" &> /dev/null; then
+		if templates_branch_exists "${Branch}"; then
 			RunAndLog info "git:info" \
 				fatal "Failed to reset to branch '{{|Branch|}}origin/${Branch}{{[-]}}'." \
 				git -C "${TEMPLATES_PARENT_FOLDER}" reset --hard origin/"${Branch}"


### PR DESCRIPTION
On initial cloning of the app and templates, we will now "downgrade" to the latest release tag if we aren't already on the latest release.

For updates, when on the `main` branch, only consider the latest reelease tag as newer, instead of hte latest commit.

Also, check for updates using `git ls-remote`, and avoid fetches unless needed, to reduce network traffic.

# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Adjust cloning and update workflows to align installations with the latest release tags while reducing unnecessary git network activity.

New Features:
- Automatically check out the latest reachable release tag after cloning the application and templates when the clone tip is ahead of that release.
- Log the initially cloned application and templates version to provide clearer visibility into the starting state.

Enhancements:
- Introduce a helper to determine the latest reachable tag by creation date for reuse across update logic.
- Change git fetch behavior to use a lightweight ls-remote comparison before performing a full fetch, avoiding redundant network calls.
- Shorten the minimum interval between automatic update checks from 24 hours to 15 minutes.
- Use existing branch-existence helpers instead of direct ls-remote calls in self and template update scripts to centralize branch detection logic.