### PR TITLE
Second attempt to fix app version not downgrading after clone

### DIFF
--- a/includes/ds_functions.sh
+++ b/includes/ds_functions.sh
@@ -396,7 +396,10 @@ git_checkout_latest_release_after_clone() {
 		# No tagged release reachable yet -- the default branch's tip stands.
 		return 0
 	fi
-	if git -C "${GitPath}" merge-base --is-ancestor "${LatestTag}" HEAD 2> /dev/null; then
+	local TagHash HeadHash
+	TagHash=$(git -C "${GitPath}" rev-parse --quiet --verify "${LatestTag}^{commit}" 2> /dev/null) || true
+	HeadHash=$(git -C "${GitPath}" rev-parse --quiet --verify HEAD 2> /dev/null) || true
+	if [[ -n ${TagHash} && ${TagHash} == "${HeadHash}" ]]; then
 		# The cloned tip already is the latest release -- nothing to check out.
 		return 0
 	fi

--- a/includes/ds_functions.sh
+++ b/includes/ds_functions.sh
@@ -248,9 +248,14 @@ git_update_available() {
 			TargetRef="${CurrentRef}"
 		fi
 
-		# If CurrentRef is a tag, we compare against TargetRef (usually a branch)
-		# Even if it's a tag, we compare the current hash against the target branch/ref hash
-		Remote=$(git -C "${GitPath}" rev-parse "origin/${TargetRef}" 2> /dev/null || true)
+		# TargetRef can be a tag (e.g. the latest-release policy in
+		# git_resolve_update_target_into resolving to a tag name) or a
+		# branch -- tags aren't under refs/remotes/origin/, so try TargetRef
+		# as a tag first and fall back to origin/TargetRef as a branch.
+		Remote=$(git -C "${GitPath}" rev-parse --quiet --verify "refs/tags/${TargetRef}" 2> /dev/null) || true
+		if [[ -z ${Remote} ]]; then
+			Remote=$(git -C "${GitPath}" rev-parse "origin/${TargetRef}" 2> /dev/null || true)
+		fi
 		[[ ${Current} != "${Remote}" ]]
 		result=$?
 	else

--- a/main.sh
+++ b/main.sh
@@ -886,11 +886,16 @@ clone_repo() {
 
 	local LatestTag
 	LatestTag="$(git -C "${ClonedGitPath}" tag --merged "origin/${APPLICATION_DEFAULT_BRANCH}" --sort=-creatordate 2> /dev/null | head -1)" || true
-	if [[ -n ${LatestTag} ]] && ! git -C "${ClonedGitPath}" merge-base --is-ancestor "${LatestTag}" HEAD 2> /dev/null; then
-		notice "Checking out {{|ApplicationName|}}${APPLICATION_NAME}{{[-]}} release '{{|Version|}}${LatestTag}{{[-]}}'"
-		RunAndLog info "git:info" \
-			fatal "Failed to switch to github ref '{{|Branch|}}${LatestTag}{{[-]}}'." \
-			git -C "${ClonedGitPath}" checkout --force "${LatestTag}"
+	if [[ -n ${LatestTag} ]]; then
+		local TagHash HeadHash
+		TagHash="$(git -C "${ClonedGitPath}" rev-parse --quiet --verify "${LatestTag}^{commit}" 2> /dev/null)" || true
+		HeadHash="$(git -C "${ClonedGitPath}" rev-parse --quiet --verify HEAD 2> /dev/null)" || true
+		if [[ -z ${TagHash} || ${TagHash} != "${HeadHash}" ]]; then
+			notice "Checking out {{|ApplicationName|}}${APPLICATION_NAME}{{[-]}} release '{{|Version|}}${LatestTag}{{[-]}}'"
+			RunAndLog info "git:info" \
+				fatal "Failed to switch to github ref '{{|Branch|}}${LatestTag}{{[-]}}'." \
+				git -C "${ClonedGitPath}" checkout --force "${LatestTag}"
+		fi
 	fi
 
 	if [[ ${#ARGS[@]} -eq 0 ]]; then


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Ensure cloned repositories correctly track and check out the latest tagged release when it differs from the default branch tip.

New Features:
- Support resolving update targets when the target reference is a tag instead of only a branch.

Bug Fixes:
- Prevent situations where the application version fails to downgrade to the latest release after cloning when HEAD already matches or differs from the latest tag.

Enhancements:
- Improve git reference resolution by explicitly handling tag hashes and comparing commit hashes rather than relying on merge-base ancestor checks.