### PR TITLE
Add an `--uninstall` command

### DIFF
--- a/includes/cmdline.sh
+++ b/includes/cmdline.sh
@@ -79,7 +79,8 @@ parse_arguments() {
 				--theme-shadows | --theme-no-shadows) ;&
 				--theme-scrollbar | --theme-no-scrollbar) ;&
 				--theme-lines | --theme-no-lines) ;&
-				--theme-borders | --theme-no-borders)
+				--theme-borders | --theme-no-borders) ;&
+				--uninstall)
 					CurrentCommand=("${OPTION}")
 					break
 					;;
@@ -501,6 +502,7 @@ run_command() {
 		["--list-referenced"]="app_list_referenced"
 		["--theme-list"]="theme_list"
 		["--theme-table"]="theme_table"
+		["--uninstall"]="uninstall"
 	)
 	MenuCommandScript+=(
 		["main"]="menu_main"
@@ -830,7 +832,8 @@ run_command() {
 		-s | --status) ;&
 		-S | --select) ;&
 		--status-disable | --status-enable) ;&
-		--theme-list | --theme-table)
+		--theme-list | --theme-table) ;&
+		--uninstall)
 			if [[ -z ${Script} ]]; then
 				fatal \
 					"No script is defined for command '{{|UserCommand|}}${Command}{{[-]}}'."
@@ -850,6 +853,7 @@ run_command() {
 					run_script_tui "${Title}" "${SubTitle}" "" \
 						"${Script}" "${ParamsArray[@]-}" || result=$?
 				else
+					declare -gx PROMPT="CLI"
 					run_script "${Script}" "${ParamsArray[@]-}" || result=$?
 				fi
 			fi

--- a/includes/usage.sh
+++ b/includes/usage.sh
@@ -452,6 +452,13 @@ EOF
 	Update {{|ApplicationName|}}${TEMPLATES_NAME}{{[-]}} to the specified branch, tag, or commit
 EOF
 			;;&
+		-u | --uninstall | "")
+			Found=1
+			cat << EOF
+{{|UsageCommand|}}-u --uninstall{{[-]}}
+	Uninstall {{|ApplicationName|}}${APPLICATION_NAME}{{[-]}}
+EOF
+			;;&
 		-V | --version | "")
 			Found=1
 			cat << EOF

--- a/main.sh
+++ b/main.sh
@@ -544,6 +544,17 @@ MKTEMP_LOG=$(mktemp -t "${APPLICATION_NAME,,}.log.XXXXXXXXXX") || resolve_string
 readonly MKTEMP_LOG
 echo "${APPLICATION_NAME} Log" > "${MKTEMP_LOG}"
 
+flush_logs() {
+	if [[ -e ${APPLICATION_LOG} ]]; then
+		sudo chown "${DETECTED_PUID}:${DETECTED_PGID}" "${APPLICATION_LOG}" || true
+	fi
+	touch "${APPLICATION_LOG}"
+	cat "${MKTEMP_LOG:-/dev/null}" >> "${APPLICATION_LOG}" || true
+	tail -n 1000 "${APPLICATION_LOG}" > "${MKTEMP_LOG}" || true
+	cat "${MKTEMP_LOG}" > "${APPLICATION_LOG}" || true
+	rm -f "${MKTEMP_LOG}" &> /dev/null || true
+}
+
 log() {
 	local LogToTerminal=${1-}
 	local Message=${2-}
@@ -931,14 +942,7 @@ cleanup() {
 	local -ri EXIT_CODE=$?
 	trap - ERR EXIT SIGABRT SIGALRM SIGHUP SIGINT SIGQUIT SIGTERM
 
-	if [[ -e ${APPLICATION_LOG} ]]; then
-		sudo chown "${DETECTED_PUID}:${DETECTED_PGID}" "${APPLICATION_LOG}" || true
-	fi
-	touch "${APPLICATION_LOG}"
-	cat "${MKTEMP_LOG:-/dev/null}" >> "${APPLICATION_LOG}" || true
-	tail -n 1000 "${APPLICATION_LOG}" > "${MKTEMP_LOG}" || true
-	cat "${MKTEMP_LOG}" > "${APPLICATION_LOG}" || true
-	rm -f "${MKTEMP_LOG}" &> /dev/null || true
+	flush_logs
 
 	if [[ -n ${APPLICATION_CACHE_FOLDER-} && -d ${APPLICATION_CACHE_FOLDER} ]]; then
 		sudo rm -rf "${APPLICATION_CACHE_FOLDER?}" &> /dev/null || true

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+uninstall() {
+	local Title="Uninstall"
+	local Question="Do you want to uninstall {{|ApplicationName|}}${APPLICATION_NAME}{{[-]}}?"
+	if ! run_script 'question_prompt' N "${Question}" "${Title}" "${ASSUMEYES:+Y}"; then
+		notice "Not uninstalling {{|ApplicationName|}}${APPLICATION_NAME}{{[-]}}"
+		return 0
+	fi
+	local -a UninstallNotice=(
+		""
+		"Uninstalling {{|ApplicationName|}}${APPLICATION_NAME}{{[-]}}"
+		""
+	)
+
+	# Keep the compose and configuration folders
+	local -a ExcludePaths=(
+		"${APPLICATION_CONFIG_FOLDER}"
+		"${COMPOSE_FOLDER}"
+	)
+	if [[ ${COMPOSE_FOLDER} != "${SCRIPTPATH}/compose" ]]; then
+		ExcludePaths+=("${SCRIPTPATH}/compose")
+	fi
+
+	local DOCKER_VOLUME_CONFIG
+	run_script 'env_get_into' DOCKER_VOLUME_CONFIG DOCKER_VOLUME_CONFIG
+	DOCKER_VOLUME_CONFIG="$(
+		expand_vars "${DOCKER_VOLUME_CONFIG}" \
+			DOCKER_CONFIG_FOLDER "${CONFIG_FOLDER}" \
+			HOME "${DETECTED_HOMEDIR}"
+	)"
+	if [[ -n ${DOCKER_VOLUME_CONFIG} ]]; then
+		ExcludePaths+=("${DOCKER_VOLUME_CONFIG}")
+	fi
+
+	if ds2_installed; then
+		# Keep the templates folder
+		local TemplatesFolder="${APPLICATION_STATE_FOLDER}/${TEMPLATES_PARENT_FOLDER_NAME}"
+		ExcludePaths+=("${TemplatesFolder}")
+		UninstallNotice+=(
+			"{{|ApplicationName|}}DockSTARTer2{{[-]}} install detected. Keeping downloaded templates in '{{|Folder|}}${TemplatesFolder}{{[-]}}'."
+			""
+		)
+	fi
+
+	for path_index in "${!ExcludePaths[@]}"; do
+		local path="${ExcludePaths[path_index]}"
+		if [[ ! -e ${path} ]]; then
+			unset 'ExcludePaths[path_index]'
+		fi
+	done
+
+	UninstallNotice+=(
+		"Keeping:"
+		"$(printf "\t'{{|Folder|}}%s{{[-]}}'\n" "${ExcludePaths[@]}")"
+		""
+	)
+
+	notice "${UninstallNotice[@]}"
+
+	# Delete the application state folder contents
+	local -a ExcludeFindArgs=()
+	for path in "${ExcludePaths[@]}"; do
+		ExcludeFindArgs+=(-not -path "${path}")
+	done
+
+	if [[ -n ${APPLICATION_CACHE_FOLDER-} && -d ${APPLICATION_CACHE_FOLDER} ]]; then
+		notice "Removing {{|ApplicationName|}}${APPLICATION_NAME}{{[-]}} cache folder '{{|Folder|}}${APPLICATION_CACHE_FOLDER}{{[-]}}'"
+		sudo rm -rf "${APPLICATION_CACHE_FOLDER?}" &> /dev/null || true
+	fi
+
+	# Remove all files and folders in the application state folder, except the excluded paths
+	notice "Removing {{|ApplicationName|}}${APPLICATION_NAME}{{[-]}} state folder '{{|Folder|}}${APPLICATION_STATE_FOLDER}{{[-]}}'"
+	find "${APPLICATION_STATE_FOLDER}" -mindepth 1 -maxdepth 1 "${ExcludeFindArgs[@]}" -exec sudo rm -rf {} + || true
+
+	# Remove the application state folder if it's empty
+	sudo rmdir "${APPLICATION_STATE_FOLDER}" 2> /dev/null || true
+
+	# Exec into this script to remove the DockSTARTer script folder
+	notice "Removing {{|ApplicationName|}}${APPLICATION_NAME}{{[-]}} symlinks and script folder"
+
+	flush_logs
+	exec bash "${BASH_SOURCE[0]}" "${SCRIPTPATH}" "${SCRIPTNAME}" "${APPLICATION_COMMAND}" "${ExcludeFindArgs[@]}"
+}
+
+ds2_installed() {
+	# Return "true" if DockSTARTer2 is installed
+	[[ -d "${XDG_STATE_HOME}/dockstarter2" ]]
+}
+
+test_uninstall() {
+	warn "CI does not test uninstall."
+}
+
+uninstall_finalize() {
+	local script_folder=${1}
+	local script=${2}
+	local symlink_name=${3}
+	shift 3
+	local -a ExcludeFindArgs=("$@")
+	while true; do
+		hash -r
+		local symlink
+		symlink="$(command -v "${symlink_name}" 2> /dev/null)" || break
+		if [[ ! -L ${symlink} ]] || [[ "$(readlink -f "${symlink}")" != "${script}" ]]; then
+			break
+		fi
+		echo "Removing symlink: ${symlink}"
+		sudo rm "${symlink}"
+	done
+	echo "Removing script folder: ${script_folder}"
+	find "${script_folder}" -mindepth 1 -maxdepth 1 "${ExcludeFindArgs[@]}" -exec sudo rm -rf {} +
+	sudo rmdir "${script_folder}" 2> /dev/null || true
+	echo "DockSTARTer has been uninstalled."
+}
+
+[[ ${BASH_SOURCE[0]} == "${0}" ]] && uninstall_finalize "$@"

--- a/scripts/update_self.sh
+++ b/scripts/update_self.sh
@@ -85,6 +85,8 @@ update_self() {
 	local CommandNotice
 	CommandNotice="exec $(printf '%q ' "${CommandArray[@]}" | xargs)"
 	notice "Running: {{|RunningCommand|}}${CommandNotice}{{[-]}}"
+
+	flush_logs
 	exec "${CommandArray[@]}"
 	exit
 }


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Add a command-line uninstall flow that removes DockSTARTer while preserving key configuration and state directories, and centralize log flushing for reuse across scripts.

New Features:
- Introduce a new `--uninstall` command and associated script to guide users through uninstalling DockSTARTer.
- Add usage documentation for the new uninstall command in the CLI help output.

Enhancements:
- Extract log flushing logic into a reusable `flush_logs` helper and use it from cleanup and self-update flows to ensure logs are persisted consistently.

Tests:
- Add a placeholder `test_uninstall` function indicating uninstall behavior is not exercised in CI.