### PR TITLE
Fix app not being downgraded to latest tagged release after cloning

### DIFF
--- a/includes/ds_functions.sh
+++ b/includes/ds_functions.sh
@@ -396,7 +396,10 @@ git_checkout_latest_release_after_clone() {
 		# No tagged release reachable yet -- the default branch's tip stands.
 		return 0
 	fi
-	if git -C "${GitPath}" merge-base --is-ancestor "${LatestTag}" HEAD 2> /dev/null; then
+	local TagHash HeadHash
+	TagHash=$(git -C "${GitPath}" rev-parse --quiet --verify "${LatestTag}^{commit}" 2> /dev/null) || true
+	HeadHash=$(git -C "${GitPath}" rev-parse --quiet --verify HEAD 2> /dev/null) || true
+	if [[ -n ${TagHash} && ${TagHash} == "${HeadHash}" ]]; then
 		# The cloned tip already is the latest release -- nothing to check out.
 		return 0
 	fi

--- a/main.sh
+++ b/main.sh
@@ -886,11 +886,16 @@ clone_repo() {
 
 	local LatestTag
 	LatestTag="$(git -C "${ClonedGitPath}" tag --merged "origin/${APPLICATION_DEFAULT_BRANCH}" --sort=-creatordate 2> /dev/null | head -1)" || true
-	if [[ -n ${LatestTag} ]] && ! git -C "${ClonedGitPath}" merge-base --is-ancestor "${LatestTag}" HEAD 2> /dev/null; then
-		notice "Checking out {{|ApplicationName|}}${APPLICATION_NAME}{{[-]}} release '{{|Version|}}${LatestTag}{{[-]}}'"
-		RunAndLog info "git:info" \
-			fatal "Failed to switch to github ref '{{|Branch|}}${LatestTag}{{[-]}}'." \
-			git -C "${ClonedGitPath}" checkout --force "${LatestTag}"
+	if [[ -n ${LatestTag} ]]; then
+		local TagHash HeadHash
+		TagHash="$(git -C "${ClonedGitPath}" rev-parse --quiet --verify "${LatestTag}^{commit}" 2> /dev/null)" || true
+		HeadHash="$(git -C "${ClonedGitPath}" rev-parse --quiet --verify HEAD 2> /dev/null)" || true
+		if [[ -z ${TagHash} || ${TagHash} != "${HeadHash}" ]]; then
+			notice "Checking out {{|ApplicationName|}}${APPLICATION_NAME}{{[-]}} release '{{|Version|}}${LatestTag}{{[-]}}'"
+			RunAndLog info "git:info" \
+				fatal "Failed to switch to github ref '{{|Branch|}}${LatestTag}{{[-]}}'." \
+				git -C "${ClonedGitPath}" checkout --force "${LatestTag}"
+		fi
 	fi
 
 	if [[ ${#ARGS[@]} -eq 0 ]]; then


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Ensure cloned repositories are checked out to the latest tagged release when appropriate instead of leaving them at the default branch tip.

Bug Fixes:
- Fix logic that failed to downgrade a freshly cloned repository to the latest tagged release when the tag was not an ancestor of HEAD.

Enhancements:
- Use commit hash comparison to detect whether the cloned HEAD already matches the latest tagged release before performing a checkout.