### PR TITLE
Fix false positives in update checks in the TUI.

### DIFF
--- a/includes/ds_functions.sh
+++ b/includes/ds_functions.sh
@@ -323,9 +323,54 @@ ds_version() {
 	echo "${result}"
 }
 
+ds_resolve_update_branch_into() {
+	# Resolves the branch/tag that an update should target, applying the
+	# "latest reachable tag" release policy (see
+	# git_resolve_update_target_into's doc comment). RequestedBranch defaults
+	# to the current branch when empty; if that default is itself a tag
+	# (i.e. currently on a release), resolves to the best branch first so
+	# the policy has a real branch to compare against. Returns non-zero (with
+	# empty output) only when no branch could be determined at all.
+	local -n _drubi_out_="${1}"
+	assert_nameref_is_string "${1}"
+	local RequestedBranch=${2-}
+
+	local CurrentBranch
+	ds_branch_into CurrentBranch
+
+	if [[ -z ${RequestedBranch-} ]]; then
+		RequestedBranch="${CurrentBranch}"
+		if ds_tag_exists "${RequestedBranch-}"; then
+			ds_best_branch_into RequestedBranch
+		fi
+	fi
+	if [[ -z ${RequestedBranch-} ]]; then
+		_drubi_out_=""
+		return 1
+	fi
+
+	git_resolve_update_target_into _drubi_out_ "${SCRIPTPATH}" "${APPLICATION_DEFAULT_BRANCH}" "${RequestedBranch}" "${CurrentBranch}"
+}
+
 ds_update_available() {
 	local CurrentRef=${1-}
 	local TargetRef=${2-}
+	if [[ -z ${CurrentRef-} && -z ${TargetRef-} ]]; then
+		# Compares resolved version strings rather than raw commit hashes:
+		# a detached HEAD (checked out at a release tag) has no upstream,
+		# and origin/main is routinely ahead of the latest tag between
+		# releases, so a hash-based compare would report an update as
+		# available even when already on the latest release.
+		local TargetBranch
+		if ! ds_resolve_update_branch_into TargetBranch; then
+			return 1
+		fi
+		local CurrentVersion RemoteVersion
+		ds_version_into CurrentVersion
+		ds_version_into RemoteVersion "${TargetBranch}"
+		[[ ${CurrentVersion-} != "${RemoteVersion-}" ]]
+		return $?
+	fi
 	git_update_available "${SCRIPTPATH}" "${CurrentRef-}" "${TargetRef-}"
 }
 
@@ -378,9 +423,50 @@ templates_version() {
 	echo "${result}"
 }
 
+templates_resolve_update_branch_into() {
+	# templates_ counterpart to ds_resolve_update_branch_into -- see its doc
+	# comment. Shared by update_templates and templates_update_available.
+	local -n _trubi_out_="${1}"
+	assert_nameref_is_string "${1}"
+	local RequestedBranch=${2-}
+
+	local CurrentBranch
+	templates_branch_into CurrentBranch
+
+	if [[ -z ${RequestedBranch-} ]]; then
+		RequestedBranch="${CurrentBranch}"
+		if templates_tag_exists "${RequestedBranch-}"; then
+			templates_best_branch_into RequestedBranch
+		fi
+	fi
+	if [[ -z ${RequestedBranch-} ]]; then
+		_trubi_out_=""
+		return 1
+	fi
+
+	git_resolve_update_target_into _trubi_out_ "${TEMPLATES_PARENT_FOLDER}" "${TEMPLATES_DEFAULT_BRANCH}" "${RequestedBranch}" "${CurrentBranch}"
+}
+
 templates_update_available() {
 	local CurrentRef=${1-}
 	local TargetRef=${2-}
+	if [[ -z ${CurrentRef-} && -z ${TargetRef-} ]]; then
+		# Compares resolved version strings rather than raw commit hashes:
+		# a detached HEAD (checked out at a release tag, the normal state
+		# for Templates) has no upstream, and origin/main is routinely
+		# ahead of the latest tag between releases, so a hash-based compare
+		# would report an update as available even when already on the
+		# latest release.
+		local TargetBranch
+		if ! templates_resolve_update_branch_into TargetBranch; then
+			return 1
+		fi
+		local CurrentVersion RemoteVersion
+		templates_version_into CurrentVersion
+		templates_version_into RemoteVersion "${TargetBranch}"
+		[[ ${CurrentVersion-} != "${RemoteVersion-}" ]]
+		return $?
+	fi
 	git_update_available "${TEMPLATES_PARENT_FOLDER}" "${CurrentRef-}" "${TargetRef-}"
 }
 

--- a/scripts/update_self.sh
+++ b/scripts/update_self.sh
@@ -15,25 +15,12 @@ update_self() {
 	local Title="Update ${APPLICATION_NAME}"
 	local Question YesNotice NoNotice
 
-	local CurrentBranch
-	ds_branch_into CurrentBranch
-
-	if [[ -z ${Branch-} ]]; then
-		Branch="${CurrentBranch}"
-		if ds_tag_exists "${Branch-}"; then
-			ds_best_branch_into Branch
-		fi
-		if [[ -z ${Branch-} ]]; then
-			error "You need to specify a branch to update to."
-			return 1
-		fi
+	# Resolves to the latest tagged release when Branch lands on the default
+	# branch -- see ds_resolve_update_branch_into's doc comment for why.
+	if ! ds_resolve_update_branch_into Branch "${Branch}"; then
+		error "You need to specify a branch to update to."
+		return 1
 	fi
-
-	# On the default branch, restrict to the latest tagged release instead
-	# of the branch's literal tip -- see git_resolve_update_target_into's
-	# doc comment for why. Downstream logic (version lookup, checkout) is
-	# unchanged: it already treats a tag name exactly like a branch name.
-	git_resolve_update_target_into Branch "${SCRIPTPATH}" "${APPLICATION_DEFAULT_BRANCH}" "${Branch}" "${CurrentBranch}"
 
 	ds_version_into CurrentVersion
 	ds_version_into RemoteVersion "${Branch}"

--- a/scripts/update_templates.sh
+++ b/scripts/update_templates.sh
@@ -13,25 +13,13 @@ update_templates() {
 
 	templates_fetch true
 
-	local CurrentBranch
-	templates_branch_into CurrentBranch
-
-	if [[ -z ${Branch-} ]]; then
-		Branch="${CurrentBranch}"
-		if templates_tag_exists "${Branch-}"; then
-			templates_best_branch_into Branch
-		fi
-		if [[ -z ${Branch-} ]]; then
-			error "You need to specify a branch to update to."
-			return 1
-		fi
+	# Resolves to the latest tagged release when Branch lands on the default
+	# branch -- see templates_resolve_update_branch_into's doc comment for
+	# why.
+	if ! templates_resolve_update_branch_into Branch "${Branch}"; then
+		error "You need to specify a branch to update to."
+		return 1
 	fi
-
-	# On the default branch, restrict to the latest tagged release instead
-	# of the branch's literal tip -- see git_resolve_update_target_into's
-	# doc comment for why. Downstream logic (version lookup, checkout) is
-	# unchanged: it already treats a tag name exactly like a branch name.
-	git_resolve_update_target_into Branch "${TEMPLATES_PARENT_FOLDER}" "${TEMPLATES_DEFAULT_BRANCH}" "${Branch}" "${CurrentBranch}"
 
 	templates_version_into CurrentVersion
 	templates_version_into RemoteVersion "${Branch}"


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Improve update logic for DockSTARTer and templates to avoid false-positive update notifications when already on the latest tagged release.

Bug Fixes:
- Prevent update checks from reporting updates as available when running on the latest tagged release without an upstream branch.

Enhancements:
- Introduce shared helpers to resolve the appropriate update branch/tag for both DockSTARTer and templates, centralizing release-targeting logic.
- Refactor self-update and template-update scripts to use the new branch resolution helpers for more consistent update behavior.