### PR TITLE
Silence `git` error message on clone when no local git repo exists yet

### DIFF
--- a/includes/ds_functions.sh
+++ b/includes/ds_functions.sh
@@ -473,7 +473,7 @@ git_best_branch_into() {
 
 	# 4. If we ended up with the Legacy Branch but the Default Branch exists, force use of Default Branch
 	if [[ ${BestBranch} == "${LegacyBranch}" ]] && [[ -n ${DefaultBranch} ]]; then
-		if git -C "${GitPath}" show-ref --quiet --verify "refs/remotes/origin/${DefaultBranch}"; then
+		if git -C "${GitPath}" show-ref --quiet --verify "refs/remotes/origin/${DefaultBranch}" 2> /dev/null; then
 			BestBranch="${DefaultBranch}"
 		fi
 	fi


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Bug Fixes:
- Suppress git show-ref error output when checking for the default remote branch in environments without an existing local git repo.