### PR TITLE
Fix the initial update check to only consider tagged releases as new

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -1064,6 +1064,7 @@ init_check_update() {
 	if ds_tag_exists "${Branch}"; then
 		ds_best_branch_into TargetBranch
 	fi
+	git_resolve_update_target_into TargetBranch "${SCRIPTPATH}" "${APPLICATION_DEFAULT_BRANCH}" "${TargetBranch}" "${Branch}"
 	if ds_ref_exists "${Branch}"; then
 		if ds_update_available "${Branch}" "${TargetBranch}"; then
 			local TargetVersion
@@ -1101,6 +1102,7 @@ init_check_update() {
 	if templates_tag_exists "${Branch}"; then
 		templates_best_branch_into TargetBranch
 	fi
+	git_resolve_update_target_into TargetBranch "${TEMPLATES_PARENT_FOLDER}" "${TEMPLATES_DEFAULT_BRANCH}" "${TargetBranch}" "${Branch}"
 	if templates_ref_exists "${Branch}"; then
 		if templates_update_available "${Branch}" "${TargetBranch}"; then
 			local TargetVersion


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Bug Fixes:
- Fix update checks to only consider valid tagged branches when determining if a new version is available.