### PR TITLE
Allow installing into an existing `.dockstarter` folder, keeping an existing compose folder.

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -879,11 +879,36 @@ check_sudo() {
 	fi
 }
 clone_repo() {
+	local TargetPath="${DETECTED_HOMEDIR}/${APPLICATION_FOLDER_NAME_DEFAULT}"
 	warn \
-		"Attempting to clone {{|ApplicationName|}}${APPLICATION_NAME}{{[-]}} repo to '{{|Folder|}}${DETECTED_HOMEDIR}/${APPLICATION_FOLDER_NAME_DEFAULT}{{[-]}}' location."
+		"Attempting to clone {{|ApplicationName|}}${APPLICATION_NAME}{{[-]}} repo to '{{|Folder|}}${TargetPath}{{[-]}}' location."
+
+	# Safely create and initialize the directory
+	RunAndLog notice "mkdir:notice" \
+		fatal "Failed to create {{|ApplicationName|}}${APPLICATION_NAME}{{[-]}} repo directory." \
+		mkdir -p "${TargetPath}"
+
 	RunAndLog notice "git:notice" \
-		fatal "Failed to clone {{|ApplicationName|}}${APPLICATION_NAME}{{[-]}} repo." \
-		git clone -b "${APPLICATION_DEFAULT_BRANCH}" "${APPLICATION_REPO}" "${DETECTED_HOMEDIR}/${APPLICATION_FOLDER_NAME_DEFAULT}"
+		fatal "Failed to initialize {{|ApplicationName|}}${APPLICATION_NAME}{{[-]}} repo." \
+		git -C "${TargetPath}" init -b "${APPLICATION_DEFAULT_BRANCH}"
+
+	# Handle the remote origin dynamically (avoids fatal error if already exists)
+	git -C "${TargetPath}" remote set-url origin "${APPLICATION_REPO}" 2> /dev/null || git -C "${TargetPath}" remote add origin "${APPLICATION_REPO}"
+
+	# Fetch specifically the target branch to save bandwidth
+	RunAndLog notice "git:notice" \
+		fatal "Failed to fetch {{|ApplicationName|}}${APPLICATION_NAME}{{[-]}} repo." \
+		git -C "${TargetPath}" fetch origin "${APPLICATION_DEFAULT_BRANCH}"
+
+	# Force overwrite all tracked files to match the remote branch
+	RunAndLog notice "git:notice" \
+		fatal "Failed to reset {{|ApplicationName|}}${APPLICATION_NAME}{{[-]}} repo." \
+		git -C "${TargetPath}" reset --hard "origin/${APPLICATION_DEFAULT_BRANCH}"
+
+	# Clean untracked files, skipping everything in .gitignore (like your compose folder)
+	RunAndLog notice "git:notice" \
+		fatal "Failed to clean {{|ApplicationName|}}${APPLICATION_NAME}{{[-]}} repo." \
+		git -C "$TargetPath" clean -df
 
 	# This bootstrap copy runs from outside the cloned repo, so
 	# includes/ds_functions.sh isn't sourced yet -- use plain git directly.


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Support installing or updating DockSTARTer into an existing application folder instead of requiring a fresh clone.

Enhancements:
- Change repository setup to initialize or reuse the existing .dockstarter directory, fetching and resetting the target branch in place.
- Ensure git cleanup only affects tracked files while preserving user-managed content such as compose folders via .gitignore-aware cleaning.