### PR TITLE
Fix occasional panics in `tail` when truncating log files

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -934,11 +934,12 @@ cleanup() {
 	if [[ -e ${APPLICATION_LOG} ]]; then
 		sudo chown "${DETECTED_PUID}:${DETECTED_PGID}" "${APPLICATION_LOG}" || true
 	fi
+	touch "${APPLICATION_LOG}"
 	cat "${MKTEMP_LOG:-/dev/null}" >> "${APPLICATION_LOG}" || true
-	if [[ -n ${MKTEMP_LOG-} && -f ${MKTEMP_LOG} ]]; then
-		sudo rm -f "${MKTEMP_LOG}" &> /dev/null || true
-	fi
-	tail -1000 "${APPLICATION_LOG}" | tee "${APPLICATION_LOG}" > /dev/null || true
+	tail -n 1000 "${APPLICATION_LOG}" > "${MKTEMP_LOG}" || true
+	cat "${MKTEMP_LOG}" > "${APPLICATION_LOG}" || true
+	rm -f "${MKTEMP_LOG}" &> /dev/null || true
+
 	if [[ -n ${APPLICATION_CACHE_FOLDER-} && -d ${APPLICATION_CACHE_FOLDER} ]]; then
 		sudo rm -rf "${APPLICATION_CACHE_FOLDER?}" &> /dev/null || true
 	fi


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Bug Fixes:
- Resolve occasional panics in the log tailing step by avoiding writing to the same file being read and ensuring the log file exists before truncation.